### PR TITLE
PrincipalEngineer 1: DashboardDataService Implementation

### DIFF
--- a/.agentsquad/dashboarddataservice-implementation.task
+++ b/.agentsquad/dashboarddataservice-implementation.task
@@ -1,0 +1,4 @@
+agent: PrincipalEngineer 1
+task: DashboardDataService Implementation
+complexity: High
+status: in-progress

--- a/src/AgentSquad.Runner/Models/DashboardData.cs
+++ b/src/AgentSquad.Runner/Models/DashboardData.cs
@@ -1,13 +1,8 @@
-using System.ComponentModel.DataAnnotations;
-
 namespace AgentSquad.Runner.Models;
 
 public class DashboardData
 {
-    [Required]
-    public Project Project { get; init; } = null!;
-
-    public List<Milestone> Milestones { get; init; } = [];
-
-    public List<WorkItem> WorkItems { get; init; } = [];
+    public Project Project { get; set; }
+    public List<Milestone> Milestones { get; set; } = new();
+    public List<WorkItem> WorkItems { get; set; } = new();
 }

--- a/src/AgentSquad.Runner/Models/DashboardOptions.cs
+++ b/src/AgentSquad.Runner/Models/DashboardOptions.cs
@@ -1,7 +1,8 @@
-namespace AgentSquad.Runner.Models;
-
-public class DashboardOptions
+namespace AgentSquad.Runner.Models
 {
-    public string DataJsonPath { get; set; } = "data.json";
-    public int FileWatchDebounceMs { get; set; } = 500;
+    public class DashboardOptions
+    {
+        public string DataJsonPath { get; set; } = "data.json";
+        public int FileWatchDebounceMs { get; set; } = 500;
+    }
 }

--- a/src/AgentSquad.Runner/Models/Milestone.cs
+++ b/src/AgentSquad.Runner/Models/Milestone.cs
@@ -1,17 +1,8 @@
-using System.ComponentModel.DataAnnotations;
-
 namespace AgentSquad.Runner.Models;
 
 public class Milestone
 {
-    [Required]
-    [StringLength(256)]
-    public string Name { get; init; } = string.Empty;
-
-    [Required]
-    public DateTime Date { get; init; }
-
-    [Required]
-    [RegularExpression(@"^(Completed|On Track|At Risk)$")]
-    public string Status { get; init; } = string.Empty;
+    public string Name { get; set; }
+    public DateTime Date { get; set; }
+    public string Status { get; set; }
 }

--- a/src/AgentSquad.Runner/Models/Project.cs
+++ b/src/AgentSquad.Runner/Models/Project.cs
@@ -1,13 +1,7 @@
-using System.ComponentModel.DataAnnotations;
-
 namespace AgentSquad.Runner.Models;
 
 public class Project
 {
-    [Required]
-    [StringLength(256)]
-    public string Name { get; init; } = string.Empty;
-
-    [StringLength(1024)]
-    public string? Description { get; init; }
+    public string Name { get; set; }
+    public string Description { get; set; }
 }

--- a/src/AgentSquad.Runner/Models/WorkItem.cs
+++ b/src/AgentSquad.Runner/Models/WorkItem.cs
@@ -1,16 +1,8 @@
-using System.ComponentModel.DataAnnotations;
-
 namespace AgentSquad.Runner.Models;
 
 public class WorkItem
 {
-    [Required]
-    [StringLength(512)]
-    public string Title { get; init; } = string.Empty;
-
-    [Required]
-    public WorkItemStatus Status { get; init; }
-
-    [StringLength(256)]
-    public string? Assignee { get; init; }
+    public string Title { get; set; }
+    public WorkItemStatus Status { get; set; }
+    public string Assignee { get; set; }
 }

--- a/src/AgentSquad.Runner/Program.cs
+++ b/src/AgentSquad.Runner/Program.cs
@@ -1,24 +1,33 @@
-using MudBlazor;
-using AgentSquad.Runner.Models;
+using AgentSquad.Runner.Services;
+using MudBlazor.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 
+// Add services to the container.
 builder.Services.AddRazorPages();
 builder.Services.AddServerSideBlazor();
 builder.Services.AddMudBlazorSnackbar();
+builder.Services.AddMudBlazorDialog();
 
+// Configuration
 builder.Services.Configure<DashboardOptions>(
     builder.Configuration.GetSection("Dashboard"));
 
+// Register DashboardDataService as singleton
+builder.Services.AddSingleton<IDashboardDataService, DashboardDataService>();
+
 var app = builder.Build();
 
+// Configure the HTTP request pipeline.
 if (!app.Environment.IsDevelopment())
 {
     app.UseExceptionHandler("/Error");
+    // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
     app.UseHsts();
 }
 
 app.UseHttpsRedirection();
+
 app.UseStaticFiles();
 
 app.UseRouting();

--- a/src/AgentSquad.Runner/Program.cs
+++ b/src/AgentSquad.Runner/Program.cs
@@ -1,33 +1,31 @@
-using AgentSquad.Runner.Services;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using MudBlazor.Services;
+using AgentSquad.Runner.Models;
+using AgentSquad.Runner.Services;
 
-var builder = WebApplication.CreateBuilder(args);
+var builder = WebApplicationBuilder.CreateBuilder(args);
 
-// Add services to the container.
 builder.Services.AddRazorPages();
 builder.Services.AddServerSideBlazor();
-builder.Services.AddMudBlazorSnackbar();
-builder.Services.AddMudBlazorDialog();
+builder.Services.AddMudServices();
 
-// Configuration
 builder.Services.Configure<DashboardOptions>(
     builder.Configuration.GetSection("Dashboard"));
 
-// Register DashboardDataService as singleton
-builder.Services.AddSingleton<IDashboardDataService, DashboardDataService>();
+builder.Services.AddSingleton<DashboardDataService>();
+builder.Services.AddSingleton<IDashboardDataService>(sp => sp.GetRequiredService<DashboardDataService>());
 
 var app = builder.Build();
 
-// Configure the HTTP request pipeline.
 if (!app.Environment.IsDevelopment())
 {
     app.UseExceptionHandler("/Error");
-    // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
     app.UseHsts();
 }
 
 app.UseHttpsRedirection();
