### PR TITLE
PrincipalEngineer: WorkItemList Component

### DIFF
--- a/.agentsquad/workitemlist-component.task
+++ b/.agentsquad/workitemlist-component.task
@@ -1,0 +1,4 @@
+agent: PrincipalEngineer
+task: WorkItemList Component
+complexity: Low
+status: in-progress

--- a/src/AgentSquad.Runner/Components/WorkItemList.razor
+++ b/src/AgentSquad.Runner/Components/WorkItemList.razor
@@ -1,7 +1,65 @@
 @inherits ComponentBase
 @using AgentSquad.Runner.Models
+@using MudBlazor
+
+<style>
+    .shipped-header {
+        background-color: #4CAF50;
+        color: white;
+        padding: 12px 16px;
+        font-weight: 600;
+        font-size: 16px;
+    }
+
+    .in-progress-header {
+        background-color: #2196F3;
+        color: white;
+        padding: 12px 16px;
+        font-weight: 600;
+        font-size: 16px;
+    }
+
+    .carried-over-header {
+        background-color: #FF9800;
+        color: white;
+        padding: 12px 16px;
+        font-weight: 600;
+        font-size: 16px;
+    }
+
+    .work-item-card {
+        margin-bottom: 16px;
+    }
+</style>
 
 <div>
-    <!-- Placeholder for work item list sections -->
-    <!-- To be implemented in Step 2 -->
+    <!-- Shipped Section -->
+    <MudCard Class="work-item-card">
+        <MudCardHeader Class="shipped-header">
+            <span>Shipped (@(Shipped?.Count ?? 0))</span>
+        </MudCardHeader>
+        <MudCardContent>
+            <!-- Work items will be rendered here -->
+        </MudCardContent>
+    </MudCard>
+
+    <!-- In Progress Section -->
+    <MudCard Class="work-item-card">
+        <MudCardHeader Class="in-progress-header">
+            <span>In Progress (@(InProgress?.Count ?? 0))</span>
+        </MudCardHeader>
+        <MudCardContent>
+            <!-- Work items will be rendered here -->
+        </MudCardContent>
+    </MudCard>
+
+    <!-- Carried Over Section -->
+    <MudCard Class="work-item-card">
+        <MudCardHeader Class="carried-over-header">
+            <span>Carried Over (@(CarriedOver?.Count ?? 0))</span>
+        </MudCardHeader>
+        <MudCardContent>
+            <!-- Work items will be rendered here -->
+        </MudCardContent>
+    </MudCard>
 </div>

--- a/src/AgentSquad.Runner/Components/WorkItemList.razor
+++ b/src/AgentSquad.Runner/Components/WorkItemList.razor
@@ -30,6 +30,39 @@
     .work-item-card {
         margin-bottom: 16px;
     }
+
+    .work-item-list {
+        list-style: circle;
+        padding-left: 20px;
+        line-height: 1.6;
+        margin: 0;
+    }
+
+    .work-item-list li {
+        margin-bottom: 8px;
+        word-wrap: break-word;
+        overflow-wrap: break-word;
+    }
+
+    .work-item-list li strong {
+        font-size: 14px;
+        display: block;
+        margin-bottom: 2px;
+    }
+
+    .assignee-text {
+        font-size: 12px;
+        color: #999;
+        font-style: italic;
+        margin-left: 8px;
+    }
+
+    .empty-state {
+        color: #999;
+        font-style: italic;
+        padding: 16px 0;
+        margin: 0;
+    }
 </style>
 
 <div>
@@ -39,7 +72,25 @@
             <span>Shipped (@(Shipped?.Count ?? 0))</span>
         </MudCardHeader>
         <MudCardContent>
