### PR TITLE
PrincipalEngineer: Implement Data Watcher Service

### DIFF
--- a/src/AgentSquad.Runner/Program.cs
+++ b/src/AgentSquad.Runner/Program.cs
@@ -26,7 +26,6 @@ var app = builder.Build();
 if (!app.Environment.IsDevelopment())
 {
     app.UseExceptionHandler("/Error", createScopeForErrors: true);
-    // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
     app.UseHsts();
 }
 

--- a/src/AgentSquad.Runner/Services/DataWatcherService.cs
+++ b/src/AgentSquad.Runner/Services/DataWatcherService.cs
@@ -1,0 +1,207 @@
+using System.IO;
+using System.Timers;
+using AgentSquad.Runner.Interfaces;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace AgentSquad.Runner.Services;
+
+/// <summary>
+/// Monitors data.json file for changes using FileSystemWatcher with 500ms debounce.
+/// Emits OnDataChanged async event on main Blazor Server thread when file changes detected.
+/// Tracks LastRefreshTime timestamp for UI display.
+/// 
+/// Thread Safety: OnDataChanged event is fired on the main Blazor Server thread via
+/// implicit marshaling through the SynchronizationContext. Blazor components subscribing
+/// to this event will have their handlers invoked on the UI thread automatically.
+/// </summary>
+public class DataWatcherService : IDataWatcherService, IDisposable, IAsyncDisposable
+{
+    private readonly IConfiguration _configuration;
+    private readonly ILogger<DataWatcherService> _logger;
+    private FileSystemWatcher? _watcher;
+    private Timer? _debounceTimer;
+    private DateTime _lastRefreshTime;
+    private readonly SynchronizationContext? _syncContext;
+
+    /// <summary>
+    /// Event fired asynchronously after debounce period when file change detected.
+    /// Handler: Func<Task> (async event)
+    /// Fired on: Main Blazor Server thread (via SynchronizationContext marshaling)
+    /// </summary>
+    public event Func<Task>? OnDataChanged;
+
+    /// <summary>
+    /// Get timestamp of last successful refresh.
+    /// </summary>
+    public DateTime LastRefreshTime => _lastRefreshTime;
+
+    /// <summary>
+    /// Get formatted timestamp for UI display (HH:mm:ss).
+    /// </summary>
+    public string LastRefreshTimeFormatted => _lastRefreshTime.ToString("HH:mm:ss");
+
+    /// <summary>
+    /// Initialize DataWatcherService with configuration and logging.
+    /// Captures current SynchronizationContext for thread-safe event firing.
+    /// </summary>
+    public DataWatcherService(IConfiguration configuration, ILogger<DataWatcherService> logger)
+    {
+        _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _lastRefreshTime = DateTime.Now;
+        _syncContext = SynchronizationContext.Current;
+        _logger.LogInformation("DataWatcherService instantiated");
+    }
+
+    /// <summary>
+    /// Initialize file watcher for specified data path.
+    /// </summary>
+    /// <param name="dataPath">Path to monitor (e.g., "./data.json"). Defaults to config or "./data.json"</param>
+    /// <remarks>Does not throw; logs errors internally. Graceful degradation if FSW fails.</remarks>
+    public void Start(string? dataPath = null)
+    {
+        try
+        {
+            // Resolve dataPath: parameter > config > default
+            dataPath ??= _configuration.GetValue<string>("AppSettings:DataPath") ?? "./data.json";
+
+            var fullPath = Path.GetFullPath(dataPath);
+            var directory = Path.GetDirectoryName(fullPath) ?? ".";
+            var filename = Path.GetFileName(fullPath);
+
+            _logger.LogInformation($"Starting DataWatcher for: {dataPath}");
+
+            // Create and configure FileSystemWatcher
+            _watcher = new FileSystemWatcher(directory)
+            {
+                Filter = filename,
+                NotifyFilter = NotifyFilters.LastWrite,
+                EnableRaisingEvents = false
+            };
+
+            // Subscribe to Changed event
+            _watcher.Changed += OnFileChanged;
+
+            // Enable raising events
+            _watcher.EnableRaisingEvents = true;
+
+            _logger.LogInformation($"DataWatcher started successfully for: {dataPath}");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning($"Failed to start DataWatcher: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Stop file watcher and cancel debounce timer.
+    /// </summary>
+    public void Stop()
+    {
+        _logger.LogInformation("Stopping DataWatcher");
+
+        try
+        {
+            if (_watcher != null)
+            {
+                _watcher.EnableRaisingEvents = false;
+            }
+
+            if (_debounceTimer != null)
+            {
+                _debounceTimer.Stop();
+                _debounceTimer.Dispose();
+                _debounceTimer = null;
+            }
+
+            _logger.LogInformation("DataWatcher stopped");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning($"Error stopping DataWatcher: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Handle file change events with debounce logic.
+    /// </summary>
+    private void OnFileChanged(object sender, FileSystemEventArgs e)
+    {
+        _logger.LogDebug("File changed detected");
+
+        try
+        {
+            if (_debounceTimer?.Enabled == true)
+            {
+                _debounceTimer.Stop();
+            }
+
+            var debounceMs = _configuration.GetValue("AppSettings:DebounceIntervalMs", 500);
+
+            _debounceTimer = new Timer(debounceMs)
+            {
+                AutoReset = false,
+                Enabled = false
+            };
+
+            _debounceTimer.Elapsed += async (s, timerEventArgs) => await OnDebounceTimerElapsed();
+
+            _debounceTimer.Start();
+
+            _logger.LogDebug($"Debounce timer started ({debounceMs}ms)");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning($"Error in OnFileChanged: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Fire OnDataChanged event after debounce period completes.
+    /// </summary>
+    private async Task OnDebounceTimerElapsed()
+    {
+        try
+        {
+            _lastRefreshTime = DateTime.Now;
+            _logger.LogInformation($"Data refresh triggered at {_lastRefreshTime:HH:mm:ss}");
+
+            if (OnDataChanged != null)
+            {
+                if (_syncContext != null)
+                {
+                    await _syncContext.InvokeAsync(async () => await OnDataChanged.Invoke());
+                }
+                else
+                {
+                    await OnDataChanged.Invoke();
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError($"Error in OnDebounceTimerElapsed: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Dispose managed resources.
+    /// </summary>
+    public void Dispose()
+    {
+        Stop();
+        _watcher?.Dispose();
+        _watcher = null;
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// Asynchronously dispose managed resources.
+    /// </summary>
+    public async ValueTask DisposeAsync()
+    {
+        Dispose();
+        await ValueTask.CompletedTask;
+    }
+}

--- a/src/Services/DataWatcherService.cs
+++ b/src/Services/DataWatcherService.cs
@@ -1,0 +1,224 @@
+using System.IO;
+using System.Timers;
+using AgentSquad.Runner.Interfaces;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace AgentSquad.Runner.Services;
+
+/// <summary>
+/// Monitors data.json file for changes using FileSystemWatcher with 500ms debounce.
+/// Emits OnDataChanged async event on main Blazor Server thread when file changes detected.
+/// Tracks LastRefreshTime timestamp for UI display.
+/// 
+/// Thread Safety: OnDataChanged event is fired on the main Blazor Server thread via
+/// implicit marshaling through the SynchronizationContext. Blazor components subscribing
+/// to this event will have their handlers invoked on the UI thread automatically.
+/// </summary>
+public class DataWatcherService : IDataWatcherService, IDisposable, IAsyncDisposable
+{
+    private readonly IConfiguration _configuration;
+    private readonly ILogger<DataWatcherService> _logger;
+    private FileSystemWatcher? _watcher;
+    private Timer? _debounceTimer;
+    private DateTime _lastRefreshTime;
+    private readonly SynchronizationContext? _syncContext;
+
+    /// <summary>
+    /// Event fired asynchronously after debounce period when file change detected.
+    /// Handler: Func<Task> (async event)
+    /// Fired on: Main Blazor Server thread (via SynchronizationContext marshaling)
+    /// </summary>
+    public event Func<Task>? OnDataChanged;
+
+    /// <summary>
+    /// Get timestamp of last successful refresh.
+    /// </summary>
+    public DateTime LastRefreshTime => _lastRefreshTime;
+
+    /// <summary>
+    /// Get formatted timestamp for UI display (HH:mm:ss).
+    /// </summary>
+    public string LastRefreshTimeFormatted => _lastRefreshTime.ToString("HH:mm:ss");
+
+    /// <summary>
+    /// Initialize DataWatcherService with configuration and logging.
+    /// Captures current SynchronizationContext for thread-safe event firing.
+    /// </summary>
+    public DataWatcherService(IConfiguration configuration, ILogger<DataWatcherService> logger)
+    {
+        _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _lastRefreshTime = DateTime.Now;
+        _syncContext = SynchronizationContext.Current;
+        _logger.LogInformation("DataWatcherService instantiated");
+    }
+
+    /// <summary>
+    /// Initialize file watcher for specified data path.
+    /// </summary>
+    /// <param name="dataPath">Path to monitor (e.g., "./data.json"). Defaults to config or "./data.json"</param>
+    /// <remarks>Does not throw; logs errors internally. Graceful degradation if FSW fails.</remarks>
+    public void Start(string? dataPath = null)
+    {
+        try
+        {
+            // Resolve dataPath: parameter > config > default
+            dataPath ??= _configuration.GetValue<string>("AppSettings:DataPath") ?? "./data.json";
+
+            var fullPath = Path.GetFullPath(dataPath);
+            var directory = Path.GetDirectoryName(fullPath) ?? ".";
+            var filename = Path.GetFileName(fullPath);
+
+            _logger.LogInformation($"Starting DataWatcher for: {dataPath}");
+
+            // Create and configure FileSystemWatcher
+            _watcher = new FileSystemWatcher(directory)
+            {
+                Filter = filename,
+                NotifyFilter = NotifyFilters.LastWrite,
+                EnableRaisingEvents = false // Enable after subscribing
+            };
+
+            // Subscribe to Changed event
+            _watcher.Changed += OnFileChanged;
+
+            // Enable raising events
+            _watcher.EnableRaisingEvents = true;
+
+            _logger.LogInformation($"DataWatcher started successfully for: {dataPath}");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning($"Failed to start DataWatcher: {ex.Message}");
+            // Graceful degradation: do not throw
+        }
+    }
+
+    /// <summary>
+    /// Stop file watcher and cancel debounce timer.
+    /// </summary>
+    public void Stop()
+    {
+        _logger.LogInformation("Stopping DataWatcher");
+
+        try
+        {
+            // Stop FileSystemWatcher
+            if (_watcher != null)
+            {
+                _watcher.EnableRaisingEvents = false;
+            }
+
+            // Stop and dispose debounce timer
+            if (_debounceTimer != null)
+            {
+                _debounceTimer.Stop();
+                _debounceTimer.Dispose();
+                _debounceTimer = null;
+            }
+
+            _logger.LogInformation("DataWatcher stopped");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning($"Error stopping DataWatcher: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Handle file change events with debounce logic.
+    /// Cancels pending timer and starts new one to collapse rapid writes.
+    /// </summary>
+    private void OnFileChanged(object sender, FileSystemEventArgs e)
+    {
+        _logger.LogDebug("File changed detected");
+
+        try
+        {
+            // Stop existing debounce timer if running
+            if (_debounceTimer?.Enabled == true)
+            {
+                _debounceTimer.Stop();
+            }
+
+            // Get debounce interval from config
+            var debounceMs = _configuration.GetValue("AppSettings:DebounceIntervalMs", 500);
+
+            // Create new debounce timer
+            _debounceTimer = new Timer(debounceMs)
+            {
+                AutoReset = false,
+                Enabled = false
+            };
+
+            // Subscribe to Elapsed event
+            _debounceTimer.Elapsed += async (s, timerEventArgs) => await OnDebounceTimerElapsed();
+
+            // Start timer
+            _debounceTimer.Start();
+
+            _logger.LogDebug($"Debounce timer started ({debounceMs}ms)");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning($"Error in OnFileChanged: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Fire OnDataChanged event after debounce period completes.
+    /// Updates LastRefreshTime timestamp.
+    /// Event is marshaled to main Blazor Server thread via SynchronizationContext.
+    /// </summary>
+    private async Task OnDebounceTimerElapsed()
+    {
+        try
+        {
+            _lastRefreshTime = DateTime.Now;
+            _logger.LogInformation($"Data refresh triggered at {_lastRefreshTime:HH:mm:ss}");
+
+            // Fire OnDataChanged event on main thread via SynchronizationContext
+            if (OnDataChanged != null)
+            {
+                if (_syncContext != null)
+                {
+                    // Marshal to main thread via captured SynchronizationContext
+                    await _syncContext.InvokeAsync(async () => await OnDataChanged.Invoke());
+                }
+                else
+                {
+                    // Fallback: invoke directly (will be marshaled by Blazor component handlers)
+                    await OnDataChanged.Invoke();
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError($"Error in OnDebounceTimerElapsed: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Dispose managed resources.
+    /// </summary>
+    public void Dispose()
+    {
+        Stop();
+
+        // Dispose FileSystemWatcher
+        _watcher?.Dispose();
+        _watcher = null;
+
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// Asynchronously dispose managed resources.
+    /// </summary>
+    public async ValueTask DisposeAsync()
+    {
+        Dispose();
+        await ValueTask.CompletedTask;
+    }
+}

--- a/tests/AgentSquad.Runner.Tests/AgentSquad.Runner.Tests.csproj
+++ b/tests/AgentSquad.Runner.Tests/AgentSquad.Runner.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.7.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="bunit" Version="1.28.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\AgentSquad.Runner\AgentSquad.Runner.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/AgentSquad.Runner.Tests/Services/DataWatcherServiceTests.cs
+++ b/tests/AgentSquad.Runner.Tests/Services/DataWatcherServiceTests.cs
@@ -1,0 +1,315 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using AgentSquad.Runner.Interfaces;
+using AgentSquad.Runner.Services;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+using FluentAssertions;
+
+namespace AgentSquad.Runner.Tests.Services
+{
+    public class DataWatcherServiceTests : IDisposable
+    {
+        private readonly Mock<IConfiguration> _mockConfiguration;
+        private readonly Mock<ILogger<DataWatcherService>> _mockLogger;
+        private readonly string _tempDirectory;
+        private readonly string _tempDataFile;
+
+        public DataWatcherServiceTests()
+        {
+            _mockConfiguration = new Mock<IConfiguration>();
+            _mockLogger = new Mock<ILogger<DataWatcherService>>();
+            
+            _tempDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(_tempDirectory);
+            _tempDataFile = Path.Combine(_tempDirectory, "data.json");
+            File.WriteAllText(_tempDataFile, "{}");
+
+            _mockConfiguration
+                .Setup(x => x.GetValue(It.IsAny<string>(), It.IsAny<int>()))
+                .Returns<string, int>((key, defaultValue) =>
+                {
+                    if (key == "AppSettings:DebounceIntervalMs")
+                        return 500;
+                    return defaultValue;
+                });
+
+            _mockConfiguration
+                .Setup(x => x.GetValue<string>(It.IsAny<string>(), It.IsAny<string>()))
+                .Returns<string, string>((key, defaultValue) =>
+                {
+                    if (key == "AppSettings:DataPath")
+                        return null;
+                    return defaultValue;
+                });
+        }
+
+        [Fact]
+        public void Start_CreatesFileSystemWatcher()
+        {
+            var service = new DataWatcherService(_mockConfiguration.Object, _mockLogger.Object);
+            service.Start(_tempDataFile);
+
+            _mockLogger.Verify(
+                x => x.Log(
+                    LogLevel.Information,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, t) => v.ToString().Contains("DataWatcher started successfully")),
+                    It.IsAny<Exception>(),
+                    It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+                Times.Once);
+
+            service.Dispose();
+        }
+
+        [Fact]
+        public async Task OnFileChanged_DebouncesSingleRefresh()
+        {
+            var service = new DataWatcherService(_mockConfiguration.Object, _mockLogger.Object);
+            var eventFiredCount = 0;
+            var taskCompletionSource = new TaskCompletionSource<bool>();
+
+            service.OnDataChanged += async () =>
+            {
+                eventFiredCount++;
+                if (eventFiredCount == 1)
+                    taskCompletionSource.SetResult(true);
+                await Task.CompletedTask;
+            };
+
+            service.Start(_tempDataFile);
+            var initialRefreshTime = service.LastRefreshTime;
+
+            for (int i = 0; i < 5; i++)
+            {
+                File.WriteAllText(_tempDataFile, $"{{\"update\": {i}}}");
+                await Task.Delay(20);
+            }
+
+            var completed = await taskCompletionSource.Task.ConfigureAwait(false);
+
+            completed.Should().BeTrue();
+            eventFiredCount.Should().Be(1, "debounce should collapse multiple writes into single event");
+            service.LastRefreshTime.Should().BeGreaterThan(initialRefreshTime);
+
+            service.Dispose();
+        }
+
+        [Fact]
+        public async Task OnFileChanged_MultipleSeparateWrites_FiresMultipleEvents()
+        {
+            var service = new DataWatcherService(_mockConfiguration.Object, _mockLogger.Object);
+            var eventFiredCount = 0;
+            var firstTaskCompletionSource = new TaskCompletionSource<bool>();
+            var secondTaskCompletionSource = new TaskCompletionSource<bool>();
+
+            service.OnDataChanged += async () =>
+            {
+                eventFiredCount++;
+                if (eventFiredCount == 1)
+                    firstTaskCompletionSource.SetResult(true);
+                else if (eventFiredCount == 2)
+                    secondTaskCompletionSource.SetResult(true);
+                await Task.CompletedTask;
+            };
+
+            service.Start(_tempDataFile);
+
+            File.WriteAllText(_tempDataFile, "{\"update\": 1}");
+            var firstCompleted = await firstTaskCompletionSource.Task.ConfigureAwait(false);
+
+            await Task.Delay(600);
+
+            File.WriteAllText(_tempDataFile, "{\"update\": 2}");
+            var secondCompleted = await secondTaskCompletionSource.Task.ConfigureAwait(false);
+
+            firstCompleted.Should().BeTrue();
+            secondCompleted.Should().BeTrue();
+            eventFiredCount.Should().Be(2, "debounce should reset between separate write windows");
+
+            service.Dispose();
+        }
+
+        [Fact]
+        public async Task LastRefreshTime_UpdatesOnDebounceComplete()
+        {
+            var service = new DataWatcherService(_mockConfiguration.Object, _mockLogger.Object);
+            var taskCompletionSource = new TaskCompletionSource<bool>();
+
+            service.OnDataChanged += async () =>
+            {
+                taskCompletionSource.SetResult(true);
+                await Task.CompletedTask;
+            };
+
+            service.Start(_tempDataFile);
+            var initialRefreshTime = service.LastRefreshTime;
+            await Task.Delay(100);
+
+            File.WriteAllText(_tempDataFile, "{\"update\": 1}");
+            await taskCompletionSource.Task.ConfigureAwait(false);
+
+            service.LastRefreshTime.Should().BeGreaterThan(initialRefreshTime);
+
+            service.Dispose();
+        }
+
+        [Fact]
+        public void LastRefreshTimeFormatted_ReturnsHHmmssFormat()
+        {
+            var service = new DataWatcherService(_mockConfiguration.Object, _mockLogger.Object);
+            service.Start(_tempDataFile);
+
+            var formatted = service.LastRefreshTimeFormatted;
+
+            formatted.Should().MatchRegex(@"^\d{2}:\d{2}:\d{2}$");
+
+            service.Dispose();
+        }
+
+        [Fact]
+        public async Task Stop_DisablesFileSystemWatcher()
+        {
+            var service = new DataWatcherService(_mockConfiguration.Object, _mockLogger.Object);
+            var eventFiredCount = 0;
+            var taskCompletionSource = new TaskCompletionSource<bool>();
+
+            service.OnDataChanged += async () =>
+            {
+                eventFiredCount++;
+                taskCompletionSource.SetResult(true);
+                await Task.CompletedTask;
+            };
+
+            service.Start(_tempDataFile);
+
+            File.WriteAllText(_tempDataFile, "{\"update\": 1}");
+            await taskCompletionSource.Task.ConfigureAwait(false);
+            int countBeforeStop = eventFiredCount;
+
+            service.Stop();
+            await Task.Delay(100);
+
+            File.WriteAllText(_tempDataFile, "{\"update\": 2}");
+            await Task.Delay(600);
+
+            countBeforeStop.Should().Be(1);
+            eventFiredCount.Should().Be(1, "after Stop(), file changes should not trigger events");
+
+            service.Dispose();
+        }
+
+        [Fact]
+        public void Start_WithInvalidDirectory_LogsWarningAndContinues()
+        {
+            var invalidPath = Path.Combine(_tempDirectory, "nonexistent", "data.json");
+            var service = new DataWatcherService(_mockConfiguration.Object, _mockLogger.Object);
+
+            service.Start(invalidPath);
+
+            _mockLogger.Verify(
+                x => x.Log(
+                    LogLevel.Warning,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, t) => v.ToString().Contains("Failed to start DataWatcher")),
+                    It.IsAny<Exception>(),
+                    It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+                Times.Once);
+
+            service.Dispose();
+        }
+
+        [Fact]
+        public void Dispose_CleansUpResources()
+        {
+            var service = new DataWatcherService(_mockConfiguration.Object, _mockLogger.Object);
+            service.Start(_tempDataFile);
+
+            service.Dispose();
+
+            _mockLogger.Verify(
+                x => x.Log(
+                    LogLevel.Information,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, t) => v.ToString().Contains("Stopping DataWatcher")),
+                    It.IsAny<Exception>(),
+                    It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task DisposeAsync_CleansUpResourcesAsync()
+        {
+            var service = new DataWatcherService(_mockConfiguration.Object, _mockLogger.Object);
+            service.Start(_tempDataFile);
+
+            await service.DisposeAsync();
+
+            _mockLogger.Verify(
+                x => x.Log(
+                    LogLevel.Information,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, t) => v.ToString().Contains("Stopping DataWatcher")),
+                    It.IsAny<Exception>(),
+                    It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task IntegrationSmoke_FileWatcherActivation()
+        {
+            var service = new DataWatcherService(_mockConfiguration.Object, _mockLogger.Object);
+            var eventFired = false;
+            var taskCompletionSource = new TaskCompletionSource<bool>();
+
+            service.OnDataChanged += async () =>
+            {
+                eventFired = true;
+                taskCompletionSource.SetResult(true);
+                await Task.CompletedTask;
+            };
+
+            service.Start(_tempDataFile);
+            _mockLogger.Verify(
+                x => x.Log(
+                    LogLevel.Information,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, t) => v.ToString().Contains("DataWatcher started successfully")),
+                    It.IsAny<Exception>(),
+                    It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+                Times.Once);
+
+            File.WriteAllText(_tempDataFile, "{\"test\": true}");
+            var completed = await taskCompletionSource.Task.ConfigureAwait(false);
+
+            completed.Should().BeTrue();
+            eventFired.Should().BeTrue();
+
+            service.Stop();
+            await Task.Delay(100);
+
+            File.WriteAllText(_tempDataFile, "{\"test\": false}");
+            await Task.Delay(600);
+
+            _mockLogger.Verify(
+                x => x.Log(
+                    LogLevel.Information,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, t) => v.ToString().Contains("Stopping DataWatcher")),
+                    It.IsAny<Exception>(),
+                    It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+                Times.Once);
+
+            service.Dispose();
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(_tempDirectory))
+                Directory.Delete(_tempDirectory, true);
+        }
+    }
+}


### PR DESCRIPTION
## Task Assignment
**Assigned To:** PrincipalEngineer
**Complexity:** Medium
**Branch:** `agent/principalengineer/t4-implement-data-watcher-service`

## Requirements
Closes #194

# PR: Implement Data Watcher Service (T4)

## Summary

This PR implements DataWatcherService, a singleton service that monitors data.json for file changes using System.IO.FileSystemWatcher with a 500ms debounce mechanism via System.Timers.Timer. The service detects Last-Write events, collapses rapid file writes into a single refresh via debouncing, and emits an async OnDataChanged event on the main Blazor Server thread. It tracks LastRefreshTime as a DateTime property and exposes LastRefreshTimeFormatted for UI display. The service implements IDisposable and IAsyncDisposable for proper resource cleanup. On errors, it logs warnings and degrades gracefully without crashing. This implementation enables Index.razor to automatically reload and re-render the dashboard when executives edit data.json, supporting the <1 second auto-refresh requirement.

## Acceptance Criteria

- [ ] DataWatcherService created in src/Services/ namespace AgentSquad.Runner.Services
- [ ] Implements IDataWatcherService interface from T1 foundation
- [ ] Implements IDisposable and IAsyncDisposable for cleanup
- [ ] Constructor accepts IConfiguration and ILogger<DataWatcherService>
- [ ] Start(string dataPath = null) method initializes FileSystemWatcher
- [ ] FileSystemWatcher configured to monitor data.json directory
- [ ] FileSystemWatcher subscribed to Changed event (Last-Write events only)
- [ ] 500ms debounce timer implemented via System.Timers.Timer
- [ ] Rapid file writes within 500ms window debounced into single refresh
- [ ] OnDataChanged event fires after debounce period with no additional changes
- [ ] OnDataChanged event fires on main Blazor Server thread (thread-safe)
- [ ] OnDataChanged event is Func<Task> (async event)
- [ ] LastRefreshTime property tracks DateTime of last successful refresh
- [ ] LastRefreshTimeFormatted property returns HH:mm:ss formatted string
- [ ] Stop() method stops FileSystemWatcher and cancels debounce timer
- [ ] Dispose() and DisposeAsync() properly clean up FileSystemWatcher and timer
- [ ] Debounce interval read from appsettings.json AppSettings:DebounceIntervalMs (default 500ms)
- [ ] Data file path resolved from parameter, config, or default "./data.json"
- [ ] All operations logged at INFO level: started, file changed, timer fired, errors
- [ ] Graceful degradation: logs WARNING on FSW errors; app continues (does not throw)
- [ ] No race conditions between debounce timer and OnDataChanged event
- [ ] Thread-safe: Blazor dispatcher invoked for event firing on main thread
- [ ] Service compiles without errors; integrates with DI from T1

## Implementation Steps

### Step 1: Create DataWatcherService Scaffold & DI Registration

**Produces:** src/Services/DataWatcherService.cs with constructor and field declarations

Create class with:
- Class declaration: `public class DataWatcherService : IDataWatcherService, IDisposable, IAsyncDisposable`
- Private fields: `IConfiguration _configuration`, `ILogger<DataWatcherService> _logger`, `FileSystemWatcher _watcher`, `System.Timers.Timer _debounceTimer`, `DateTime _lastRefreshTime`
- Constructor: Accept IConfiguration and ILogger, assign to fields
- Event declaration: `public event Func<Task> OnDataChanged;`
- Property stubs: LastRefreshTime, LastRefreshTimeFormatted
- Method stubs: Start(), Stop(), Dispose(), DisposeAsync()
- Add XML documentation comments

Update Program.cs DI registration (T1 placeholder) to wire service. Add: `builder.Services.AddSingleton<DataWatcherService>();` and `builder.Services.AddSingleton<IDataWatcherService>(sp => sp.GetRequiredService<DataWatcherService>());`

**Commits:** 1 commit: "Add DataWatcherService scaffold with DI registration"

### Step 2: Implement LastRefreshTime & LastRefreshTimeFormatted Properties

**Produces:** Functional timestamp properties with initialization

Implement properties:
- `LastRefreshTime` property: getter returns `_lastRefreshTime` (initialized to DateTime.Now in constructor)
- `LastRefreshTimeFormatted` property: getter returns `_lastRefreshTime.ToString("HH:mm:ss")`
- Initialize `_lastRefreshTime = DateTime.Now` in constructor
- Log INFO in constructor: `_logger.LogInformation("DataWatcherService instantiated")`

**Commits:** 1 commit: "Implement LastRefreshTime and LastRefreshTimeFormatted properties"

### Step 3: Implement Start() Method with FileSystemWatcher Initialization

**Produces:** Functional Start() method that initializes and subscribes to FileSystemWatcher

Implement Start(string dataPath = null):
- Resolve dataPath: parameter > config > default "./data.json"
- Get directory from dataPath: `var directory = Path.GetDirectoryName(Path.GetFullPath(dataPath)) ?? "."`
- Get filename: `var filename = Path.GetFileName(dataPath)`
- Log INFO: `_logger.LogInformation($"Starting DataWatcher for: {dataPath}")`
- Create FileSystemWatcher:
  ```csharp
  _watcher = new FileSystemWatcher(directory)
  {
    Filter = filename,
    NotifyFilter = NotifyFilters.LastWrite,
    EnableRaisingEvents = false // Enable after subscribing
  };
  ```
- Subscribe to Changed event: `_watcher.Changed += OnFileChanged;`
- Enable raising events: `_watcher.EnableRaisingEvents = true;`
- Log INFO: `_logger.LogInformation($"DataWatcher started successfully for: {dataPath}")`
- Wrap in try/catch: if FSW fails, log WARNING (do NOT throw): `_logger.LogWarning($"Failed to start DataWatcher: {ex.Message}")`

**Commits:** 1 commit: "Implement Start() method with FileSystemWatcher initialization"

### Step 4: Implement Debounce Logic with System.Timers.Timer

**Produces:** File change handler with debounce timer

Create private method `OnFileChanged(object sender, FileSystemEventArgs e)`:
- Log DEBUG: `_logger.LogDebug("File changed detected")`
- Stop existing debounce timer if running (if `_debounceTimer?.Enabled == true`)
- Get debounce interval from config: `var debounceMs = _configuration.GetValue("AppSettings:DebounceIntervalMs", 500)`
- Create new System.Timers.Timer:
  ```csharp
  _debounceTimer = new System.Timers.Timer(debounceMs)
  {
    AutoReset = false,
    Enabled = false
  };
  ```
- Subscribe to Elapsed event: `_debounceTimer.Elapsed += async (s, e) => await OnDebounceTimerElapsed();`
- Start timer: `_debounceTimer.Start()`
- Log DEBUG: `_logger.LogDebug($"Debounce timer started ({debounceMs}ms)"`

Create private async method `OnDebounceTimerElapsed()`:
- Update timestamp: `_lastRefreshTime = DateTime.Now`
- Log INFO: `_logger.LogInformation($"Data refresh triggered at {_lastRefreshTime:HH:mm:ss}")`
- Fire OnDataChanged event on main Blazor thread via Dispatcher:
  ```csharp
  if (OnDataChanged != null)
  {
    await OnDataChanged.Invoke();
  }
  ```

**Commits:** 1 commit: "Implement debounce logic with System.Timers.Timer"

### Step 5: Implement Stop() & Disposal Methods

**Produces:** Resource cleanup via Dispose/DisposeAsync

Implement Stop():
- Log INFO: `_logger.LogInformation("Stopping DataWatcher")`
- Stop FileSystemWatcher: `_watcher?.EnableRaisingEvents = false`
- Stop and dispose timer: `_debounceTimer?.Stop(); _debounceTimer?.Dispose()`
- Log INFO: `_logger.LogInformation("DataWatcher stopped")`

Implement Dispose():
- Call Stop()
- Dispose FileSystemWatcher: `_watcher?.Dispose()`

Implement DisposeAsync():
- Call Dispose()
- Return `ValueTask.CompletedTask`

**Commits:** 1 commit: "Implement Stop() and disposal methods (Dispose/DisposeAsync)"

### Step 6: Add Unit Tests & Manual Verification

**Produces:** Comprehensive unit tests (5+ test cases) verifying debounce behavior

Create tests/Services/DataWatcherServiceTests.cs with:

**Test 1: Start_CreatesFileSystemWatcher**
- Arrange: Create temp directory and empty data.json
- Act: Call Start(tempFilePath)
- Assert: FileSystemWatcher is enabled, logs contain "DataWatcher started"

**Test 2: OnFileChanged_DebouncesSingleRefresh**
- Arrange: Create temp data.json; call Start(); get initial LastRefreshTime
- Act: Write to file 5 times within 100ms
- Assert: OnDataChanged fires once (not 5 times); verify debounce worked

**Test 3: OnFileChanged_MultipleSeparateWrites_FiresMultipleEvents**
- Arrange: Create temp data.json; call Start()
- Act: Write, wait 600ms, write again
- Assert: OnDataChanged fires twice (debounce resets between windows)

**Test 4: LastRefreshTime_UpdatesOnDebounceComplete**
- Arrange: Create temp data.json; call Start(); save initial time
- Act: Write to file; wait 600ms
- Assert: LastRefreshTime > initial time

**Test 5: LastRefreshTimeFormatted_ReturnsHHmmssFormat**
- Arrange: Create service; call Start()
- Act: Call LastRefreshTimeFormatted
- Assert: Matches regex pattern HH:mm:ss (e.g., "14:32:45")

**Test 6: Stop_DisablesFileSystemWatcher**
- Arrange: Create temp data.json; call Start()
- Act: Call Stop()
- Assert: FileSystemWatcher disabled; subsequent file writes don't trigger events

Create integration smoke test:
- Create temp data.json
- Call Start()
- Verify FileSystemWatcher active
- Edit file, wait 600ms
- Verify OnDataChanged fired
- Call Stop(), verify no more events

**Commits:** 1 commit: "Add comprehensive unit tests for DataWatcherService (6 test cases + integration smoke test)"

## Testing

### Unit Tests (5+ cases)

**Debounce Collapse Test:**
- Write file 3 times within 100ms
- Assert OnDataChanged fires once (not 3 times)
- Verify `_debounceTimer` was reset on each write

**Timestamp Update Test:**
- Call Start()
- Note initial `LastRefreshTime`
- Write file; wait 600ms
- Assert `LastRefreshTime` updated to current time
- Assert `LastRefreshTimeFormatted` returns HH:mm:ss format

**Graceful Error Handling Test:**
- Point FileSystemWatcher to invalid directory
- Assert Start() logs WARNING (does not throw)
- Assert app remains responsive

**Stop & Disposal Test:**
- Call Start()
- Call Stop()
- Assert FileSystemWatcher EnableRaisingEvents = false
- Write file; assert OnDataChanged does NOT fire
- Call Dispose(); verify no memory leaks

**Thread-Safety Test:**
- Verify OnDataChanged event fires on main Blazor thread
- Use Blazor dispatcher to validate thread context
- Assert no race conditions between timer and event

### Integration Tests (After T2 & T10 Complete)

Once DataLoaderService (T2) and Index.razor (T10) are implemented:
- Launch app with data.json in working directory
- Verify DataWatcherService starts (logs show "started")
- Edit data.json in text editor; save
- Verify dashboard refreshes within 1 second
- Verify "Data refreshed at HH:mm:ss" timestamp updates
- Edit file 3 times rapidly; verify only 1 refresh (debounce works)

### Manual Testing

1. **Startup & Monitoring**
   - Launch app
   - Check browser console: "DataWatcher started..." log appears
   - Verify file monitoring is active

2. **Debounce Validation**
   - Open data.json in editor
   - Rapid-fire save 3-4 times (Ctrl+S repeatedly)
   - Dashboard updates once, not 4 times
   - Check timestamp: single refresh logged

3. **Large File Handling**
   - Create data.json with >5MB of data
   - Save file
   - Verify app responds within 1 second (no hang)

4. **Error Handling**
   - Delete data.json while app running
   - Verify error message displays (T10 handles this)
   - Recreate data.json
   - Verify refresh succeeds

---

## Dependencies & Integration

**Depends On:**
- T1 foundation: IDataWatcherService interface, DI registration, IConfiguration
- System.IO.FileSystemWatcher: Built-in .NET
- System.Timers.Timer: Built-in .NET
- Microsoft.Extensions.Logging: Built-in .NET

**Used By:**
- T10 (Index.razor orchestration): Subscribes to OnDataChanged event; calls Start()

**No File Conflicts:**
- Exclusive ownership of src/Services/DataWatcherService.cs
- Only reads IDataWatcherService interface (created in T1)
- Does not modify any other files

---

## Notes for Reviewers

- **Thread Safety:** OnDataChanged fired via Blazor dispatcher to ensure main thread context. No race conditions with debounce timer.

- **Graceful Degradation:** If FileSystemWatcher fails to initialize (e.g., directory doesn't exist), service logs WARNING and continues. App still loads with last-known-good data.

- **Debounce Correctness:** Each file write cancels pending timer and starts new one. Only fires event if timer completes without interruption (true debounce, not throttle).

- **Resource Cleanup:** Implements both IDisposable and IAsyncDisposable. Stop() called by Dispose(); timer and watcher properly cleaned up on app shutdown.

- **Configuration:** Debounce interval configurable via appsettings.json (default 500ms). Allows tuning for slow-write environments.

---

## Files Created/Modified Summary

| File | Action | Purpose |
|------|--------|---------|
| src/Services/DataWatcherService.cs | Create | Monitor data.json with FileSystemWatcher and 500ms debounce |
| Program.cs | Modify | Add DataWatcherService DI registration (singleton) |
| tests/Services/DataWatcherServiceTests.cs | Create | Unit tests (6+ cases) for debounce, timestamps, disposal |

## References
- Architecture: Architecture.md
- PM Spec: 

## Status
- [ ] Implementation
- [ ] Tests Written
- [ ] Ready for Review