-
 app.UseStaticFiles();
 
 app.UseRouting();

--- a/src/AgentSquad.Runner/Services/DashboardDataService.cs
+++ b/src/AgentSquad.Runner/Services/DashboardDataService.cs
@@ -1,5 +1,6 @@
 using System.Security.Cryptography;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using AgentSquad.Runner.Models;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -33,26 +34,37 @@ public class DashboardDataService : IDashboardDataService, IDisposable
         _lastError = null;
         _lastLoadedHash = null;
         HasData = false;
+
+        LoadFromJson();
     }
 
     public DashboardData GetCurrentData()
     {
-        throw new NotImplementedException();
+        return _cachedData;
     }
 
     public Project GetProject()
     {
-        throw new NotImplementedException();
+        return _cachedData?.Project;
     }
 
     public IReadOnlyList<Milestone> GetMilestones()
     {
-        throw new NotImplementedException();
+        if (_cachedData?.Milestones == null)
+            return new List<Milestone>().AsReadOnly();
+        
+        return _cachedData.Milestones
+            .OrderBy(m => m.Date)
+            .ToList()
+            .AsReadOnly();
     }
 
     public IReadOnlyList<WorkItem> GetWorkItems()
     {
-        throw new NotImplementedException();
+        if (_cachedData?.WorkItems == null)
+            return new List<WorkItem>().AsReadOnly();
+        
+        return _cachedData.WorkItems.AsReadOnly();
     }
 
     public IReadOnlyList<WorkItem> GetWorkItemsByStatus(WorkItemStatus status)
@@ -67,7 +79,151 @@ public class DashboardDataService : IDashboardDataService, IDisposable
 
     public string GetLastError()
     {
-        throw new NotImplementedException();
+        return _lastError;
+    }
+
+    private void LoadFromJson()
+    {
+        try
+        {
+            var dataJsonPath = Path.Combine(
+                AppContext.BaseDirectory,
+                _options.Value?.DataJsonPath ?? "data.json");
+
+            if (!File.Exists(dataJsonPath))
+            {
+                throw new FileNotFoundException($"data.json not found at {dataJsonPath}");
+            }
+
+            var jsonContent = File.ReadAllText(dataJsonPath, System.Text.Encoding.UTF8);
+
+            var options = new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true,
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                AllowTrailingCommas = false,
+                MaxDepth = 64
+            };
+
+            var data = JsonSerializer.Deserialize<DashboardData>(jsonContent, options);
+
+            ValidateData(data);
+
+            _cachedData = data;
+            _lastError = null;
+            HasData = true;
+
+            _logger.LogInformation("DashboardDataService initialized, data.json loaded successfully");
+        }
+        catch (FileNotFoundException ex)
+        {
+            _lastError = $"FileNotFound: {ex.Message}";
+            _logger.LogError(_lastError);
+            HasData = false;
+            _cachedData = new DashboardData();
+        }
+        catch (JsonException ex)
+        {
+            _lastError = $"JSON syntax error in data.json: {ex.Message}";
+            _logger.LogError(_lastError);
+            HasData = false;
+            _cachedData = new DashboardData();
+        }
+        catch (ArgumentException ex)
+        {
+            _lastError = $"Validation error: {ex.Message}";
+            _logger.LogError(_lastError);
+            HasData = false;
+            _cachedData = new DashboardData();
+        }
+        catch (Exception ex)
+        {
+            _lastError = $"Unexpected error loading data.json: {ex.Message}";
+            _logger.LogError(_lastError);
+            HasData = false;
+            _cachedData = new DashboardData();
+        }
+    }
+
+    private void ValidateData(DashboardData data)
+    {
+        if (data == null)
+        {
+            throw new ArgumentException("Deserialized data is null");
+        }
+
+        if (data.Project == null)
+        {
+            throw new ArgumentException("Project is required in data.json");
+        }
+
+        if (string.IsNullOrWhiteSpace(data.Project.Name))
+        {
+            throw new ArgumentException("Project.Name is required and cannot be empty");
+        }
+
+        if (data.Project.Name.Length > 256)
+        {
+            throw new ArgumentException($"Project.Name exceeds maximum length of 256 characters (current: {data.Project.Name.Length})");
+        }
+
+        if (!string.IsNullOrEmpty(data.Project.Description) && data.Project.Description.Length > 1024)
+        {
+            throw new ArgumentException($"Project.Description exceeds maximum length of 1024 characters (current: {data.Project.Description.Length})");
+        }
+
+        if (data.Milestones != null)
+        {
+            foreach (var milestone in data.Milestones)
+            {
+                if (string.IsNullOrWhiteSpace(milestone.Name))
+                {
+                    throw new ArgumentException("Milestone.Name is required and cannot be empty");
+                }
+
+                if (milestone.Name.Length > 256)
+                {
+                    throw new ArgumentException($"Milestone.Name exceeds maximum length of 256 characters (current: {milestone.Name.Length})");
+                }
+
+                if (string.IsNullOrEmpty(milestone.Status))
+                {
+                    throw new ArgumentException("Milestone.Status is required");
+                }
+
+                var validStatuses = new[] { "Completed", "On Track", "At Risk" };
+                if (!validStatuses.Contains(milestone.Status))
+                {
+                    throw new ArgumentException($"Invalid Milestone.Status '{milestone.Status}'. Valid values: {string.Join(", ", validStatuses)}");
+                }
+            }
+        }
+
+        if (data.WorkItems != null)
+        {
+            foreach (var workItem in data.WorkItems)
+            {
+                if (string.IsNullOrWhiteSpace(workItem.Title))
+                {
+                    throw new ArgumentException("WorkItem.Title is required and cannot be empty");
+                }
+
+                if (workItem.Title.Length > 512)
+                {
+                    throw new ArgumentException($"WorkItem.Title exceeds maximum length of 512 characters (current: {workItem.Title.Length})");
+                }
+
+                if (!Enum.IsDefined(typeof(WorkItemStatus), workItem.Status))
+                {
+                    throw new ArgumentException($"Invalid WorkItem.Status '{workItem.Status}'. Valid values: {string.Join(", ", Enum.GetNames(typeof(WorkItemStatus)))}");
+                }
+
+                if (!string.IsNullOrEmpty(workItem.Assignee) && workItem.Assignee.Length > 256)
+                {
+                    throw new ArgumentException($"WorkItem.Assignee exceeds maximum length of 256 characters (current: {workItem.Assignee.Length})");
+                }
+            }
+        }
     }
 
     public void Dispose()