-            <!-- Work items will be rendered here -->
+            @if (Shipped != null && Shipped.Count > 0)
+            {
+                <ul class="work-item-list">
+                    @foreach (var item in Shipped)
+                    {
+                        <li>
+                            <strong>@item.Title</strong>
+                            @if (!string.IsNullOrEmpty(item.Assignee))
+                            {
+                                <span class="assignee-text">@item.Assignee</span>
+                            }
+                        </li>
+                    }
+                </ul>
+            }
+            else
+            {
+                <p class="empty-state">No items shipped</p>
+            }
         </MudCardContent>
     </MudCard>
 
@@ -49,7 +100,25 @@
             <span>In Progress (@(InProgress?.Count ?? 0))</span>
         </MudCardHeader>
         <MudCardContent>
-            <!-- Work items will be rendered here -->
+            @if (InProgress != null && InProgress.Count > 0)
+            {
+                <ul class="work-item-list">
+                    @foreach (var item in InProgress)
+                    {
+                        <li>
+                            <strong>@item.Title</strong>
+                            @if (!string.IsNullOrEmpty(item.Assignee))
+                            {
+                                <span class="assignee-text">@item.Assignee</span>
+                            }
+                        </li>
+                    }
+                </ul>
+            }
+            else
+            {
+                <p class="empty-state">No items in progress</p>
+            }
         </MudCardContent>
     </MudCard>
 
@@ -59,7 +128,25 @@
             <span>Carried Over (@(CarriedOver?.Count ?? 0))</span>
         </MudCardHeader>
         <MudCardContent>
-            <!-- Work items will be rendered here -->
+            @if (CarriedOver != null && CarriedOver.Count > 0)
+            {
+                <ul class="work-item-list">
+                    @foreach (var item in CarriedOver)
+                    {
+                        <li>
+                            <strong>@item.Title</strong>
+                            @if (!string.IsNullOrEmpty(item.Assignee))
+                            {
+                                <span class="assignee-text">@item.Assignee</span>
+                            }
+                        </li>
+                    }
+                </ul>
+            }
+            else
+            {
+                <p class="empty-state">No items carried over</p>
+            }
         </MudCardContent>
     </MudCard>
 </div>

--- a/src/AgentSquad.Runner/Components/WorkItemList.razor
+++ b/src/AgentSquad.Runner/Components/WorkItemList.razor
@@ -1,0 +1,7 @@
+@inherits ComponentBase
+@using AgentSquad.Runner.Models
+
+<div>
+    <!-- Placeholder for work item list sections -->
+    <!-- To be implemented in Step 2 -->
+</div>

