### PR TITLE
TestEngineer: Tests for PR #67 - PrincipalEngineer: DataProvider service implementation

### DIFF
--- a/tests/Services/DataProviderTests.cs
+++ b/tests/Services/DataProviderTests.cs
@@ -1,0 +1,808 @@
+using AgentSquad.Runner.Models;
+using AgentSquad.Runner.Services;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System.Text.Json;
+using Xunit;
+
+namespace AgentSquad.Runner.Tests.Services
+{
+    public class DataProviderTests : IDisposable
+    {
+        private readonly string _testDataDirectory;
+        private readonly string _testDataFilePath;
+        private readonly Mock<IWebHostEnvironment> _mockEnvironment;
+        private readonly Mock<IDataCache> _mockCache;
+        private readonly Mock<ILogger<DataProvider>> _mockLogger;
+
+        public DataProviderTests()
+        {
+            _testDataDirectory = Path.Combine(Path.GetTempPath(), $"DataProviderTests_{Guid.NewGuid()}");
+            Directory.CreateDirectory(_testDataDirectory);
+            _testDataFilePath = Path.Combine(_testDataDirectory, "data.json");
+
+            _mockEnvironment = new Mock<IWebHostEnvironment>();
+            _mockEnvironment.Setup(e => e.WebRootPath).Returns(_testDataDirectory);
+
+            _mockCache = new Mock<IDataCache>();
+            _mockLogger = new Mock<ILogger<DataProvider>>();
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(_testDataDirectory))
+            {
+                Directory.Delete(_testDataDirectory, true);
+            }
+        }
+
+        private void WriteTestDataJson(object data)
+        {
+            var options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+            var json = JsonSerializer.Serialize(data, options);
+            File.WriteAllText(_testDataFilePath, json);
+        }
+
+        private Project CreateValidTestProject()
+        {
+            return new Project
+            {
+                Name = "Test Project",
+                Description = "Test Description",
+                StartDate = DateTime.Parse("2024-01-01"),
+                TargetEndDate = DateTime.Parse("2024-12-31"),
+                CompletionPercentage = 50,
+                HealthStatus = HealthStatus.OnTrack,
+                VelocityThisMonth = 10,
+                Milestones = new List<Milestone>
+                {
+                    new Milestone
+                    {
+                        Name = "Phase 1",
+                        TargetDate = DateTime.Parse("2024-03-31"),
+                        Status = MilestoneStatus.Completed,
+                        Description = "Phase 1 complete"
+                    },
+                    new Milestone
+                    {
+                        Name = "Phase 2",
+                        TargetDate = DateTime.Parse("2024-06-30"),
+                        Status = MilestoneStatus.InProgress,
+                        Description = "Phase 2 in progress"
+                    },
+                    new Milestone
+                    {
+                        Name = "Phase 3",
+                        TargetDate = DateTime.Parse("2024-09-30"),
+                        Status = MilestoneStatus.Future,
+                        Description = "Phase 3 upcoming"
+                    }
+                },
+                WorkItems = new List<WorkItem>
+                {
+                    new WorkItem { Title = "Task 1", Description = "First task", Status = WorkItemStatus.Shipped, AssignedTo = "Dev Team" },
+                    new WorkItem { Title = "Task 2", Description = "Second task", Status = WorkItemStatus.InProgress, AssignedTo = "Dev Team" },
+                    new WorkItem { Title = "Task 3", Description = "Third task", Status = WorkItemStatus.CarriedOver, AssignedTo = "Dev Team" }
+                }
+            };
+        }
+
+        #region Acceptance Criteria Tests
+
+        [Fact]
+        public async Task LoadProjectDataAsync_WithValidJsonFile_LoadsWithoutErrors()
+        {
+            // Arrange - AC: DataProvider loads wwwroot/data.json without errors when file exists and contains valid JSON
+            var testProject = CreateValidTestProject();
+            WriteTestDataJson(testProject);
+            _mockCache.Setup(c => c.GetAsync<Project>(It.IsAny<string>())).ReturnsAsync((Project)null);
+
+            var provider = new DataProvider(_mockCache.Object, _mockLogger.Object, _mockEnvironment.Object);
+
+            // Act
+            var result = await provider.LoadProjectDataAsync();
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal("Test Project", result.Name);
+        }
+
+        [Fact]
+        public async Task LoadProjectDataAsync_DeserializesJsonToStronglyTypedProject()
+        {
+            // Arrange - AC: DataProvider deserializes JSON into strongly-typed Project model with all required properties
+            var testProject = CreateValidTestProject();
+            WriteTestDataJson(testProject);
+            _mockCache.Setup(c => c.GetAsync<Project>(It.IsAny<string>())).ReturnsAsync((Project)null);
+
+            var provider = new DataProvider(_mockCache.Object, _mockLogger.Object, _mockEnvironment.Object);
+
+            // Act
+            var result = await provider.LoadProjectDataAsync();
+
+            // Assert - Verify all required properties are deserialized
+            Assert.NotNull(result);
+            Assert.NotNull(result.Name);
+            Assert.NotNull(result.Description);
+            Assert.NotNull(result.Milestones);
+            Assert.NotNull(result.WorkItems);
+            Assert.True(result.CompletionPercentage >= 0);
+            Assert.True(Enum.IsDefined(typeof(HealthStatus), result.HealthStatus));
+            Assert.True(result.VelocityThisMonth >= 0);
+        }
+
+        [Fact]
+        public async Task LoadProjectDataAsync_WithMissingRequiredFields_ThrowsInvalidOperationException()
+        {
+            // Arrange - AC: DataProvider validates JSON structure and throws descriptive InvalidOperationException when required fields missing
+            var invalidProject = new
+            {
+                description = "Missing name field",
+                startDate = "2024-01-01",
+                targetEndDate = "2024-12-31",
+                completionPercentage = 50,
+                healthStatus = "OnTrack",
+                velocityThisMonth = 10,
+                milestones = new[] { new { name = "Milestone", targetDate = "2024-03-31", status = "Completed", description = "" } },
+                workItems = new object[] { }
+            };
+
+            WriteTestDataJson(invalidProject);
+            _mockCache.Setup(c => c.GetAsync<Project>(It.IsAny<string>())).ReturnsAsync((Project)null);
+
+            var provider = new DataProvider(_mockCache.Object, _mockLogger.Object, _mockEnvironment.Object);
+
+            // Act & Assert
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => provider.LoadProjectDataAsync());
+            Assert.Contains("name", exception.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public async Task LoadProjectDataAsync_CachesDataInMemoryForOneHour()
+        {
+            // Arrange - AC: DataProvider caches parsed Project data in-memory for 1 hour via IDataCache service
+            var testProject = CreateValidTestProject();
+            WriteTestDataJson(testProject);
+            _mockCache.Setup(c => c.GetAsync<Project>(It.IsAny<string>())).ReturnsAsync((Project)null);
+
+            var provider = new DataProvider(_mockCache.Object, _mockLogger.Object, _mockEnvironment.Object);
+
+            // Act
+            await provider.LoadProjectDataAsync();
+
+            // Assert
+            _mockCache.Verify(
+                c => c.SetAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<Project>(),
+                    It.Is<TimeSpan?>(ts => ts.HasValue && ts.Value.TotalHours == 1)),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task LoadProjectDataAsync_ReturnsCachedDataOnSubsequentCalls()
+        {
+            // Arrange - AC: DataProvider returns cached data on subsequent calls within TTL window
+            var cachedProject = new Project
+            {
+                Name = "Cached Project",
+                Milestones = new List<Milestone>
+                {
+                    new Milestone { Name = "M1", Status = MilestoneStatus.Completed, TargetDate = DateTime.Now }
+                },
+                WorkItems = new List<WorkItem>()
+            };
+
+            _mockCache.Setup(c => c.GetAsync<Project>(It.IsAny<string>()))
+                .ReturnsAsync(cachedProject);
+
+            var provider = new DataProvider(_mockCache.Object, _mockLogger.Object, _mockEnvironment.Object);
+
+            // Act
+            var result = await provider.LoadProjectDataAsync();
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal("Cached Project", result.Name);
+            _mockCache.Verify(c => c.SetAsync(It.IsAny<string>(), It.IsAny<Project>(), It.IsAny<TimeSpan?>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task LoadProjectDataAsync_WithMissingFile_ThrowsFileNotFoundExceptionWithHelpfulMessage()
+        {
+            // Arrange - AC: DataProvider throws FileNotFoundException with helpful message when data.json not found
+            _mockCache.Setup(c => c.GetAsync<Project>(It.IsAny<string>())).ReturnsAsync((Project)null);
+
+            var provider = new DataProvider(_mockCache.Object, _mockLogger.Object, _mockEnvironment.Object);
+
+            // Act & Assert
+            var exception = await Assert.ThrowsAsync<FileNotFoundException>(() => provider.LoadProjectDataAsync());
+            Assert.Contains("not found", exception.Message);
+            Assert.Contains("data.json", exception.Message);
+            Assert.Contains("wwwroot", exception.Message);
+        }
+
+        [Fact]
+        public async Task LoadProjectDataAsync_WithInvalidJsonSyntax_ThrowsJsonExceptionWithLineColumnInfo()
+        {
+            // Arrange - AC: DataProvider throws JsonException with line/column info when JSON syntax invalid
+            File.WriteAllText(_testDataFilePath, "{ invalid json: content");
+            _mockCache.Setup(c => c.GetAsync<Project>(It.IsAny<string>())).ReturnsAsync((Project)null);
+
+            var provider = new DataProvider(_mockCache.Object, _mockLogger.Object, _mockEnvironment.Object);
+
+            // Act & Assert
+            var exception = await Assert.ThrowsAsync<JsonException>(() => provider.LoadProjectDataAsync());
+            Assert.Contains("Invalid JSON", exception.Message);
+        }
+
+        [Fact]
+        public void InvalidateCache_RemovesCachedData()
+        {
+            // Arrange
+            var provider = new DataProvider(_mockCache.Object, _mockLogger.Object, _mockEnvironment.Object);
+
+            // Act
+            provider.InvalidateCache();
+
+            // Assert
+            _mockCache.Verify(c => c.Remove(It.IsAny<string>()), Times.Once);
+        }
+
+        #endregion
+
+        #region Happy Path Tests
+
+        [Fact]
+        public async Task LoadProjectDataAsync_WithCompleteValidProject_ReturnsFullyPopulatedModel()
+        {
+            // Arrange
+            var testProject = CreateValidTestProject();
+            WriteTestDataJson(testProject);
+            _mockCache.Setup(c => c.GetAsync<Project>(It.IsAny<string>())).ReturnsAsync((Project)null);
+
+            var provider = new DataProvider(_mockCache.Object, _mockLogger.Object, _mockEnvironment.Object);
+
+            // Act
+            var result = await provider.LoadProjectDataAsync();
+
+            // Assert
+            Assert.Equal("Test Project", result.Name);
+            Assert.Equal("Test Description", result.Description);
+            Assert.Equal(50, result.CompletionPercentage);
+            Assert.Equal(HealthStatus.OnTrack, result.HealthStatus);
+            Assert.Equal(10, result.VelocityThisMonth);
+            Assert.Equal(3, result.Milestones.Count);
+            Assert.Equal(3, result.WorkItems.Count);
+            Assert.Equal("Phase 1", result.Milestones[0].Name);
+            Assert.Equal(MilestoneStatus.Completed, result.Milestones[0].Status);
+        }
+
+        [Fact]
+        public async Task LoadProjectDataAsync_WithMultipleMilestoneStatuses_DeserializesAllStatusesCorrectly()
+        {
+            // Arrange
+            var testProject = new Project
+            {
+                Name = "Multi-Status Project",
+                Milestones = new List<Milestone>
+                {
+                    new Milestone { Name = "Completed", Status = MilestoneStatus.Completed, TargetDate = DateTime.Now },
+                    new Milestone { Name = "InProgress", Status = MilestoneStatus.InProgress, TargetDate = DateTime.Now },
+                    new Milestone { Name = "AtRisk", Status = MilestoneStatus.AtRisk, TargetDate = DateTime.Now },
+                    new Milestone { Name = "Future", Status = MilestoneStatus.Future, TargetDate = DateTime.Now }
+                },
+                WorkItems = new List<WorkItem>()
+            };
+
+            WriteTestDataJson(testProject);
+            _mockCache.Setup(c => c.GetAsync<Project>(It.IsAny<string>())).ReturnsAsync((Project)null);
+
+            var provider = new DataProvider(_mockCache.Object, _mockLogger.Object, _mockEnvironment.Object);
+
+            // Act
+            var result = await provider.LoadProjectDataAsync();
+
+            // Assert
+            Assert.Collection(result.Milestones,
+                m => Assert.Equal(MilestoneStatus.Completed, m.Status),
+                m => Assert.Equal(MilestoneStatus.InProgress, m.Status),
+                m => Assert.Equal(MilestoneStatus.AtRisk, m.Status),
+                m => Assert.Equal(MilestoneStatus.Future, m.Status));
+        }
+
+        [Fact]
+        public async Task LoadProjectDataAsync_WithMultipleWorkItemStatuses_DeserializesAllStatusesCorrectly()
+        {
+            // Arrange
+            var testProject = new Project
+            {
+                Name = "Multi-Status Work Items",
+                Milestones = new List<Milestone>
+                {
+                    new Milestone { Name = "M1", Status = MilestoneStatus.Completed, TargetDate = DateTime.Now }
+                },
+                WorkItems = new List<WorkItem>
+                {
+                    new WorkItem { Title = "Shipped", Status = WorkItemStatus.Shipped, Description = "", AssignedTo = "" },
+                    new WorkItem { Title = "InProgress", Status = WorkItemStatus.InProgress, Description = "", AssignedTo = "" },
+                    new WorkItem { Title = "CarriedOver", Status = WorkItemStatus.CarriedOver, Description = "", AssignedTo = "" }
+                }
+            };
+
+            WriteTestDataJson(testProject);
+            _mockCache.Setup(c => c.GetAsync<Project>(It.IsAny<string>())).ReturnsAsync((Project)null);
+
+            var provider = new DataProvider(_mockCache.Object, _mockLogger.Object, _mockEnvironment.Object);
+
+            // Act
+            var result = await provider.LoadProjectDataAsync();
+
+            // Assert
+            Assert.Collection(result.WorkItems,
+                w => Assert.Equal(WorkItemStatus.Shipped, w.Status),
+                w => Assert.Equal(WorkItemStatus.InProgress, w.Status),
+                w => Assert.Equal(WorkItemStatus.CarriedOver, w.Status));
+        }
+
+        [Fact]
+        public async Task LoadProjectDataAsync_WithVariousHealthStatuses_DeserializesAllStatusesCorrectly()
+        {
+            // Arrange
+            var healthStatuses = new[] { HealthStatus.OnTrack, HealthStatus.AtRisk, HealthStatus.Blocked };
+
+            foreach (var status in healthStatuses)
+            {
+                var testProject = new Project
+                {
+                    Name = "Health Status Test",
+                    HealthStatus = status,
+                    Milestones = new List<Milestone>
+                    {
+                        new Milestone { Name = "M1", Status = MilestoneStatus.Completed, TargetDate = DateTime.Now }
+                    },
+                    WorkItems = new List<WorkItem>()
+                };
+
+                WriteTestDataJson(testProject);
+                _mockCache.Setup(c => c.GetAsync<Project>(It.IsAny<string>())).ReturnsAsync((Project)null);
+
+                var provider = new DataProvider(_mockCache.Object, _mockLogger.Object, _mockEnvironment.Object);
+
+                // Act
+                var result = await provider.LoadProjectDataAsync();
+
+                // Assert
+                Assert.Equal(status, result.HealthStatus);
+            }
+        }
+
+        #endregion
+
+        #region Edge Cases & Validation Tests
+
+        [Fact]
+        public async Task LoadProjectDataAsync_WithNullProject_ThrowsInvalidOperationException()
+        {
+            // Arrange
+            File.WriteAllText(_testDataFilePath, "null");
+            _mockCache.Setup(c => c.GetAsync<Project>(It.IsAny<string>())).ReturnsAsync((Project)null);
+
+            var provider = new DataProvider(_mockCache.Object, _mockLogger.Object, _mockEnvironment.Object);
+
+            // Act & Assert
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => provider.LoadProjectDataAsync());
+            Assert.Contains("null", exception.Message);
+        }
+
+        [Fact]
+        public async Task LoadProjectDataAsync_WithEmptyProjectName_ThrowsInvalidOperationException()
+        {
+            // Arrange
+            var projectWithEmptyName = CreateValidTestProject();
+            projectWithEmptyName.Name = "";
+
+            WriteTestDataJson(projectWithEmptyName);
+            _mockCache.Setup(c => c.GetAsync<Project>(It.IsAny<string>())).ReturnsAsync((Project)null);
+
+            var provider = new DataProvider(_mockCache.Object, _mockLogger.Object, _mockEnvironment.Object);
+
+            // Act & Assert
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => provider.LoadProjectDataAsync());
+            Assert.Contains("name", exception.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public async Task LoadProjectDataAsync_WithWhitespaceOnlyProjectName_ThrowsInvalidOperationException()
+        {
+            // Arrange
+            var projectWithWhitespaceName = CreateValidTestProject();
+            projectWithWhitespaceName.Name = "   ";
+
+            WriteTestDataJson(projectWithWhitespaceName);
+            _mockCache.Setup(c => c.GetAsync<Project>(It.IsAny<string>())).ReturnsAsync((Project)null);
+
+            var provider = new DataProvider(_mockCache.Object, _mockLogger.Object, _mockEnvironment.Object);
+
+            // Act & Assert
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => provider.LoadProjectDataAsync());
+            Assert.Contains("name", exception.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public async Task LoadProjectDataAsync_WithNoMilestones_ThrowsInvalidOperationException()
+        {
+            // Arrange
+            var projectWithoutMilestones = CreateValidTestProject();
+            projectWithoutMilestones.Milestones = new List<Milestone>();
+
+            WriteTestDataJson(projectWithoutMilestones);
+            _mockCache.Setup(c => c.GetAsync<Project>(It.IsAny<string>())).ReturnsAsync((Project)null);
+
+            var provider = new DataProvider(_mockCache.Object, _mockLogger.Object, _mockEnvironment.Object);
+
+            // Act & Assert
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => provider.LoadProjectDataAsync());
+            Assert.Contains("milestone", exception.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public async Task LoadProjectDataAsync_WithNullMilestonesList_ThrowsInvalidOperationException()
+        {
+            // Arrange
+            var projectWithNullMilestones = CreateValidTestProject();
+            projectWithNullMilestones.Milestones = null;
+
+            WriteTestDataJson(projectWithNullMilestones);
+            _mockCache.Setup(c => c.GetAsync<Project>(It.IsAny<string>())).ReturnsAsync((Project)null);
+
+            var provider = new DataProvider(_mockCache.Object, _mockLogger.Object, _mockEnvironment.Object);
+
+            // Act & Assert
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => provider.LoadProjectDataAsync());
+            Assert.Contains("milestone", exception.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public async Task LoadProjectDataAsync_WithCompletionPercentageNegative_ThrowsInvalidOperationException()
+        {
+            // Arrange
+            var projectWithNegativeCompletion = CreateValidTestProject();
+            projectWithNegativeCompletion.CompletionPercentage = -1;
+
+            WriteTestDataJson(projectWithNegativeCompletion);
+            _mockCache.Setup(c => c.GetAsync<Project>(It.IsAny<string>())).ReturnsAsync((Project)null);
+
+            var provider = new DataProvider(_mockCache.Object, _mockLogger.Object, _mockEnvironment.Object);
+
+            // Act & Assert
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => provider.LoadProjectDataAsync());
+            Assert.Contains("Completion percentage", exception.Message);
+        }
+
+        [Fact]
+        public async Task LoadProjectDataAsync_WithCompletionPercentageOver100_ThrowsInvalidOperationException()
+        {
+            // Arrange
+            var projectWithExcessCompletion = CreateValidTestProject();
+            projectWithExcessCompletion.CompletionPercentage = 101;
+
+            WriteTestDataJson(projectWithExcessCompletion);
+            _mockCache.Setup(c => c.GetAsync<Project>(It.IsAny<string>())).ReturnsAsync((Project)null);
+
+            var provider = new DataProvider(_mockCache.Object, _mockLogger.Object, _mockEnvironment.Object);
+
+            // Act & Assert
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => provider.LoadProjectDataAsync());
+            Assert.Contains("Completion percentage", exception.Message);
+        }
+
+        [Fact]
+        public async Task LoadProjectDataAsync_WithCompletionPercentageBoundaryValues_Succeeds()
+        {
+            // Arrange - Test both valid boundary values
+            foreach (var percentage in new[] { 0, 100 })
+            {
+                var testProject = CreateValidTestProject();
+                testProject.CompletionPercentage = percentage;
+
+                WriteTestDataJson(testProject);
+                _mockCache.Setup(c => c.GetAsync<Project>(It.IsAny<string>())).ReturnsAsync((Project)null);
+
+                var provider = new DataProvider(_mockCache.Object, _mockLogger.Object, _mockEnvironment.Object);
+
+                // Act
+                var result = await provider.LoadProjectDataAsync();
+
+                // Assert
+                Assert.Equal(percentage, result.CompletionPercentage);
+            }
+        }
+
+        [Fact]
+        public async Task LoadProjectDataAsync_WithMilestoneEmptyName_ThrowsInvalidOperationException()
+        {
+            // Arrange
+            var projectWithEmptyMilestoneName = CreateValidTestProject();
+            projectWithEmptyMilestoneName.Milestones[0].Name = "";
+
+            WriteTestDataJson(projectWithEmptyMilestoneName);
+            _mockCache.Setup(c => c.GetAsync<Project>(It.IsAny<string>())).ReturnsAsync((Project)null);
+
+            var provider = new DataProvider(_mockCache.Object, _mockLogger.Object, _mockEnvironment.Object);
+
+            // Act & Assert
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => provider.LoadProjectDataAsync());
+            Assert.Contains("Milestone name", exception.Message);
+        }
+
+        [Fact]
+        public async Task LoadProjectDataAsync_WithNullMilestoneName_ThrowsInvalidOperationException()
+        {
+            // Arrange
+            var projectWithNullMilestoneName = CreateValidTestProject();
+            projectWithNullMilestoneName.Milestones[0].Name = null;
+
+            WriteTestDataJson(projectWithNullMilestoneName);
+            _mockCache.Setup(c => c.GetAsync<Project>(It.IsAny<string>())).ReturnsAsync((Project)null);
+
+            var provider = new DataProvider(_mockCache.Object, _mockLogger.Object, _mockEnvironment.Object);
+
+            // Act & Assert
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => provider.LoadProjectDataAsync());
+            Assert.Contains("Milestone name", exception.Message);
+        }
+
+        [Fact]
+        public async Task LoadProjectDataAsync_WithInvalidMilestoneStatus_ThrowsInvalidOperationException()
+        {
+            // Arrange - Create JSON with invalid milestone status string
+            var projectJson = @"{
+                ""name"": ""Test"",
+                ""description"": ""Test"",
+                ""startDate"": ""2024-01-01"",
+                ""targetEndDate"": ""2024-12-31"",
+                ""completionPercentage"": 50,
+                ""healthStatus"": ""OnTrack"",
+                ""velocityThisMonth"": 10,
+                ""milestones"": [
+                    {
+                        ""name"": ""Invalid Status"",
+                        ""targetDate"": ""2024-03-31"",
+                        ""status"": ""InvalidStatus"",
+                        ""description"": ""Test""
+                    }
+                ],
+                ""workItems"": []
+            }";
+
+            File.WriteAllText(_testDataFilePath, projectJson);
+            _mockCache.Setup(c => c.GetAsync<Project>(It.IsAny<string>())).ReturnsAsync((Project)null);
+
+            var provider = new DataProvider(_mockCache.Object, _mockLogger.Object, _mockEnvironment.Object);
+
+            // Act & Assert
+            var exception = await Assert.ThrowsAsync<JsonException>(() => provider.LoadProjectDataAsync());
+        }
+
+        [Fact]
+        public async Task LoadProjectDataAsync_WithNullWorkItemsList_InitializesEmptyList()
+        {
+            // Arrange
+            var testProject = CreateValidTestProject();
+            testProject.WorkItems = null;
+
+            WriteTestDataJson(testProject);
+            _mockCache.Setup(c => c.GetAsync<Project>(It.IsAny<string>())).ReturnsAsync((Project)null);
+
+            var provider = new DataProvider(_mockCache.Object, _mockLogger.Object, _mockEnvironment.Object);
+
+            // Act
+            var result = await provider.LoadProjectDataAsync();
+
+            // Assert
+            Assert.NotNull(result.WorkItems);
+            Assert.Empty(result.WorkItems);
+        }
+
+        [Fact]
+        public async Task LoadProjectDataAsync_WithEmptyWorkItemsList_Succeeds()
+        {
+            // Arrange
+            var testProject = CreateValidTestProject();
+            testProject.WorkItems = new List<WorkItem>();
+
+            WriteTestDataJson(testProject);
+            _mockCache.Setup(c => c.GetAsync<Project>(It.IsAny<string>())).ReturnsAsync((Project)null);
+
+            var provider = new DataProvider(_mockCache.Object, _mockLogger.Object, _mockEnvironment.Object);
+
+            // Act
+            var result = await provider.LoadProjectDataAsync();
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Empty(result.WorkItems);
+        }
+
+        [Fact]
+        public async Task LoadProjectDataAsync_WithLargeProjectData_LoadsSuccessfully()
+        {
+            // Arrange - Create large project with many milestones and work items
+            var largeProject = new Project
+            {
+                Name = "Large Project",
+                Description = "Project with many items",
+                StartDate = DateTime.Parse("2024-01-01"),
+                TargetEndDate = DateTime.Parse("2024-12-31"),
+                CompletionPercentage = 75,
+                HealthStatus = HealthStatus.OnTrack,
+                VelocityThisMonth = 50,
+                Milestones = Enumerable.Range(1, 20)
+                    .Select(i => new Milestone
+                    {
+                        Name = $"Milestone {i}",
+                        TargetDate = DateTime.Parse("2024-01-01").AddMonths(i),
+                        Status = MilestoneStatus.Future,
+                        Description = $"Description {i}"
+                    })
+                    .ToList(),
+                WorkItems = Enumerable.Range(1, 50)
+                    .Select(i => new WorkItem
+                    {
+                        Title = $"Work Item {i}",
+                        Description = $"Description {i}",
+                        Status = (WorkItemStatus)(i % 3),
+                        AssignedTo = $"Team Member {i % 5}"
+                    })
+                    .ToList()
+            };
+
+            WriteTestDataJson(largeProject);
+            _mockCache.Setup(c => c.GetAsync<Project>(It.IsAny<string>())).ReturnsAsync((Project)null);
+
+            var provider = new DataProvider(_mockCache.Object, _mockLogger.Object, _mockEnvironment.Object);
+
+            // Act
+            var result = await provider.LoadProjectDataAsync();
+
+            // Assert
+            Assert.Equal(20, result.Milestones.Count);
+            Assert.Equal(50, result.WorkItems.Count);
+        }
+
+        #endregion
+
+        #region Cache Behavior Tests
+
+        [Fact]
+        public async Task LoadProjectDataAsync_WithCacheHit_DoesNotReadFile()
+        {
+            // Arrange
+            var cachedProject = new Project
+            {
+                Name = "Cached",
+                Milestones = new List<Milestone>
+                {
+                    new Milestone { Name = "M1", Status = MilestoneStatus.Completed, TargetDate = DateTime.Now }
+                },
+                WorkItems = new List<WorkItem>()
+            };
+
+            _mockCache.Setup(c => c.GetAsync<Project>(It.IsAny<string>()))
+                .ReturnsAsync(cachedProject);
+
+            var provider = new DataProvider(_mockCache.Object, _mockLogger.Object, _mockEnvironment.Object);
+
+            // Act
+            var result = await provider.LoadProjectDataAsync();
+
+            // Assert
+            Assert.Equal("Cached", result.Name);
+            Assert.False(File.Exists(_testDataFilePath), "File should not be read when cache hit occurs");
+        }
+
+        [Fact]
+        public async Task LoadProjectDataAsync_WithCacheMiss_WritesToCache()
+        {
+            // Arrange
+            var testProject = CreateValidTestProject();
+            WriteTestDataJson(testProject);
+            _mockCache.Setup(c => c.GetAsync<Project>(It.IsAny<string>())).ReturnsAsync((Project)null);
+
+            var provider = new DataProvider(_mockCache.Object, _mockLogger.Object, _mockEnvironment.Object);
+
+            // Act
+            await provider.LoadProjectDataAsync();
+
+            // Assert
+            _mockCache.Verify(
+                c => c.SetAsync(It.IsAny<string>(), It.IsAny<Project>(), It.IsAny<TimeSpan?>()),
+                Times.Once);
+        }
+
+        #endregion
+
+        #region Error Handling & Logging Tests
+
+        [Fact]
+        public async Task LoadProjectDataAsync_LogsErrorOnFileNotFound()
+        {
+            // Arrange
+            _mockCache.Setup(c => c.GetAsync<Project>(It.IsAny<string>())).ReturnsAsync((Project)null);
+
+            var provider = new DataProvider(_mockCache.Object, _mockLogger.Object, _mockEnvironment.Object);
+
+            // Act & Assert
+            await Assert.ThrowsAsync<FileNotFoundException>(() => provider.LoadProjectDataAsync());
+
+            _mockLogger.Verify(
+                x => x.Log(
+                    LogLevel.Error,
+                    It.IsAny<EventId>(),
+                    It.IsAny<It.IsAnyType>(),
+                    It.IsAny<Exception>(),
+                    It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+                Times.AtLeastOnce);
+        }
+
+        [Fact]
+        public async Task LoadProjectDataAsync_LogsErrorOnValidationFailure()
+        {
+            // Arrange
+            var invalidProject = CreateValidTestProject();
+            invalidProject.Name = "";
+
+            WriteTestDataJson(invalidProject);
+            _mockCache.Setup(c => c.GetAsync<Project>(It.IsAny<string>())).ReturnsAsync((Project)null);
+
+            var provider = new DataProvider(_mockCache.Object, _mockLogger.Object, _mockEnvironment.Object);
+
+            // Act & Assert
+            await Assert.ThrowsAsync<InvalidOperationException>(() => provider.LoadProjectDataAsync());
+
+            _mockLogger.Verify(
+                x => x.Log(
+                    LogLevel.Error,
+                    It.IsAny<EventId>(),
+                    It.IsAny<It.IsAnyType>(),
+                    It.IsAny<Exception>(),
+                    It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+                Times.AtLeastOnce);
+        }
+
+        #endregion
+
+        #region Dependency Tests
+
+        [Fact]
+        public void Constructor_WithNullCache_ThrowsArgumentNullException()
+        {
+            // Act & Assert
+            var exception = Assert.Throws<ArgumentNullException>(() =>
+                new DataProvider(null, _mockLogger.Object, _mockEnvironment.Object));
+            Assert.Equal("cache", exception.ParamName);
+        }
+
+        [Fact]
+        public void Constructor_WithNullLogger_ThrowsArgumentNullException()
+        {
+            // Act & Assert
+            var exception = Assert.Throws<ArgumentNullException>(() =>
+                new DataProvider(_mockCache.Object, null, _mockEnvironment.Object));
+            Assert.Equal("logger", exception.ParamName);
+        }
+
+        [Fact]
+        public void Constructor_WithNullEnvironment_ThrowsArgumentNullException()
+        {
+            // Act & Assert
+            var exception = Assert.Throws<ArgumentNullException>(() =>
+                new DataProvider(_mockCache.Object, _mockLogger.Object, null));
+            Assert.Equal("webHostEnvironment", exception.ParamName);
+        }
+
+        #endregion
+    }
+}

--- a/tests/Services/MemoryCacheProviderTests.cs
+++ b/tests/Services/MemoryCacheProviderTests.cs
@@ -1,0 +1,688 @@
+using AgentSquad.Runner.Services;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace AgentSquad.Runner.Tests.Services
+{
+    public class MemoryCacheProviderTests
+    {
+        private readonly IMemoryCache _memoryCache;
+        private readonly Mock<ILogger<MemoryCacheProvider>> _mockLogger;
+
+        public MemoryCacheProviderTests()
+        {
+            _memoryCache = new MemoryCache(new MemoryCacheOptions());
+            _mockLogger = new Mock<ILogger<MemoryCacheProvider>>();
+        }
+
+        private class TestData
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+            public DateTime CreatedAt { get; set; }
+        }
+
+        #region Set Operations Tests
+
+        [Fact]
+        public async Task SetAsync_StoresValueInCache()
+        {
+            // Arrange
+            var provider = new MemoryCacheProvider(_memoryCache, _mockLogger.Object);
+            var testValue = new TestData { Id = 1, Name = "Test Item", CreatedAt = DateTime.Now };
+
+            // Act
+            await provider.SetAsync("test_key", testValue);
+
+            // Assert
+            var retrieved = await provider.GetAsync<TestData>("test_key");
+            Assert.NotNull(retrieved);
+            Assert.Equal(1, retrieved.Id);
+            Assert.Equal("Test Item", retrieved.Name);
+        }
+
+        [Fact]
+        public async Task SetAsync_WithValidKey_CachesValue()
+        {
+            // Arrange - AC: IDataCache implementation wraps IMemoryCache with async Get/Set/Remove operations
+            var provider = new MemoryCacheProvider(_memoryCache, _mockLogger.Object);
+            var testValue = new TestData { Id = 42, Name = "Cached Value" };
+
+            // Act
+            await provider.SetAsync("key1", testValue);
+            var result = await provider.GetAsync<TestData>("key1");
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(42, result.Id);
+        }
+
+        [Fact]
+        public async Task SetAsync_WithNullKey_DoesNotThrowAndLogsWarning()
+        {
+            // Arrange
+            var provider = new MemoryCacheProvider(_memoryCache, _mockLogger.Object);
+            var testValue = new TestData { Id = 1, Name = "Test" };
+
+            // Act & Assert - Should not throw
+            await provider.SetAsync(null, testValue);
+
+            _mockLogger.Verify(
+                x => x.Log(
+                    LogLevel.Warning,
+                    It.IsAny<EventId>(),
+                    It.IsAny<It.IsAnyType>(),
+                    It.IsAny<Exception>(),
+                    It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task SetAsync_WithEmptyStringKey_DoesNotThrowAndLogsWarning()
+        {
+            // Arrange
+            var provider = new MemoryCacheProvider(_memoryCache, _mockLogger.Object);
+            var testValue = new TestData { Id = 1, Name = "Test" };
+
+            // Act & Assert
+            await provider.SetAsync("", testValue);
+
+            _mockLogger.Verify(
+                x => x.Log(
+                    LogLevel.Warning,
+                    It.IsAny<EventId>(),
+                    It.IsAny<It.IsAnyType>(),
+                    It.IsAny<Exception>(),
+                    It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task SetAsync_WithWhitespaceKey_DoesNotThrowAndLogsWarning()
+        {
+            // Arrange
+            var provider = new MemoryCacheProvider(_memoryCache, _mockLogger.Object);
+            var testValue = new TestData { Id = 1, Name = "Test" };
+
+            // Act & Assert
+            await provider.SetAsync("   ", testValue);
+
+            _mockLogger.Verify(
+                x => x.Log(
+                    LogLevel.Warning,
+                    It.IsAny<EventId>(),
+                    It.IsAny<It.IsAnyType>(),
+                    It.IsAny<Exception>(),
+                    It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task SetAsync_WithNullValue_DoesNotThrowAndLogsWarning()
+        {
+            // Arrange
+            var provider = new MemoryCacheProvider(_memoryCache, _mockLogger.Object);
+
+            // Act & Assert
+            await provider.SetAsync("test_key", (TestData)null);
+
+            _mockLogger.Verify(
+                x => x.Log(
+                    LogLevel.Warning,
+                    It.IsAny<EventId>(),
+                    It.IsAny<It.IsAnyType>(),
+                    It.IsAny<Exception>(),
+                    It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task SetAsync_WithDefaultTTL_Sets1HourExpiration()
+        {
+            // Arrange
+            var provider = new MemoryCacheProvider(_memoryCache, _mockLogger.Object);
+            var testValue = new TestData { Id = 1, Name = "Test" };
+
+            // Act
+            await provider.SetAsync("test_key", testValue, null);
+
+            // Assert - Value should still be available (1 hour hasn't passed)
+            var retrieved = await provider.GetAsync<TestData>("test_key");
+            Assert.NotNull(retrieved);
+        }
+
+        [Fact]
+        public async Task SetAsync_WithCustomTTL_UsesProvidedExpiration()
+        {
+            // Arrange
+            var provider = new MemoryCacheProvider(_memoryCache, _mockLogger.Object);
+            var testValue = new TestData { Id = 1, Name = "Short Lived" };
+            var shortTTL = TimeSpan.FromMilliseconds(100);
+
+            // Act
+            await provider.SetAsync("short_lived", testValue, shortTTL);
+
+            // Assert - Should exist immediately
+            var immediate = await provider.GetAsync<TestData>("short_lived");
+            Assert.NotNull(immediate);
+
+            // Wait for expiration
+            await Task.Delay(150);
+
+            // Should be expired
+            var expired = await provider.GetAsync<TestData>("short_lived");
+            Assert.Null(expired);
+        }
+
+        [Fact]
+        public async Task SetAsync_OverwritesExistingValue()
+        {
+            // Arrange
+            var provider = new MemoryCacheProvider(_memoryCache, _mockLogger.Object);
+            var value1 = new TestData { Id = 1, Name = "First" };
+            var value2 = new TestData { Id = 2, Name = "Second" };
+
+            await provider.SetAsync("key", value1);
+
+            // Act
+            await provider.SetAsync("key", value2);
+
+            // Assert
+            var result = await provider.GetAsync<TestData>("key");
+            Assert.Equal(2, result.Id);
+            Assert.Equal("Second", result.Name);
+        }
+
+        #endregion
+
+        #region Get Operations Tests
+
+        [Fact]
+        public async Task GetAsync_WithValidKey_ReturnsCachedValue()
+        {
+            // Arrange - AC: Support optional TTL parameter (default 1 hour)
+            var provider = new MemoryCacheProvider(_memoryCache, _mockLogger.Object);
+            var testValue = new TestData { Id = 99, Name = "Retrieved Value" };
+            await provider.SetAsync("retrieve_key", testValue);
+
+            // Act
+            var result = await provider.GetAsync<TestData>("retrieve_key");
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(99, result.Id);
+            Assert.Equal("Retrieved Value", result.Name);
+        }
+
+        [Fact]
+        public async Task GetAsync_WithNonexistentKey_ReturnsNull()
+        {
+            // Arrange
+            var provider = new MemoryCacheProvider(_memoryCache, _mockLogger.Object);
+
+            // Act
+            var result = await provider.GetAsync<TestData>("nonexistent_key_xyz");
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public async Task GetAsync_WithNullKey_ReturnsNullAndLogsWarning()
+        {
+            // Arrange
+            var provider = new MemoryCacheProvider(_memoryCache, _mockLogger.Object);
+
+            // Act
+            var result = await provider.GetAsync<TestData>(null);
+
+            // Assert
+            Assert.Null(result);
+            _mockLogger.Verify(
+                x => x.Log(
+                    LogLevel.Warning,
+                    It.IsAny<EventId>(),
+                    It.IsAny<It.IsAnyType>(),
+                    It.IsAny<Exception>(),
+                    It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task GetAsync_WithEmptyKey_ReturnsNullAndLogsWarning()
+        {
+            // Arrange
+            var provider = new MemoryCacheProvider(_memoryCache, _mockLogger.Object);
+
+            // Act
+            var result = await provider.GetAsync<TestData>("");
+
+            // Assert
+            Assert.Null(result);
+            _mockLogger.Verify(
+                x => x.Log(
+                    LogLevel.Warning,
+                    It.IsAny<EventId>(),
+                    It.IsAny<It.IsAnyType>(),
+                    It.IsAny<Exception>(),
+                    It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task GetAsync_WithWhitespaceKey_ReturnsNullAndLogsWarning()
+        {
+            // Arrange
+            var provider = new MemoryCacheProvider(_memoryCache, _mockLogger.Object);
+
+            // Act
+            var result = await provider.GetAsync<TestData>("   ");
+
+            // Assert
+            Assert.Null(result);
+            _mockLogger.Verify(
+                x => x.Log(
+                    LogLevel.Warning,
+                    It.IsAny<EventId>(),
+                    It.IsAny<It.IsAnyType>(),
+                    It.IsAny<Exception>(),
+                    It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task GetAsync_LogsCacheHitAtDebugLevel()
+        {
+            // Arrange - AC: Log cache hits/misses at Debug level
+            var provider = new MemoryCacheProvider(_memoryCache, _mockLogger.Object);
+            var testValue = new TestData { Id = 1, Name = "Test" };
+            await provider.SetAsync("hit_key", testValue);
+
+            // Act
+            await provider.GetAsync<TestData>("hit_key");
+
+            // Assert
+            _mockLogger.Verify(
+                x => x.Log(
+                    LogLevel.Debug,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, t) => v.ToString().Contains("Cache hit")),
+                    It.IsAny<Exception>(),
+                    It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task GetAsync_LogsCacheMissAtDebugLevel()
+        {
+            // Arrange - AC: Log cache hits/misses at Debug level
+            var provider = new MemoryCacheProvider(_memoryCache, _mockLogger.Object);
+
+            // Act
+            await provider.GetAsync<TestData>("miss_key");
+
+            // Assert
+            _mockLogger.Verify(
+                x => x.Log(
+                    LogLevel.Debug,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, t) => v.ToString().Contains("Cache miss")),
+                    It.IsAny<Exception>(),
+                    It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task GetAsync_WithExpiredData_ReturnsNull()
+        {
+            // Arrange
+            var provider = new MemoryCacheProvider(_memoryCache, _mockLogger.Object);
+            var testValue = new TestData { Id = 1, Name = "Expiring" };
+            await provider.SetAsync("expiring_key", testValue, TimeSpan.FromMilliseconds(50));
+
+            // Act & Assert - Immediate access succeeds
+            var immediate = await provider.GetAsync<TestData>("expiring_key");
+            Assert.NotNull(immediate);
+
+            // Wait for expiration
+            await Task.Delay(100);
+
+            // After expiration, returns null
+            var afterExpiry = await provider.GetAsync<TestData>("expiring_key");
+            Assert.Null(afterExpiry);
+        }
+
+        #endregion
+
+        #region Remove Operations Tests
+
+        [Fact]
+        public async Task Remove_DeletesKeyFromCache()
+        {
+            // Arrange - AC: IDataCache implementation wraps IMemoryCache with async Get/Set/Remove operations
+            var provider = new MemoryCacheProvider(_memoryCache, _mockLogger.Object);
+            var testValue = new TestData { Id = 1, Name = "To Remove" };
+            await provider.SetAsync("remove_key", testValue);
+
+            // Act
+            provider.Remove("remove_key");
+
+            // Assert
+            var result = await provider.GetAsync<TestData>("remove_key");
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public async Task Remove_WithNullKey_DoesNotThrowAndLogsWarning()
+        {
+            // Arrange
+            var provider = new MemoryCacheProvider(_memoryCache, _mockLogger.Object);
+
+            // Act & Assert
+            provider.Remove(null);
+
+            _mockLogger.Verify(
+                x => x.Log(
+                    LogLevel.Warning,
+                    It.IsAny<EventId>(),
+                    It.IsAny<It.IsAnyType>(),
+                    It.IsAny<Exception>(),
+                    It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task Remove_WithEmptyKey_DoesNotThrowAndLogsWarning()
+        {
+            // Arrange
+            var provider = new MemoryCacheProvider(_memoryCache, _mockLogger.Object);
+
+            // Act & Assert
+            provider.Remove("");
+
+            _mockLogger.Verify(
+                x => x.Log(
+                    LogLevel.Warning,
+                    It.IsAny<EventId>(),
+                    It.IsAny<It.IsAnyType>(),
+                    It.IsAny<Exception>(),
+                    It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task Remove_WithWhitespaceKey_DoesNotThrowAndLogsWarning()
+        {
+            // Arrange
+            var provider = new MemoryCacheProvider(_memoryCache, _mockLogger.Object);
+
+            // Act & Assert
+            provider.Remove("   ");
+
+            _mockLogger.Verify(
+                x => x.Log(
+                    LogLevel.Warning,
+                    It.IsAny<EventId>(),
+                    It.IsAny<It.IsAnyType>(),
+                    It.IsAny<Exception>(),
+                    It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task Remove_WithNonexistentKey_DoesNotThrow()
+        {
+            // Arrange
+            var provider = new MemoryCacheProvider(_memoryCache, _mockLogger.Object);
+
+            // Act & Assert - Should not throw
+            provider.Remove("never_existed");
+        }
+
+        [Fact]
+        public async Task Remove_LogsAtDebugLevel()
+        {
+            // Arrange
+            var provider = new MemoryCacheProvider(_memoryCache, _mockLogger.Object);
+            var testValue = new TestData { Id = 1, Name = "Test" };
+            await provider.SetAsync("log_remove_key", testValue);
+
+            // Act
+            provider.Remove("log_remove_key");
+
+            // Assert
+            _mockLogger.Verify(
+                x => x.Log(
+                    LogLevel.Debug,
+                    It.IsAny<EventId>(),
+                    It.IsAny<It.IsAnyType>(),
+                    It.IsAny<Exception>(),
+                    It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+                Times.AtLeastOnce);
+        }
+
+        #endregion
+
+        #region Multiple Keys Tests
+
+        [Fact]
+        public async Task MultipleKeys_StoredAndRetrievedIndependently()
+        {
+            // Arrange
+            var provider = new MemoryCacheProvider(_memoryCache, _mockLogger.Object);
+            var value1 = new TestData { Id = 1, Name = "First" };
+            var value2 = new TestData { Id = 2, Name = "Second" };
+            var value3 = new TestData { Id = 3, Name = "Third" };
+
+            // Act
+            await provider.SetAsync("key1", value1);
+            await provider.SetAsync("key2", value2);
+            await provider.SetAsync("key3", value3);
+
+            // Assert
+            var retrieved1 = await provider.GetAsync<TestData>("key1");
+            var retrieved2 = await provider.GetAsync<TestData>("key2");
+            var retrieved3 = await provider.GetAsync<TestData>("key3");
+
+            Assert.Equal(1, retrieved1.Id);
+            Assert.Equal(2, retrieved2.Id);
+            Assert.Equal(3, retrieved3.Id);
+        }
+
+        [Fact]
+        public async Task MultipleKeys_RemovalIsolated()
+        {
+            // Arrange
+            var provider = new MemoryCacheProvider(_memoryCache, _mockLogger.Object);
+            var value1 = new TestData { Id = 1, Name = "Keep" };
+            var value2 = new TestData { Id = 2, Name = "Remove" };
+
+            await provider.SetAsync("keep_key", value1);
+            await provider.SetAsync("remove_key", value2);
+
+            // Act
+            provider.Remove("remove_key");
+
+            // Assert
+            var kept = await provider.GetAsync<TestData>("keep_key");
+            var removed = await provider.GetAsync<TestData>("remove_key");
+
+            Assert.NotNull(kept);
+            Assert.Null(removed);
+        }
+
+        [Fact]
+        public async Task MultipleKeys_DifferentTTLs_ExpireIndependently()
+        {
+            // Arrange
+            var provider = new MemoryCacheProvider(_memoryCache, _mockLogger.Object);
+            var shortLived = new TestData { Id = 1, Name = "Short" };
+            var longLived = new TestData { Id = 2, Name = "Long" };
+
+            await provider.SetAsync("short", shortLived, TimeSpan.FromMilliseconds(75));
+            await provider.SetAsync("long", longLived, TimeSpan.FromMilliseconds(500));
+
+            // Act & Assert - After short expiration
+            await Task.Delay(100);
+
+            var shortResult = await provider.GetAsync<TestData>("short");
+            var longResult = await provider.GetAsync<TestData>("long");
+
+            Assert.Null(shortResult);
+            Assert.NotNull(longResult);
+
+            // Wait for long expiration
+            await Task.Delay(450);
+
+            var finalLongResult = await provider.GetAsync<TestData>("long");
+            Assert.Null(finalLongResult);
+        }
+
+        #endregion
+
+        #region Complex Type Tests
+
+        [Fact]
+        public async Task SetGetAsync_WithComplexObject_PreservesStructure()
+        {
+            // Arrange
+            var provider = new MemoryCacheProvider(_memoryCache, _mockLogger.Object);
+            var complexObject = new TestData
+            {
+                Id = 123,
+                Name = "Complex Name",
+                CreatedAt = new DateTime(2024, 1, 15, 10, 30, 45)
+            };
+
+            // Act
+            await provider.SetAsync("complex", complexObject);
+            var result = await provider.GetAsync<TestData>("complex");
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(123, result.Id);
+            Assert.Equal("Complex Name", result.Name);
+            Assert.Equal(new DateTime(2024, 1, 15, 10, 30, 45), result.CreatedAt);
+        }
+
+        #endregion
+
+        #region Concurrency Tests
+
+        [Fact]
+        public async Task ConcurrentSetAsync_AllOperationsSucceed()
+        {
+            // Arrange
+            var provider = new MemoryCacheProvider(_memoryCache, _mockLogger.Object);
+            var tasks = Enumerable.Range(1, 10)
+                .Select(i => provider.SetAsync($"key{i}", new TestData { Id = i, Name = $"Item{i}" }))
+                .ToList();
+
+            // Act
+            await Task.WhenAll(tasks);
+
+            // Assert
+            for (int i = 1; i <= 10; i++)
+            {
+                var result = await provider.GetAsync<TestData>($"key{i}");
+                Assert.NotNull(result);
+                Assert.Equal(i, result.Id);
+            }
+        }
+
+        [Fact]
+        public async Task ConcurrentGetAsync_AllOperationsSucceed()
+        {
+            // Arrange
+            var provider = new MemoryCacheProvider(_memoryCache, _mockLogger.Object);
+            var testValue = new TestData { Id = 42, Name = "Shared" };
+            await provider.SetAsync("shared_key", testValue);
+
+            var getTasks = Enumerable.Range(1, 10)
+                .Select(_ => provider.GetAsync<TestData>("shared_key"))
+                .ToList();
+
+            // Act
+            var results = await Task.WhenAll(getTasks);
+
+            // Assert
+            Assert.All(results, result => Assert.NotNull(result));
+            Assert.All(results, result => Assert.Equal(42, result.Id));
+        }
+
+        #endregion
+
+        #region Async Behavior Tests
+
+        [Fact]
+        public async Task SetAsync_ReturnsCompletedTask()
+        {
+            // Arrange
+            var provider = new MemoryCacheProvider(_memoryCache, _mockLogger.Object);
+            var testValue = new TestData { Id = 1, Name = "Test" };
+
+            // Act
+            var task = provider.SetAsync("key", testValue);
+
+            // Assert
+            Assert.True(task.IsCompleted);
+            await task;
+        }
+
+        [Fact]
+        public async Task GetAsync_ReturnsCompletedTask()
+        {
+            // Arrange
+            var provider = new MemoryCacheProvider(_memoryCache, _mockLogger.Object);
+            var testValue = new TestData { Id = 1, Name = "Test" };
+            await provider.SetAsync("key", testValue);
+
+            // Act
+            var task = provider.GetAsync<TestData>("key");
+
+            // Assert
+            Assert.True(task.IsCompleted);
+            var result = await task;
+            Assert.NotNull(result);
+        }
+
+        #endregion
+
+        #region TTL Boundary Tests
+
+        [Fact]
+        public async Task SetAsync_WithZeroTTL_ExpiresFastButNotImmediate()
+        {
+            // Arrange
+            var provider = new MemoryCacheProvider(_memoryCache, _mockLogger.Object);
+            var testValue = new TestData { Id = 1, Name = "Zero TTL" };
+
+            // Act
+            await provider.SetAsync("zero_ttl", testValue, TimeSpan.Zero);
+
+            // Assert - May or may not be available immediately depending on timing
+            var result = await provider.GetAsync<TestData>("zero_ttl");
+            // This behavior is implementation-dependent, just ensure no exception
+        }
+
+        [Fact]
+        public async Task SetAsync_WithVeryLargeTTL_EffectivelyPersists()
+        {
+            // Arrange
+            var provider = new MemoryCacheProvider(_memoryCache, _mockLogger.Object);
+            var testValue = new TestData { Id = 1, Name = "Long Lived" };
+            var longTTL = TimeSpan.FromDays(365);
+
+            // Act
+            await provider.SetAsync("long_ttl", testValue, longTTL);
+
+            // Assert - Should definitely be available
+            var result = await provider.GetAsync<TestData>("long_ttl");
+            Assert.NotNull(result);
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
## Test Engineering

**Source PR:** #67 (merged)
**Generated by:** TestEngineer
**Test Files:** 2

### Test Files
- `tests/Services/DataProviderTests.cs`
- `tests/Services/MemoryCacheProviderTests.cs`

### Coverage
- Unit tests for new/changed functions and classes
- Integration tests for component interactions
- Edge case and error handling coverage

### How to Run
Run the test suite with the standard test runner for the project tech stack.