--- a/src/AgentSquad.Runner/Services/DashboardDataService.cs
+++ b/src/AgentSquad.Runner/Services/DashboardDataService.cs
@@ -118,30 +118,32 @@ public class DashboardDataService : IDashboardDataService, IDisposable
         catch (FileNotFoundException ex)
         {
             _lastError = $"FileNotFound: {ex.Message}";
-            _logger.LogError(_lastError);
+            _logger.LogError("Failed to load data.json: {error}", _lastError);
             HasData = false;
-            _cachedData = new DashboardData();
         }
         catch (JsonException ex)
         {
             _lastError = $"JSON syntax error in data.json: {ex.Message}";
-            _logger.LogError(_lastError);
+            _logger.LogError("Failed to parse data.json: {error}", _lastError);
             HasData = false;
-            _cachedData = new DashboardData();
         }
         catch (ArgumentException ex)
         {
             _lastError = $"Validation error: {ex.Message}";
-            _logger.LogError(_lastError);
+            _logger.LogError("Validation failed for data.json: {error}", _lastError);
             HasData = false;
-            _cachedData = new DashboardData();
+        }
+        catch (IOException ex)
+        {
+            _lastError = $"IO error reading data.json: {ex.Message}";
+            _logger.LogError("IO error reading data.json: {error}", _lastError);
+            HasData = false;
         }
         catch (Exception ex)
         {
             _lastError = $"Unexpected error loading data.json: {ex.Message}";
-            _logger.LogError(_lastError);
+            _logger.LogError("Unexpected error: {error}", _lastError);
             HasData = false;
-            _cachedData = new DashboardData();
         }
     }
 

--- a/src/AgentSquad.Runner/Services/DashboardDataService.cs
+++ b/src/AgentSquad.Runner/Services/DashboardDataService.cs
@@ -1,351 +1,351 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using System.Security.Cryptography;
+using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using AgentSquad.Runner.Models;
+using System.Threading;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using AgentSquad.Runner.Models;
 
-namespace AgentSquad.Runner.Services;
-
-public class DashboardDataService : IDashboardDataService, IDisposable
+namespace AgentSquad.Runner.Services
 {
-    private readonly ILogger<DashboardDataService> _logger;
-    private readonly IOptions<DashboardOptions> _options;
-    
-    private DashboardData _cachedData;
-    private string _lastError;
-    private string _lastLoadedHash;
-    private FileSystemWatcher _watcher;
-    private Timer _debounceTimer;
-    private bool _disposed;
-    private readonly object _lockObject = new();
-
-    public event Action OnDataChanged;
-
-    public bool HasData { get; private set; }
-
-    public DashboardDataService(
-        ILogger<DashboardDataService> logger,
-        IOptions<DashboardOptions> options)
+    public class DashboardDataService : IDashboardDataService, IDisposable
     {
-        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-        _options = options ?? throw new ArgumentNullException(nameof(options));
-        
-        _cachedData = new DashboardData();
-        _lastError = null;
-        _lastLoadedHash = null;
-        HasData = false;
+        private readonly ILogger<DashboardDataService> _logger;
+        private readonly IOptions<DashboardOptions> _options;
+        private DashboardData _cachedData;
+        private string _lastError;
+        private string _lastLoadedHash;
+        private FileSystemWatcher _watcher;
+        private Timer _debounceTimer;
+        private bool _pendingReload;
+        private object _lockObject = new object();
+        private bool _disposed;
 
-        LoadFromJson();
-        InitializeFileWatcher();
-    }
+        public event Action OnDataChanged;
 
-    public DashboardData GetCurrentData()
-    {
-        return _cachedData;
-    }
+        public bool HasData => _cachedData != null && string.IsNullOrEmpty(_lastError);
 
-    public Project GetProject()
-    {
-        return _cachedData?.Project;
-    }
-
-    public IReadOnlyList<Milestone> GetMilestones()
-    {
-        if (_cachedData?.Milestones == null)
-            return new List<Milestone>().AsReadOnly();
-        
-        return _cachedData.Milestones
-            .OrderBy(m => m.Date)
-            .ToList()
-            .AsReadOnly();
-    }
-
-    public IReadOnlyList<WorkItem> GetWorkItems()
-    {
-        if (_cachedData?.WorkItems == null)
-            return new List<WorkItem>().AsReadOnly();
-        
-        return _cachedData.WorkItems.AsReadOnly();
-    }
-
-    public IReadOnlyList<WorkItem> GetWorkItemsByStatus(WorkItemStatus status)
-    {
-        throw new NotImplementedException();
-    }
-
-    public (int Shipped, int InProgress, int CarriedOver) GetStatusCounts()
-    {
-        throw new NotImplementedException();
-    }
-
-    public string GetLastError()
-    {
-        return _lastError;
-    }
-
-    private void InitializeFileWatcher()
-    {
-        try
+        public DashboardDataService(ILogger<DashboardDataService> logger, IOptions<DashboardOptions> options)
         {
-            var dataJsonPath = Path.Combine(
-                AppContext.BaseDirectory,
-                _options.Value?.DataJsonPath ?? "data.json");
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _options = options ?? throw new ArgumentNullException(nameof(options));
+            _pendingReload = false;
 
-            var directoryPath = Path.GetDirectoryName(dataJsonPath);
-            var fileName = Path.GetFileName(dataJsonPath);
+            LoadInitialData();
+            InitializeFileWatcher();
+        }
 
-            _watcher = new FileSystemWatcher(directoryPath, fileName)
+        private void LoadInitialData()
+        {
+            try
             {
-                NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.Size,
-                EnableRaisingEvents = false
-            };
-
-            _watcher.Changed += OnDataJsonChanged;
-            _watcher.EnableRaisingEvents = true;
-
-            _logger.LogInformation("FileSystemWatcher initialized for data.json at {path}", dataJsonPath);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError("Failed to initialize FileSystemWatcher: {error}", ex.Message);
-        }
-    }
-
-    private void OnDataJsonChanged(object sender, FileSystemEventArgs e)
-    {
-        lock (_lockObject)
-        {
-            _debounceTimer?.Dispose();
-            _debounceTimer = new Timer(
-                _ => ReloadDataFromFile(),
-                null,
-                _options.Value?.FileWatchDebounceMs ?? 500,
-                Timeout.Infinite);
-        }
-    }
-
-    private void ReloadDataFromFile()
-    {
-        try
-        {
-            lock (_lockObject)
+                _cachedData = LoadFromJson();
+                _lastError = null;
+                _lastLoadedHash = HashFile(_options.Value.DataJsonPath);
+                _logger.LogInformation("DashboardDataService initialized, data.json loaded successfully");
+            }
+            catch (FileNotFoundException ex)
             {
-                var dataJsonPath = Path.Combine(
-                    AppContext.BaseDirectory,
-                    _options.Value?.DataJsonPath ?? "data.json");
-
-                if (!File.Exists(dataJsonPath))
-                {
-                    _logger.LogInformation("data.json change detected, re-parsing...");
-                    LoadFromJson();
-                    OnDataChanged?.Invoke();
-                    return;
-                }
-
-                var fileHash = HashFile(dataJsonPath);
-                
-                if (fileHash == _lastLoadedHash)
-                {
-                    _logger.LogDebug("File hash unchanged; skipping reload");
-                    return;
-                }
-
-                _logger.LogInformation("data.json change detected, re-parsing...");
-                LoadFromJson();
-                OnDataChanged?.Invoke();
+                _lastError = $"File not found: {ex.Message}";
+                _logger.LogError($"IOException reading data.json: {_lastError}");
+                _cachedData = null;
+            }
+            catch (JsonException ex)
+            {
+                _lastError = $"JSON syntax error in data.json: {ex.Message}";
+                _logger.LogError($"Failed to parse data.json: {_lastError}");
+                _cachedData = null;
+            }
+            catch (Exception ex)
+            {
+                _lastError = $"Error loading data.json: {ex.Message}";
+                _logger.LogError($"Error loading data.json: {_lastError}");
+                _cachedData = null;
             }
         }
-        catch (Exception ex)
+
+        private void InitializeFileWatcher()
         {
-            _logger.LogError("Error reloading data from file: {error}", ex.Message);
+            try
+            {
+                var dataJsonPath = Path.Combine(AppContext.BaseDirectory, _options.Value.DataJsonPath);
+                var directoryPath = Path.GetDirectoryName(dataJsonPath);
+                var fileName = Path.GetFileName(dataJsonPath);
+
+                _watcher = new FileSystemWatcher(directoryPath, fileName)
+                {
+                    NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.Size
+                };
+
+                _watcher.Changed += OnFileChanged;
+                _watcher.EnableRaisingEvents = true;
+
+                _logger.LogInformation("FileSystemWatcher initialized for data.json");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError($"Failed to initialize FileSystemWatcher: {ex.Message}");
+            }
         }
-        finally
+
+        private void OnFileChanged(object sender, FileSystemEventArgs e)
         {
             lock (_lockObject)
             {
+                _pendingReload = true;
                 _debounceTimer?.Dispose();
-                _debounceTimer = null;
+                _debounceTimer = new Timer(_ => OnDebounceTimerElapsed(), null, _options.Value.FileWatchDebounceMs, Timeout.Infinite);
             }
         }
-    }
 