--- a/src/AgentSquad.Runner/Components/WorkItemList.razor
+++ b/src/AgentSquad.Runner/Components/WorkItemList.razor
@@ -29,6 +29,7 @@
 
     .work-item-card {
         margin-bottom: 16px;
+        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
     }
 
     .work-item-list {

--- a/src/AgentSquad.Runner/Components/WorkItemList.razor
+++ b/src/AgentSquad.Runner/Components/WorkItemList.razor
@@ -30,6 +30,8 @@
     .work-item-card {
         margin-bottom: 16px;
         box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+        word-wrap: break-word;
+        overflow-wrap: break-word;
     }
 
     .work-item-list {
@@ -37,18 +39,23 @@
         padding-left: 20px;
         line-height: 1.6;
         margin: 0;
+        word-wrap: break-word;
+        overflow-wrap: break-word;
     }
 
     .work-item-list li {
         margin-bottom: 8px;
         word-wrap: break-word;
         overflow-wrap: break-word;
+        word-break: break-word;
     }
 
     .work-item-list li strong {
-        font-size: 14px;
+        font-size: 15px;
         display: block;
         margin-bottom: 2px;
+        word-wrap: break-word;
+        overflow-wrap: break-word;
     }
 
     .assignee-text {
@@ -56,6 +63,8 @@
         color: #999;
         font-style: italic;
         margin-left: 8px;
+        word-wrap: break-word;
+        overflow-wrap: break-word;
     }
 
     .empty-state {
@@ -63,6 +72,16 @@
         font-style: italic;
         padding: 16px 0;
         margin: 0;
+    }
+
+    .mud-card {
+        overflow: hidden;
+    }
+
+    .mud-card-content {
+        overflow-x: hidden;
+        word-wrap: break-word;
+        overflow-wrap: break-word;
     }
 </style>
 

--- a/src/AgentSquad.Runner/Components/WorkItemList.razor.cs
+++ b/src/AgentSquad.Runner/Components/WorkItemList.razor.cs
@@ -1,0 +1,16 @@
+using Microsoft.AspNetCore.Components;
+using AgentSquad.Runner.Models;
+
+namespace AgentSquad.Runner.Components;
+
+public partial class WorkItemList : ComponentBase
+{
+    [Parameter]
+    public IReadOnlyList<WorkItem> Shipped { get; set; } = new List<WorkItem>().AsReadOnly();
+
+    [Parameter]
+    public IReadOnlyList<WorkItem> InProgress { get; set; } = new List<WorkItem>().AsReadOnly();
+
+    [Parameter]
+    public IReadOnlyList<WorkItem> CarriedOver { get; set; } = new List<WorkItem>().AsReadOnly();
+}


### PR DESCRIPTION
## Task Assignment
**Assigned To:** PrincipalEngineer
**Complexity:** Low
**Branch:** `agent/principalengineer/t6-workitemlist-component`

## Requirements
Closes #341

# PR: WorkItemList Component (T6)

## Summary

Implement the `WorkItemList.razor` child component responsible for rendering work items grouped by status in three color-coded sections: Shipped (Green), In Progress (Blue), and Carried Over (Orange). This component receives three separate `[Parameter]` lists (Shipped, InProgress, CarriedOver) via parent composition, renders each status group as a MudBlazor Card with labeled header, displays work items as semantic HTML unordered lists with title and optional assignee, and gracefully handles empty lists with placeholder text.

**Component integrates with:**
- Dashboard.razor parent component (passes grouped work item lists)
- WorkItem model (displays Title and Assignee properties)
- MudBlazor UI components (Card, Grid, Typography)

---

## Acceptance Criteria

- [ ] Component files created: `Components/WorkItemList.razor` and `Components/WorkItemList.razor.cs`
- [ ] Three `[Parameter]` properties defined:
  - `[Parameter] public IReadOnlyList<WorkItem> Shipped { get; set; }`
  - `[Parameter] public IReadOnlyList<WorkItem> InProgress { get; set; }`
  - `[Parameter] public IReadOnlyList<WorkItem> CarriedOver { get; set; }`
- [ ] Three sections rendered as MudBlazor Cards with color-coded headers:
  - "Shipped" with Green background (#4CAF50)
  - "In Progress" with Blue background (#2196F3)
  - "Carried Over" with Orange background (#FF9800)
- [ ] Work items displayed in semantic HTML `<ul>` list within each section
- [ ] Each work item displays:
  - Title (required, primary text)
  - Assignee (optional, secondary text or italicized)
- [ ] Empty state handling:
  - If Shipped list is empty: display "No items shipped"
  - If In Progress list is empty: display "No items in progress"
  - If Carried Over list is empty: display "No items carried over"
- [ ] Work item count badge on section header (e.g., "Shipped (5)")
- [ ] Responsive text sizing: work item titles 14-16px, assignee text 12-13px muted gray
- [ ] No horizontal scrollbars within section; text wraps at container boundary
- [ ] Semantic HTML: use `<ul>` for lists, `<li>` for items, proper nesting
- [ ] No JavaScript errors in browser console (F12 DevTools)
- [ ] Component renders immediately on parameter set; no async operations required

---

## Implementation Steps

### Step 1: Create Component Files & Scaffolding
**Commit message:** "Create WorkItemList component with parameter binding and code-behind"

**Tasks:**
- Create `Components/WorkItemList.razor` with:
  - `@inherits ComponentBase` directive
  - `@using AgentSquad.Runner.Models` for WorkItem model
  - Three `[Parameter]` properties (Shipped, InProgress, CarriedOver)
  - Empty markup section (no @code yet)
- Create `Components/WorkItemList.razor.cs` with:
  - Class `WorkItemList : ComponentBase`
  - Three parameter property declarations with initialization
- Verify component compiles: `dotnet build`

**Output:** Scaffold files with parameter binding; component ready for rendering logic.

---

### Step 2: Create Static Markup Structure & MudBlazor Layout
**Commit message:** "Add MudBlazor Card structure for three work item sections"

**Tasks:**
- In `WorkItemList.razor`:
  - Add MudBlazor `using` statements: `@using MudBlazor`
  - Wrap three sections in `<MudContainer MaxWidth="MaxWidth.lg">` (or within parent Dashboard container, TBD based on parent layout)
  - For each section (Shipped, In Progress, Carried Over):
    - Create `<MudCard Class="mb-4">` container
    - Add `<MudCardHeader>` with color-coded background CSS class
    - Add section title text (e.g., "Shipped")
    - Add work item count in parentheses
    - Add `<MudCardContent>` placeholder for item list markup
- Add inline CSS class definitions (or reference from `dashboard.css`):
  - `.shipped-header`: background-color: #4CAF50
  - `.in-progress-header`: background-color: #2196F3
  - `.carried-over-header`: background-color: #FF9800
  - All headers: color: white, padding: 12px, font-weight: bold

**Output:** Static markup structure with MudBlazor Cards; ready for dynamic content.

---

### Step 3: Implement Work Item List Rendering
**Commit message:** "Render work items as semantic HTML lists with title and assignee"

**Tasks:**
- In `WorkItemList.razor`, within each `<MudCardContent>`:
  - Add conditional rendering: `@if (Shipped != null && Shipped.Count > 0)`
  - If true: render `<ul Class="work-item-list">` with `@foreach` loop:
    ```razor
    <ul class="work-item-list">
      @foreach (var item in Shipped) {
          <li>
              <strong>@item.Title</strong>
              @if (!string.IsNullOrEmpty(item.Assignee)) {
                  <span class="assignee-text">@item.Assignee</span>
              }
          </li>
      }
    </ul>
    ```
  - If false (empty list): render empty state message: `<p class="empty-state">No items shipped</p>`
- Add CSS classes:
  - `.work-item-list`: `<ul>` styling (list-style: circle, padding-left: 20px, line-height: 1.6)
  - `.assignee-text`: font-size: 12px, color: #999, font-style: italic, margin-left: 8px
  - `.empty-state`: color: #999, font-style: italic, padding: 16px 0
- Repeat for InProgress and CarriedOver sections with appropriate empty state messages

**Output:** Functional component rendering all work items grouped by status with title, assignee, and empty states.

---

### Step 4: Add Work Item Count Badge & Polish Headers
**Commit message:** "Add work item count badges to section headers and refine styling"

**Tasks:**
- In each `<MudCardHeader>`:
  - Update title text to include count: `Shipped (5)` format
  - Dynamically compute count: `Shipped?.Count ?? 0`
  - Example: `<span>Shipped (@(Shipped?.Count ?? 0))</span>`
- Refine header styling:
  - Add padding: 12px 16px
  - Set text color: white
  - Font weight: 600 (bold)
  - Font size: 16px
- Refine MudCard styling:
  - Add margin-bottom: 16px
  - Add box-shadow for depth (optional, light shadow only)
- Test visual appearance on 1920x1080 viewport: verify no horizontal scrollbars

**Output:** Polished component with visual hierarchy (colored headers with counts, grouped work items, empty state messages).

---

### Step 5: Add Responsive Text Wrapping & Cross-Browser Testing
**Commit message:** "Ensure work item text wraps at container boundary; test cross-browser consistency"

**Tasks:**
- In CSS:
  - `.work-item-list li`: word-wrap: break-word, overflow-wrap: break-word
  - Ensure work item title and assignee wrap within container without overflow
- Test on 1920x1080 viewport:
  - No horizontal scrollbars in any section
  - Long titles (100+ chars) wrap gracefully
  - Assignee text does not overflow
- Test cross-browser: Chrome and Edge rendering consistency
  - Verify color-coded headers render correctly
  - Verify text wrapping is consistent
  - Verify MudBlazor Card styling consistent
- F12 DevTools: verify no JavaScript errors, no console warnings

**Output:** Fully styled, cross-browser-tested component; ready for integration.

---

## Testing

### Manual Testing
- [ ] Render with Shipped=[5 items], InProgress=[3 items], CarriedOver=[2 items]
  - Verify three cards render with correct counts (5, 3, 2 in parentheses)
  - Verify all work items display with title and assignee
  - Verify colors: Green header (Shipped), Blue header (In Progress), Orange header (Carried Over)
- [ ] Render with Shipped=[], InProgress=[1 item], CarriedOver=[]
  - Verify "No items shipped" message displays
  - Verify "No items carried over" message displays
  - Verify In Progress section shows single item
- [ ] Render with all empty lists (Shipped=[], InProgress=[], CarriedOver=[])
  - Verify three cards render with empty state messages
  - Verify counts show (0) in headers
- [ ] Test with long work item titles (100+ chars)
  - Verify text wraps at container boundary
  - Verify no horizontal scrollbars
- [ ] Test with missing assignee (null or empty string)
  - Verify title displays
  - Verify no assignee text shown
  - No extra spacing or visual artifacts
- [ ] Test on 1920x1080 viewport
  - Verify all three cards fit within fixed-width 1200px container
  - Verify no horizontal scrollbars
  - Verify cards are centered/aligned within container
- [ ] Cross-browser testing (Chrome and Edge)
  - Verify header colors render consistently
  - Verify MudBlazor Card styling identical
  - Verify text wrapping consistent
- [ ] F12 DevTools Console: no JavaScript errors, no warnings

### Integration Testing (T3: Dashboard Component)
- [ ] Dashboard.razor calls `GetWorkItemsByStatus(WorkItemStatus.Shipped)`, `InProgress`, `CarriedOver`
- [ ] Dashboard passes three lists to WorkItemList component
- [ ] WorkItemList renders all three sections
- [ ] Modify data.json, add/remove work item, Dashboard updates (OnDataChanged → StateHasChanged → WorkItemList re-renders)
- [ ] Verify updated work item counts display in headers
- [ ] Verify empty state messages display when list becomes empty

### Unit Testing (Optional - Low Priority)
- [ ] Parameter binding: Component correctly receives three lists via [Parameter]
- [ ] Empty list handling: Component displays appropriate "No items" message
- [ ] Item rendering: Component displays all items from each list
- [ ] Count accuracy: Header badge shows correct count (length of list)

---

## Notes for Reviewer

- Component is purely presentational (receives data via parameters, no service dependencies)
- Semantic HTML: uses `<ul>` and `<li>` for accessibility and screenshot clarity
- MudBlazor Card component used for consistent layout with Dashboard
- Color scheme fixed in component CSS (hardcoded hex values for screenshot consistency)
- Empty state handling prevents rendering empty lists; gracefully degrades to text messages
- No async operations or lifecycle hooks required (simple stateless component)
- Styling finalized in T7 (UI Styling & Layout task); this PR focuses on functionality and structure
- Cross-browser testing (Chrome, Edge) required; no IE11 support needed

---

## Related Issues

- Depends on #336 (T1: Project Foundation & Scaffolding)
- Part of #332 (US-1: Executive Views Project Status Dashboard)
- Unblocks #342 (T7: UI Styling & Layout)

## References
- Architecture: Architecture.md
- PM Spec: 

## Status
- [ ] Implementation
- [ ] Tests Written
- [ ] Ready for Review