-    private string HashFile(string filePath)
-    {
-        try
+        private void OnDebounceTimerElapsed()
         {
-            using (var sha256 = SHA256.Create())
+            lock (_lockObject)
             {
-                using (var fileStream = File.OpenRead(filePath))
+                if (!_pendingReload)
+                    return;
+
+                _pendingReload = false;
+
+                try
                 {
-                    var hashBytes = sha256.ComputeHash(fileStream);
-                    return Convert.ToBase64String(hashBytes);
+                    var dataJsonPath = Path.Combine(AppContext.BaseDirectory, _options.Value.DataJsonPath);
+                    var fileHash = HashFile(dataJsonPath);
+
+                    if (fileHash == _lastLoadedHash)
+                    {
+                        _logger.LogDebug("File hash unchanged; skipping reload");
+                        return;
+                    }
+
+                    _logger.LogInformation("data.json change detected, re-parsing...");
+
+                    var newData = LoadFromJson();
+                    _cachedData = newData;
+                    _lastError = null;
+                    _lastLoadedHash = fileHash;
+
+                    OnDataChanged?.Invoke();
+                }
+                catch (JsonException ex)
+                {
+                    _lastError = $"JSON syntax error in data.json: {ex.Message}";
+                    _logger.LogError($"Failed to parse data.json: {_lastError}");
+                    OnDataChanged?.Invoke();
+                }
+                catch (IOException ex)
+                {
+                    _lastError = $"IOException reading data.json: {ex.Message}";
+                    _logger.LogError(_lastError);
+                    OnDataChanged?.Invoke();
+                }
+                catch (Exception ex)
+                {
+                    _lastError = $"Error loading data.json: {ex.Message}";
+                    _logger.LogError(_lastError);
+                    OnDataChanged?.Invoke();
                 }
             }
         }
-        catch (Exception ex)
-        {
-            _logger.LogError("Error computing file hash: {error}", ex.Message);
-            return null;
-        }
-    }
 
-    private void LoadFromJson()
-    {
-        try
+        private DashboardData LoadFromJson()
         {
-            var dataJsonPath = Path.Combine(
-                AppContext.BaseDirectory,
-                _options.Value?.DataJsonPath ?? "data.json");
+            var dataJsonPath = Path.Combine(AppContext.BaseDirectory, _options.Value.DataJsonPath);
 
             if (!File.Exists(dataJsonPath))
             {
                 throw new FileNotFoundException($"data.json not found at {dataJsonPath}");
             }
 
-            var jsonContent = File.ReadAllText(dataJsonPath, System.Text.Encoding.UTF8);
+            var json = File.ReadAllText(dataJsonPath, Encoding.UTF8);
 
             var options = new JsonSerializerOptions
             {
                 PropertyNameCaseInsensitive = true,
-                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
                 AllowTrailingCommas = false,
-                MaxDepth = 64
+                MaxDepth = 64,
+                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
             };
 
-            var data = JsonSerializer.Deserialize<DashboardData>(jsonContent, options);
+            var data = JsonSerializer.Deserialize<DashboardData>(json, options);
 
             ValidateData(data);
 
-            _cachedData = data;
-            _lastError = null;
-            HasData = true;
-
-            var fileHash = HashFile(dataJsonPath);
-            _lastLoadedHash = fileHash;
-
-            _logger.LogInformation("DashboardDataService initialized, data.json loaded successfully");
-        }
-        catch (FileNotFoundException ex)
-        {
-            _lastError = $"FileNotFound: {ex.Message}";
-            _logger.LogError("Failed to load data.json: {error}", _lastError);
-            HasData = false;
-        }
-        catch (JsonException ex)
-        {
-            _lastError = $"JSON syntax error in data.json: {ex.Message}";
-            _logger.LogError("Failed to parse data.json: {error}", _lastError);
-            HasData = false;
-        }
-        catch (ArgumentException ex)
-        {
-            _lastError = $"Validation error: {ex.Message}";
-            _logger.LogError("Validation failed for data.json: {error}", _lastError);
-            HasData = false;
-        }
-        catch (IOException ex)
-        {
-            _lastError = $"IO error reading data.json: {ex.Message}";
-            _logger.LogError("IO error reading data.json: {error}", _lastError);
-            HasData = false;
-        }
-        catch (Exception ex)
-        {
-            _lastError = $"Unexpected error loading data.json: {ex.Message}";
-            _logger.LogError("Unexpected error: {error}", _lastError);
-            HasData = false;
-        }
-    }
-
-    private void ValidateData(DashboardData data)
-    {
-        if (data == null)
-        {
-            throw new ArgumentException("Deserialized data is null");
+            return data;
         }
 
-        if (data.Project == null)
+        private void ValidateData(DashboardData data)
         {
-            throw new ArgumentException("Project is required in data.json");
-        }
-
-        if (string.IsNullOrWhiteSpace(data.Project.Name))
-        {
-            throw new ArgumentException("Project.Name is required and cannot be empty");
-        }
-
-        if (data.Project.Name.Length > 256)
-        {
-            throw new ArgumentException($"Project.Name exceeds maximum length of 256 characters (current: {data.Project.Name.Length})");
-        }
-
-        if (!string.IsNullOrEmpty(data.Project.Description) && data.Project.Description.Length > 1024)
-        {
-            throw new ArgumentException($"Project.Description exceeds maximum length of 1024 characters (current: {data.Project.Description.Length})");
-        }
-
-        if (data.Milestones != null)
-        {
-            foreach (var milestone in data.Milestones)
+            if (data?.Project == null)
             {
-                if (string.IsNullOrWhiteSpace(milestone.Name))
-                {
-                    throw new ArgumentException("Milestone.Name is required and cannot be empty");
-                }
+                throw new InvalidOperationException("Project is required in data.json");
+            }
 
-                if (milestone.Name.Length > 256)
-                {
-                    throw new ArgumentException($"Milestone.Name exceeds maximum length of 256 characters (current: {milestone.Name.Length})");
-                }
+            if (string.IsNullOrWhiteSpace(data.Project.Name))
+            {
+                throw new InvalidOperationException("Project.Name is required");
+            }
 
-                if (string.IsNullOrEmpty(milestone.Status))
-                {
-                    throw new ArgumentException("Milestone.Status is required");
-                }
+            if (data.Project.Name.Length > 256)
+            {
+                throw new InvalidOperationException("Project.Name exceeds 256 character limit");
+            }
 
-                var validStatuses = new[] { "Completed", "On Track", "At Risk" };
-                if (!validStatuses.Contains(milestone.Status))
+            if (!string.IsNullOrEmpty(data.Project.Description) && data.Project.Description.Length > 1024)
+            {
+                throw new InvalidOperationException("Project.Description exceeds 1024 character limit");
+            }
+
+            if (data.Milestones != null)
+            {
+                foreach (var milestone in data.Milestones)
                 {
-                    throw new ArgumentException($"Invalid Milestone.Status '{milestone.Status}'. Valid values: {string.Join(", ", validStatuses)}");
+                    if (string.IsNullOrWhiteSpace(milestone.Name))
+                    {
+                        throw new InvalidOperationException("Milestone.Name is required");
+                    }
+
+                    if (milestone.Name.Length > 256)
+                    {
+                        throw new InvalidOperationException("Milestone.Name exceeds 256 character limit");
+                    }
+                }
+            }
+
+            if (data.WorkItems != null)
+            {
+                foreach (var item in data.WorkItems)
+                {
+                    if (string.IsNullOrWhiteSpace(item.Title))
+                    {
+                        throw new InvalidOperationException("WorkItem.Title is required");
+                    }
+
+                    if (item.Title.Length > 512)
+                    {
+                        throw new InvalidOperationException("WorkItem.Title exceeds 512 character limit");
+                    }
+
+                    if (!Enum.IsDefined(typeof(WorkItemStatus), item.Status))
+                    {
+                        throw new InvalidOperationException($"Invalid WorkItem.Status: {item.Status}");
+                    }
+
+                    if (!string.IsNullOrEmpty(item.Assignee) && item.Assignee.Length > 256)
+                    {
+                        throw new InvalidOperationException("WorkItem.Assignee exceeds 256 character limit");
+                    }
                 }
             }
         }
 
-        if (data.WorkItems != null)
+        private string HashFile(string filePath)
         {
-            foreach (var workItem in data.WorkItems)
+            try
             {
-                if (string.IsNullOrWhiteSpace(workItem.Title))
+                if (!File.Exists(filePath))
                 {
-                    throw new ArgumentException("WorkItem.Title is required and cannot be empty");
+                    return null;
                 }
 
-                if (workItem.Title.Length > 512)
+                using (var sha256 = SHA256.Create())
                 {
-                    throw new ArgumentException($"WorkItem.Title exceeds maximum length of 512 characters (current: {workItem.Title.Length})");
-                }
-
-                if (!Enum.IsDefined(typeof(WorkItemStatus), workItem.Status))
-                {
-                    throw new ArgumentException($"Invalid WorkItem.Status '{workItem.Status}'. Valid values: {string.Join(", ", Enum.GetNames(typeof(WorkItemStatus)))}");
-                }
-
-                if (!string.IsNullOrEmpty(workItem.Assignee) && workItem.Assignee.Length > 256)
-                {
-                    throw new ArgumentException($"WorkItem.Assignee exceeds maximum length of 256 characters (current: {workItem.Assignee.Length})");
+                    using (var fileStream = File.OpenRead(filePath))
+                    {
+                        var hash = sha256.ComputeHash(fileStream);
+                        return Convert.ToBase64String(hash);
+                    }
                 }
             }
+            catch (Exception ex)
+            {
+                _logger.LogWarning($"Failed to compute file hash: {ex.Message}");
+                return null;
+            }
         }
-    }
 
-    public void Dispose()
-    {
-        if (_disposed)
-            return;
+        public DashboardData GetCurrentData()
+        {
+            return _cachedData;
+        }
 
-        _debounceTimer?.Dispose();
-        _watcher?.Dispose();
-        _disposed = true;
+        public Project GetProject()
+        {
+            return _cachedData?.Project;
+        }
+
+        public IReadOnlyList<Milestone> GetMilestones()
+        {
+            if (_cachedData?.Milestones == null)
+            {
+                return new List<Milestone>().AsReadOnly();
+            }
+
+            return _cachedData.Milestones
+                .OrderBy(m => m.Date)
+                .ToList()
+                .AsReadOnly();
+        }
+
+        public IReadOnlyList<WorkItem> GetWorkItems()
+        {
+            if (_cachedData?.WorkItems == null)
+            {
+                return new List<WorkItem>().AsReadOnly();
+            }
+
+            return _cachedData.WorkItems.AsReadOnly();
+        }
+
+        public IReadOnlyList<WorkItem> GetWorkItemsByStatus(WorkItemStatus status)
+        {
+            if (_cachedData?.WorkItems == null)
+            {
+                return new List<WorkItem>().AsReadOnly();
+            }
+
+            return _cachedData.WorkItems
+                .Where(w => w.Status == status)
+                .ToList()
+                .AsReadOnly();
+        }
+
+        public (int Shipped, int InProgress, int CarriedOver) GetStatusCounts()
+        {
+            if (_cachedData?.WorkItems == null)
+            {
+                return (0, 0, 0);
+            }
+
+            var shipped = _cachedData.WorkItems.Count(w => w.Status == WorkItemStatus.Shipped);
+            var inProgress = _cachedData.WorkItems.Count(w => w.Status == WorkItemStatus.InProgress);
+            var carriedOver = _cachedData.WorkItems.Count(w => w.Status == WorkItemStatus.CarriedOver);
+
+            return (shipped, inProgress, carriedOver);
+        }
+
+        public string GetLastError()
+        {
+            return _lastError;
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _debounceTimer?.Dispose();
+            _watcher?.Dispose();
+            _disposed = true;
+
+            GC.SuppressFinalize(this);
+        }
     }
 }

--- a/src/AgentSquad.Runner/Services/DashboardDataService.cs
+++ b/src/AgentSquad.Runner/Services/DashboardDataService.cs
@@ -131,6 +131,26 @@ public class DashboardDataService : IDashboardDataService, IDisposable
         {
             lock (_lockObject)
             {
+                var dataJsonPath = Path.Combine(
+                    AppContext.BaseDirectory,
+                    _options.Value?.DataJsonPath ?? "data.json");
+
+                if (!File.Exists(dataJsonPath))
+                {
+                    _logger.LogInformation("data.json change detected, re-parsing...");
+                    LoadFromJson();
+                    OnDataChanged?.Invoke();
+                    return;
+                }
+
+                var fileHash = HashFile(dataJsonPath);
+                
+                if (fileHash == _lastLoadedHash)
+                {
+                    _logger.LogDebug("File hash unchanged; skipping reload");
+                    return;
+                }
+
                 _logger.LogInformation("data.json change detected, re-parsing...");
                 LoadFromJson();
                 OnDataChanged?.Invoke();
@@ -147,6 +167,26 @@ public class DashboardDataService : IDashboardDataService, IDisposable
                 _debounceTimer?.Dispose();
                 _debounceTimer = null;
             }
+        }
+    }
+
+    private string HashFile(string filePath)
+    {
+        try
+        {
+            using (var sha256 = SHA256.Create())
+            {
+                using (var fileStream = File.OpenRead(filePath))
+                {
+                    var hashBytes = sha256.ComputeHash(fileStream);
+                    return Convert.ToBase64String(hashBytes);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError("Error computing file hash: {error}", ex.Message);
+            return null;
         }
     }
 
@@ -180,6 +220,9 @@ public class DashboardDataService : IDashboardDataService, IDisposable
             _cachedData = data;
             _lastError = null;
             HasData = true;
+
+            var fileHash = HashFile(dataJsonPath);
+            _lastLoadedHash = fileHash;
 
             _logger.LogInformation("DashboardDataService initialized, data.json loaded successfully");
         }

--- a/src/AgentSquad.Runner/Services/DashboardDataService.cs
+++ b/src/AgentSquad.Runner/Services/DashboardDataService.cs
@@ -1,0 +1,82 @@
+using System.Security.Cryptography;
+using System.Text.Json;
+using AgentSquad.Runner.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace AgentSquad.Runner.Services;
+
+public class DashboardDataService : IDashboardDataService, IDisposable
+{
+    private readonly ILogger<DashboardDataService> _logger;
+    private readonly IOptions<DashboardOptions> _options;
+    
+    private DashboardData _cachedData;
+    private string _lastError;
+    private string _lastLoadedHash;
+    private FileSystemWatcher _watcher;
+    private Timer _debounceTimer;
+    private bool _disposed;
+
+    public event Action OnDataChanged;
+
+    public bool HasData { get; private set; }
+
+    public DashboardDataService(
+        ILogger<DashboardDataService> logger,
+        IOptions<DashboardOptions> options)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        
+        _cachedData = new DashboardData();
+        _lastError = null;
+        _lastLoadedHash = null;
+        HasData = false;
+    }
+
+    public DashboardData GetCurrentData()
+    {
+        throw new NotImplementedException();
+    }
+
+    public Project GetProject()
+    {
+        throw new NotImplementedException();
+    }
+
+    public IReadOnlyList<Milestone> GetMilestones()
+    {
+        throw new NotImplementedException();
+    }
+
+    public IReadOnlyList<WorkItem> GetWorkItems()
+    {
+        throw new NotImplementedException();
+    }
+
+    public IReadOnlyList<WorkItem> GetWorkItemsByStatus(WorkItemStatus status)
+    {
+        throw new NotImplementedException();
+    }
+
+    public (int Shipped, int InProgress, int CarriedOver) GetStatusCounts()
+    {
+        throw new NotImplementedException();
+    }
+
+    public string GetLastError()
+    {
+        throw new NotImplementedException();
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+
+        _debounceTimer?.Dispose();
+        _watcher?.Dispose();
+        _disposed = true;
+    }
+}

--- a/src/AgentSquad.Runner/Services/DashboardDataService.cs
+++ b/src/AgentSquad.Runner/Services/DashboardDataService.cs
@@ -18,6 +18,7 @@ public class DashboardDataService : IDashboardDataService, IDisposable
     private FileSystemWatcher _watcher;
     private Timer _debounceTimer;
     private bool _disposed;
+    private readonly object _lockObject = new();
 
     public event Action OnDataChanged;
 
@@ -36,6 +37,7 @@ public class DashboardDataService : IDashboardDataService, IDisposable
         HasData = false;
 
         LoadFromJson();
+        InitializeFileWatcher();
     }
 
     public DashboardData GetCurrentData()
@@ -80,6 +82,72 @@ public class DashboardDataService : IDashboardDataService, IDisposable
     public string GetLastError()
     {
         return _lastError;
+    }
+
+    private void InitializeFileWatcher()
+    {
+        try
+        {
+            var dataJsonPath = Path.Combine(
+                AppContext.BaseDirectory,
+                _options.Value?.DataJsonPath ?? "data.json");
+
+            var directoryPath = Path.GetDirectoryName(dataJsonPath);
+            var fileName = Path.GetFileName(dataJsonPath);
+
+            _watcher = new FileSystemWatcher(directoryPath, fileName)
+            {
+                NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.Size,
+                EnableRaisingEvents = false
+            };
+
+            _watcher.Changed += OnDataJsonChanged;
+            _watcher.EnableRaisingEvents = true;
+
+            _logger.LogInformation("FileSystemWatcher initialized for data.json at {path}", dataJsonPath);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError("Failed to initialize FileSystemWatcher: {error}", ex.Message);
+        }
+    }
+
+    private void OnDataJsonChanged(object sender, FileSystemEventArgs e)
+    {
+        lock (_lockObject)
+        {
+            _debounceTimer?.Dispose();
+            _debounceTimer = new Timer(
+                _ => ReloadDataFromFile(),
+                null,
+                _options.Value?.FileWatchDebounceMs ?? 500,
+                Timeout.Infinite);
+        }
+    }
+
+    private void ReloadDataFromFile()
+    {
+        try
+        {
+            lock (_lockObject)
+            {
+                _logger.LogInformation("data.json change detected, re-parsing...");
+                LoadFromJson();
+                OnDataChanged?.Invoke();
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError("Error reloading data from file: {error}", ex.Message);
+        }
+        finally
+        {
+            lock (_lockObject)
+            {
+                _debounceTimer?.Dispose();
+                _debounceTimer = null;
+            }
+        }
     }
 
     private void LoadFromJson()

--- a/src/AgentSquad.Runner/Services/IDashboardDataService.cs
+++ b/src/AgentSquad.Runner/Services/IDashboardDataService.cs
@@ -1,17 +1,20 @@
+using System;
+using System.Collections.Generic;
 using AgentSquad.Runner.Models;
 
-namespace AgentSquad.Runner.Services;
-
-public interface IDashboardDataService
+namespace AgentSquad.Runner.Services
 {
-    event Action OnDataChanged;
+    public interface IDashboardDataService
+    {
+        event Action OnDataChanged;
 
-    DashboardData GetCurrentData();
-    Project GetProject();
-    IReadOnlyList<Milestone> GetMilestones();
-    IReadOnlyList<WorkItem> GetWorkItems();
-    IReadOnlyList<WorkItem> GetWorkItemsByStatus(WorkItemStatus status);
-    (int Shipped, int InProgress, int CarriedOver) GetStatusCounts();
-    string GetLastError();
-    bool HasData { get; }
+        DashboardData GetCurrentData();
+        Project GetProject();
+        IReadOnlyList<Milestone> GetMilestones();
+        IReadOnlyList<WorkItem> GetWorkItems();
+        IReadOnlyList<WorkItem> GetWorkItemsByStatus(WorkItemStatus status);
+        (int Shipped, int InProgress, int CarriedOver) GetStatusCounts();
+        string GetLastError();
+        bool HasData { get; }
+    }
 }

--- a/src/AgentSquad.Runner/Services/IDashboardDataService.cs
+++ b/src/AgentSquad.Runner/Services/IDashboardDataService.cs
@@ -1,0 +1,17 @@
+using AgentSquad.Runner.Models;
+
+namespace AgentSquad.Runner.Services;
+
+public interface IDashboardDataService
+{
+    event Action OnDataChanged;
+
+    DashboardData GetCurrentData();
+    Project GetProject();
+    IReadOnlyList<Milestone> GetMilestones();
+    IReadOnlyList<WorkItem> GetWorkItems();
+    IReadOnlyList<WorkItem> GetWorkItemsByStatus(WorkItemStatus status);
+    (int Shipped, int InProgress, int CarriedOver) GetStatusCounts();
+    string GetLastError();
+    bool HasData { get; }
+}


### PR DESCRIPTION
## Task Assignment
**Assigned To:** PrincipalEngineer 1
**Complexity:** High
**Branch:** `agent/principalengineer-1/t-337-dashboarddataservice-implementation`

## Requirements
Closes #337

# PR: Implement DashboardDataService Singleton

## Summary

Implement `DashboardDataService`, a singleton service that loads project data from `data.json`, caches it in-memory, monitors file changes via `FileSystemWatcher` with 500ms debounce, and notifies subscribers when data changes. Service validates JSON using `System.Text.Json`, handles errors gracefully with fallback to last-known-good data, and prevents duplicate parsing via file hash deduplication.

## Acceptance Criteria

- [ ] `DashboardDataService` loads `data.json` on first request (lazy initialization in constructor or GetCurrentData)
- [ ] JSON parsed using `System.Text.Json` with `PropertyNameCaseInsensitive: true`, `MaxDepth: 64`
- [ ] All public methods return cached data (no re-parsing on each call)
- [ ] `FileSystemWatcher` monitors `data.json` with 500ms debounce; fires `OnDataChanged` event on file change
- [ ] File hash deduplication prevents duplicate parsing from multiple write events
- [ ] Parse errors logged with `ILogger<DashboardDataService>` and stored in `GetLastError()`
- [ ] Missing/malformed `data.json` displays friendly error; dashboard shows error UI (no crash)
- [ ] Last-known-good cache fallback: if parse fails, previous data returned
- [ ] Service registered as singleton in `Program.cs`
- [ ] All public methods match interface: `GetCurrentData()`, `GetProject()`, `GetMilestones()`, `GetWorkItems()`, `GetWorkItemsByStatus()`, `GetStatusCounts()`, `GetLastError()`, `HasData` property
- [ ] Service implements `IDisposable`; disposes `FileSystemWatcher` on app shutdown
- [ ] Unit tests cover: valid JSON parsing, parse errors (syntax/validation), file watch debounce, hash deduplication, missing file

## Implementation Steps

**Step 1: Scaffolding – Create Service Class & Interface**
Create `src/AgentSquad.Runner/Services/DashboardDataService.cs` with skeleton: constructor (accept `ILogger<DashboardDataService>`, `IOptions<DashboardOptions>`), private fields (`_cachedData`, `_watcher`, `_lastError`, `_lastLoadedHash`), public interface methods (stubs). Create `IDashboardDataService` interface. Register in `Program.cs` as singleton. **Deliverable:** Empty service compiles; dependency injection wired.

**Step 2: JSON Loading & Parsing**
Implement `LoadFromJson()` private method: read `data.json` from disk via `File.ReadAllText()`, deserialize using `System.Text.Json` with configured options, validate post-deserialization (check `Project != null`, valid `WorkItemStatus` enums, string length constraints). Implement `GetCurrentData()`, `GetProject()`, `GetMilestones()`, `GetWorkItems()` public methods (return cached data). **Deliverable:** Service loads and parses JSON on startup; data accessible via public getters.

**Step 3: Caching & Error Handling**
Implement caching layer: constructor calls `LoadFromJson()`, stores result in `_cachedData`. Wrap `LoadFromJson()` in try-catch: catch `JsonException`, `ValidationException`, `IOException`, log via `ILogger`, store error message in `_lastError`. Implement `GetLastError()` and `HasData` property. Fallback: if parse fails, keep previous `_cachedData` (last-known-good). **Deliverable:** Service tolerates malformed JSON; error messages logged and accessible; no crashes.

**Step 4: FileSystemWatcher & Debounce**
Implement `FileSystemWatcher` in constructor: monitor directory containing `data.json`, subscribe to `Changed` event, implement 500ms debounce timer (queue event, wait 500ms before reloading to handle atomic write multiple events). Implement `OnDataChanged` event. Call `LoadFromJson()` on debounce timer fire. **Deliverable:** File changes trigger reload within 1 second; multiple rapid writes debounced into single parse.

**Step 5: File Hash Deduplication**
Implement `HashFile()` method: compute SHA256 hash of `data.json` content. In debounce timer, check `_lastLoadedHash` before parsing: if hash unchanged, skip reload and log debug message. Update `_lastLoadedHash` after successful parse. **Deliverable:** Duplicate file writes (e.g., Windows atomic write triggering two events) result in only one parse.

**Step 6: Filtered Data Access & Disposal**
Implement `GetWorkItemsByStatus()`: filter cached work items by status enum, return `IReadOnlyList`. Implement `GetStatusCounts()`: return tuple `(Shipped count, InProgress count, CarriedOver count)` from cached items. Implement `IDisposable`: dispose `FileSystemWatcher` in `Dispose()` method. **Deliverable:** All service methods operational; resource cleanup on app shutdown.

## Testing

**Unit Tests (xUnit + Moq):**
- **Valid JSON**: Load sample `data.json`, assert cached data matches expected milestones/work items counts
- **Parse Error (Syntax)**: Invalid JSON (missing comma), assert `HasData == false`, `GetLastError()` contains "JSON syntax error"
- **Parse Error (Validation)**: Missing required `Project.Name`, assert validation error logged and `HasData == false`
- **File Not Found**: Delete `data.json`, assert `GetLastError()` contains "FileNotFound"
- **Debounce**: Mock `FileSystemWatcher`, fire 5 change events in 100ms, assert `LoadFromJson()` called only once (not 5 times)
- **Hash Deduplication**: Mock file, fire event twice with identical content, assert second reload skipped
- **Last-Known-Good**: Parse first file, cache data, then fail to parse second file, assert `GetCurrentData()` returns first file's data
- **Dispose**: Verify `FileSystemWatcher.Dispose()` called when service disposed
- **Status Counts**: Assert `GetStatusCounts()` returns correct tuple for 5 Shipped, 3 InProgress, 2 CarriedOver items

**Integration Smoke Test:**
- Start application, verify `DashboardDataService` singleton loaded, assert `HasData == true` and `GetCurrentData()` not null

## References
- Architecture: Architecture.md
- PM Spec: 

## Status
- [ ] Implementation
- [ ] Tests Written
- [ ] Ready for Review