### PR TITLE
PrincipalEngineer: Screenshot Print CSS and Print Mode

### DIFF
--- a/.agentsquad/screenshot-print-css-and-print-mode.task
+++ b/.agentsquad/screenshot-print-css-and-print-mode.task
@@ -1,0 +1,4 @@
+agent: PrincipalEngineer
+task: Screenshot Print CSS and Print Mode
+complexity: Medium
+status: in-progress

--- a/Components/Pages/Dashboard.razor
+++ b/Components/Pages/Dashboard.razor
@@ -33,8 +33,9 @@
         DataService.OnDataChanged += OnDataChanged;
 
         var uri = new Uri(Navigation.Uri);
-        var query = System.Web.HttpUtility.ParseQueryString(uri.Query);
-        _printMode = string.Equals(query["print"], "true", StringComparison.OrdinalIgnoreCase);
+        var query = QueryHelpers.ParseQuery(uri.Query);
+        _printMode = query.TryGetValue("print", out var values)
+            && values.ToString().Equals("true", StringComparison.OrdinalIgnoreCase);
     }
 
     private async void OnDataChanged()

--- a/Components/_Imports.razor
+++ b/Components/_Imports.razor
@@ -1,5 +1,6 @@
 @using Microsoft.AspNetCore.Components.Web
 @using Microsoft.AspNetCore.Components.Routing
+@using Microsoft.AspNetCore.WebUtilities
 @using ReportingDashboard
 @using ReportingDashboard.Models
 @using ReportingDashboard.Services

--- a/wwwroot/css/app.css
+++ b/wwwroot/css/app.css
@@ -241,10 +241,14 @@ html, body {
     display: none;
 }
 
-/* Print-mode overrides */
-.dashboard.print-mode #blazor-error-ui,
-.dashboard.print-mode .blazor-reconnect-modal {
-    display: none !important;
+/*
+ * Trend label: hidden by default in normal mode.
+ * Color arrows/icons are sufficient when color is available.
+ * Shown in print-mode and @media print for B&W fallback.
+ * Depends on T9 adding <span class="trend-label">(up)</span> to MetricBadge.
+ */
+.trend-label {
+    display: none;
 }
 
 /* ============================================
@@ -372,4 +376,84 @@ html, body {
     .progress-fill {
         background-color: #333 !important;
     }
+}
+
+/* ============================================
+   Print Mode — Screenshot Capture via ?print=true
+   Applied when Dashboard.razor detects the query
+   parameter and adds class="dashboard print-mode"
+   ============================================ */
+
+/* Hide all Blazor framework chrome in screenshot mode */
+.dashboard.print-mode #blazor-error-ui,
+.dashboard.print-mode .blazor-error-ui,
+.dashboard.print-mode .blazor-reconnect-modal,
+.dashboard.print-mode [data-blazor-reconnect] {
+    display: none !important;
+}
+
+/* Hide the error banner in print mode (PM will fix data before capturing) */
+.dashboard.print-mode .error-banner {
+    display: none !important;
+}
+
+/* Remove all box-shadows for flat screenshot appearance */
+.dashboard.print-mode *,
+.dashboard.print-mode *::before,
+.dashboard.print-mode *::after {
+    box-shadow: none !important;
+}
+
+/* Cards: subtle borders replace shadows */
+.dashboard.print-mode .card {
+    border: 1px solid var(--border-color);
+}
+
+/* Work item sections: subtle borders replace shadows */
+.dashboard.print-mode .work-item-section {
+    border: 1px solid var(--border-color);
+}
+
+/* Metric badges: subtle borders replace shadows */
+.dashboard.print-mode .metric-badge {
+    border: 1px solid var(--border-color);
+}
+
+/* Milestone timeline: subtle border replaces shadow */
+.dashboard.print-mode .milestone-timeline {
+    border: 1px solid var(--border-color);
+}
+
+/*
+ * B&W fallback: show text labels on trend indicators.
+ * In print-mode, .trend-label is shown as a parenthetical.
+ * Depends on T9 adding <span class="trend-label">(up)</span> to MetricBadge.
+ */
+.dashboard.print-mode .trend-label {
+    display: inline;
+    font-size: var(--font-size-small);
+    color: var(--text-secondary);
+    margin-left: 4px;
+}
+
+/* Status badges: add border for monochrome screenshot fidelity */
+.dashboard.print-mode .status-badge {
+    border: 1px solid rgba(0, 0, 0, 0.3);
+}
+
+/*
+ * Section header text indicators for B&W identification.
+ * Unicode prefixes convey section meaning without relying on color.
+ * Depends on T6/T7/T8 applying status classes to .section-header elements.
+ */
+.dashboard.print-mode .section-header.shipped::before {
+    content: "\2713 ";
+}
+
+.dashboard.print-mode .section-header.in-progress::before {
+    content: "\25B6 ";
+}
+
+.dashboard.print-mode .section-header.carried-over::before {
+    content: "\26A0 ";
 }

--- a/wwwroot/css/app.css
+++ b/wwwroot/css/app.css
@@ -376,6 +376,67 @@ html, body {
     .progress-fill {
         background-color: #333 !important;
     }
+
+    /* --- High-Contrast B&W Fallbacks (print) --- */
+
+    /*
+     * Priority badges: graduated borders so P0–P3 severity
+     * is distinguishable without color (red/orange/yellow/gray).
+     * The badge text ("P0", "P1", etc.) is always visible;
+     * border weight reinforces urgency in monochrome output.
+     */
+    .priority-badge.priority-p0 {
+        border: 2px solid #000;
+        font-weight: 700;
+    }
+
+    .priority-badge.priority-p1 {
+        border: 2px solid #333;
+        font-weight: 600;
+    }
+
+    .priority-badge.priority-p2 {
+        border: 1px solid #666;
+    }
+
+    .priority-badge.priority-p3 {
+        border: 1px dashed #999;
+    }
+
+    /*
+     * Project status badge: distinct border patterns per status.
+     * Text ("On Track" / "At Risk" / "Off Track") is the primary
+     * identifier in B&W; border style provides secondary cue.
+     */
+    .status-badge.status-on-track {
+        border: 2px solid #000;
+    }
+
+    .status-badge.status-at-risk {
+        border: 2px dashed #000;
+    }
+
+    .status-badge.status-off-track {
+        border: 3px solid #000;
+        font-weight: 700;
+    }
+
+    .status-badge.status-unknown {
+        border: 1px dotted #999;
+    }
+
+    /*
+     * Timeline "Today" marker: thick solid black line so it
+     * stands out in monochrome (normally red dashed).
+     */
+    .today-marker {
+        border-left: 3px solid #000 !important;
+    }
+
+    .today-marker-label {
+        color: #000 !important;
+        font-weight: 700;
+    }
 }
 
 /* ============================================
@@ -456,4 +517,71 @@ html, body {
 
 .dashboard.print-mode .section-header.carried-over::before {
     content: "\26A0 ";
+}
+
+/* ============================================
+   High-Contrast B&W Fallbacks — Screenshot Mode
+   Graduated borders and patterns for elements
+   that rely on color in normal mode.
+   ============================================ */
+
+/*
+ * Priority badges: graduated border weight/style so P0–P3
+ * severity is distinguishable without color in screenshots.
+ * Mirrors the @media print rules for consistency.
+ */
+.dashboard.print-mode .priority-badge.priority-p0 {
+    border: 2px solid #000;
+    font-weight: 700;
+}
+
+.dashboard.print-mode .priority-badge.priority-p1 {
+    border: 2px solid #333;
+    font-weight: 600;
+}
+
+.dashboard.print-mode .priority-badge.priority-p2 {
+    border: 1px solid #666;
+}
+
+.dashboard.print-mode .priority-badge.priority-p3 {
+    border: 1px dashed #999;
+}
+
+/*
+ * Project status badge: distinct border patterns per status.
+ * "On Track" = solid, "At Risk" = dashed, "Off Track" = heavy,
+ * unknown = dotted. Text label is the primary B&W identifier;
+ * border pattern is the secondary visual cue.
+ */
+.dashboard.print-mode .status-badge.status-on-track {
+    border: 2px solid #000;
+}
+
+.dashboard.print-mode .status-badge.status-at-risk {
+    border: 2px dashed #000;
+}
+
+.dashboard.print-mode .status-badge.status-off-track {
+    border: 3px solid #000;
+    font-weight: 700;
+}
+
+.dashboard.print-mode .status-badge.status-unknown {
+    border: 1px dotted #999;
+}
+
+/*
+ * Timeline "Today" marker: thick solid black line
+ * replaces the default red dashed style for B&W fidelity.
+ * Depends on T5 (MilestoneTimeline) using .today-marker
+ * and .today-marker-label CSS classes.
+ */
+.dashboard.print-mode .today-marker {
+    border-left: 3px solid #000;
+}
+
+.dashboard.print-mode .today-marker-label {
+    color: #000;
+    font-weight: 700;
 }

--- a/wwwroot/css/app.css
+++ b/wwwroot/css/app.css
@@ -380,7 +380,7 @@ html, body {
     /* --- High-Contrast B&W Fallbacks (print) --- */
 
     /*
-     * Priority badges: graduated borders so P0–P3 severity
+     * Priority badges: graduated borders so P0-P3 severity
      * is distinguishable without color (red/orange/yellow/gray).
      * The badge text ("P0", "P1", etc.) is always visible;
      * border weight reinforces urgency in monochrome output.
@@ -465,9 +465,15 @@ html, body {
     box-shadow: none !important;
 }
 
-/* Cards: subtle borders replace shadows */
+/*
+ * Cards: subtle borders replace shadows.
+ * Uses individual border sides to preserve the colored border-left
+ * set by .card.shipped / .card.in-progress / .card.carried-over.
+ */
 .dashboard.print-mode .card {
-    border: 1px solid var(--border-color);
+    border-top: 1px solid var(--border-color);
+    border-right: 1px solid var(--border-color);
+    border-bottom: 1px solid var(--border-color);
 }
 
 /* Work item sections: subtle borders replace shadows */
@@ -526,7 +532,7 @@ html, body {
    ============================================ */
 
 /*
- * Priority badges: graduated border weight/style so P0–P3
+ * Priority badges: graduated border weight/style so P0-P3
  * severity is distinguishable without color in screenshots.
  * Mirrors the @media print rules for consistency.
  */

--- a/wwwroot/css/app.css
+++ b/wwwroot/css/app.css
@@ -247,36 +247,129 @@ html, body {
     display: none !important;
 }
 
-/* Print media query */
+/* ============================================
+   @media print — Browser Print / PDF Output
+   Activated via Ctrl+P or "Print to PDF"
+   ============================================ */
 @media print {
+    /* Reset page margins for edge-to-edge printing */
+    @page {
+        margin: 0;
+        size: landscape;
+    }
+
     body {
         margin: 0;
         padding: 0;
+        background-color: white;
     }
 
+    /* Expand dashboard to fill print page and preserve colors */
     .dashboard {
         width: 100%;
+        min-height: auto;
+        margin: 0;
         box-shadow: none;
+        overflow: visible;
+        -webkit-print-color-adjust: exact;
+        print-color-adjust: exact;
     }
 
+    /* Remove all box-shadows globally */
+    * {
+        box-shadow: none !important;
+    }
+
+    /* Hide Blazor framework UI and error banner */
     #blazor-error-ui,
-    .blazor-error-ui {
+    .blazor-error-ui,
+    .blazor-reconnect-modal,
+    [data-blazor-reconnect],
+    .error-banner {
         display: none !important;
     }
 
-    .error-banner {
-        print-color-adjust: exact;
-        -webkit-print-color-adjust: exact;
-    }
-
+    /* Preserve colors on all visual indicator elements */
     .card,
     .work-item-section,
     .metric-badge,
     .milestone-timeline,
     .project-header,
     .status-badge,
-    .priority-badge {
+    .priority-badge,
+    .progress-track,
+    .progress-fill,
+    .milestone-marker {
         print-color-adjust: exact;
         -webkit-print-color-adjust: exact;
+    }
+
+    /* Cards: visible borders instead of shadows for monochrome fidelity */
+    .card {
+        border: 1px solid #999;
+    }
+
+    /* Status badges: add border so they remain visible without color */
+    .status-badge {
+        border: 1px solid #333;
+    }
+
+    /* Section left borders: increase thickness for monochrome visibility */
+    .card.shipped {
+        border-left: 5px solid #333;
+    }
+
+    .card.in-progress {
+        border-left: 5px solid #666;
+    }
+
+    .card.carried-over {
+        border-left: 5px solid #999;
+    }
+
+    /* Work item sections: visible borders */
+    .work-item-section {
+        border: 1px solid #ccc;
+    }
+
+    /* Metric badges: visible borders */
+    .metric-badge {
+        border: 1px solid #ccc;
+    }
+
+    /* Milestone markers: distinct border patterns for B&W */
+    .milestone-marker.completed {
+        background-color: #333 !important;
+        border-color: #333 !important;
+    }
+
+    .milestone-marker.in-progress {
+        background-color: white !important;
+        border: 3px solid #333 !important;
+        border-right-color: transparent !important;
+    }
+
+    .milestone-marker.upcoming {
+        background-color: white !important;
+        border: 2px dashed #666 !important;
+    }
+
+    .milestone-marker.delayed {
+        background-color: white !important;
+        border: 3px double #333 !important;
+    }
+
+    /* Trend indicators: ensure text labels are visible in print */
+    .trend-label {
+        display: inline !important;
+    }
+
+    /* Progress bars: add border for monochrome visibility */
+    .progress-track {
+        border: 1px solid #666;
+    }
+
+    .progress-fill {
+        background-color: #333 !important;
     }
 }


### PR DESCRIPTION
## Task Assignment
**Assigned To:** PrincipalEngineer
**Complexity:** Medium
**Branch:** `agent/principalengineer/t10-screenshot-print-css-and-print-mode`

## Requirements
Closes #411

# PR: Screenshot-Optimized Print CSS and Print Mode

**Issue:** #401 | **Task:** T10 | **Complexity:** Medium | **Depends On:** T1 (#402)

## Summary

Adds comprehensive print and screenshot-capture support to the Executive Reporting Dashboard. This PR modifies two existing files — `wwwroot/css/app.css` and `Components/Pages/Dashboard.razor` — to deliver three capabilities:

1. **`@media print` stylesheet** — When the user prints the page or uses "Print to PDF" from the browser, all decorative elements (shadows, Blazor framework UI, error overlays) are stripped, the dashboard expands to fill the page width, and margins are zeroed for clean PDF output.
2. **`?print=true` query parameter mode** — When the dashboard URL includes `?print=true`, a `print-mode` CSS class is applied to the dashboard container, hiding Blazor reconnection UI, error boundaries, and any non-content browser chrome. This produces a cleaner screenshot without requiring actual print invocation.
3. **Black-and-white print accessibility** — Status indicators (badges, left borders, milestone markers, trend arrows) that currently rely on color alone are augmented with text labels, shapes, and high-contrast borders so they remain distinguishable when printed on a monochrome printer or viewed in a grayscale screenshot.

This is a cross-cutting CSS concern that touches the global stylesheet and the root page component. No new files are created. No component rendering logic changes — only the `Dashboard.razor` code block is extended to parse the query parameter and apply the CSS class.

## Acceptance Criteria

- [ ] **Fixed 1280px width preserved in normal mode:** The `.dashboard` container remains exactly 1280px wide when viewed in a browser without `?print=true`.
- [ ] **`@media print` rules active:** Opening browser print preview (Ctrl+P) shows: no `box-shadow` on any element, no `#blazor-error-ui` or `.blazor-error-ui` visible, no `.blazor-reconnect-modal` visible, dashboard width set to `100%` (fills print page), `body` has `margin: 0; padding: 0`.
- [ ] **`@media print` color preservation:** Print styles include `-webkit-print-color-adjust: exact` and `print-color-adjust: exact` on `.dashboard` so status colors render in PDF output rather than being stripped by the browser's "save ink" default.
- [ ] **`?print=true` toggles print-mode class:** Navigating to `http://localhost:5000/?print=true` adds the CSS class `print-mode` to the outermost `.dashboard` div. Navigating to `http://localhost:5000/` (no param) does not.
- [ ] **Print-mode hides Blazor UI:** When `print-mode` is active, `#blazor-error-ui`, `.blazor-error-ui`, `.blazor-reconnect-modal`, and any element with `[data-blazor-reconnect]` are hidden via `display: none !important`.
- [ ] **Print-mode removes decorative elements:** In `print-mode`, `box-shadow` is `none` on all elements, and the `ErrorBanner` component is hidden (errors should not appear in screenshots — the PM will fix the data before capturing).
- [ ] **No animations or transitions:** Verify that zero `transition`, `animation`, or `@keyframes` rules exist in `app.css` (this should already be true from T1, but this PR must not introduce any).
- [ ] **Black-and-white distinguishability for status badges:** The project status badge ("On Track", "At Risk", "Off Track") displays its text label inside the badge, making it readable even without color. Under `@media print`, badges have a visible `border` (1px solid dark color) so they don't disappear against a white background.
- [ ] **Black-and-white distinguishability for section borders:** Under `@media print`, the left-border color on work item cards (green/blue/amber) is supplemented by a thicker border (4px) and a section heading that includes a text indicator (e.g., "✓ Shipped", "→ In Progress", "⚠ Carried Over") so sections are identifiable without color.
- [ ] **Black-and-white distinguishability for milestone markers:** Under `@media print`, milestone status circles get a distinct border pattern: Completed = solid filled dark, In Progress = half-filled with dark border, Upcoming = dashed border, Delayed = double border. The status text label is rendered below each marker.
- [ ] **Black-and-white distinguishability for trend arrows:** Under `@media print`, metric trend indicators include a parenthetical text label: "(↑ up)", "(↓ down)", "(— stable)" so the direction is readable without color.
- [ ] **Dashboard.razor compiles and runs:** `dotnet build` succeeds. The page loads at `http://localhost:5000/` with no console errors. The page loads at `http://localhost:5000/?print=true` with no console errors.
- [ ] **No new files created:** This PR only modifies `wwwroot/css/app.css` and `Components/Pages/Dashboard.razor`.
- [ ] **No external dependencies added:** No new NuGet packages, no JavaScript files, no CDN links.

## Implementation Steps

### Step 1: Add `?print=true` query parameter parsing to Dashboard.razor

Modify `Components/Pages/Dashboard.razor` to detect the `?print=true` query parameter and apply a CSS class.

**What to do:**
- In the `@code` block, add a private `bool _printMode` field (if not already present from T1 stub).
- In `OnInitialized` (or `OnParametersSet`), inject `NavigationManager` (should already be injected from T1), parse `Navigation.Uri` using `Microsoft.AspNetCore.WebUtilities.QueryHelpers.ParseQuery` or `System.Web.HttpUtility.ParseQueryString` or manual `Uri` parsing. Check if the query string contains `print=true` (case-insensitive value comparison).
- Set `_printMode = true` if the parameter is present and equals `"true"`.
- In the Razor markup, the outermost `<div>` should already have `class="dashboard @(_printMode ? "print-mode" : "")"` from the T1 stub. If not, add it.
- **Do NOT use `NavigationManager.LocationChanged`** — `print-mode` is set once at page load and does not need to react to SPA navigation (there is only one page).
- Use `Uri` and `QueryHelpers` from `Microsoft.AspNetCore.WebUtilities` (built into the framework, no NuGet needed) for robust parsing: `var uri = new Uri(Navigation.Uri); var query = QueryHelpers.ParseQuery(uri.Query); _printMode = query.TryGetValue("print", out var values) && values.ToString().Equals("true", StringComparison.OrdinalIgnoreCase);`

**Note on imports:** Add `@using Microsoft.AspNetCore.WebUtilities` to the top of `Dashboard.razor` or to `_Imports.razor` (prefer `_Imports.razor` since other components may need it in the future).

**Commit message:** `feat: parse ?print=true query parameter in Dashboard.razor`

**Verification:** `dotnet build` succeeds. Navigate to `http://localhost:5000/?print=true` — inspect the DOM and confirm the outermost div has class `dashboard print-mode`. Navigate without the param — confirm class is just `dashboard`.

### Step 2: Add `@media print` CSS rules to app.css

Append a comprehensive `@media print` block to the end of `wwwroot/css/app.css`. This block controls browser print/PDF output.

**Rules to add inside `@media print { ... }`:**

```css
@media print {
    /* Reset page margins for edge-to-edge printing */
    @page {
        margin: 0;
        size: landscape;
    }
    
    body {
        margin: 0;
        padding: 0;
        background-color: white;
    }
    
    /* Expand dashboard to fill print page */
    .dashboard {
        width: 100%;
        min-height: auto;
        margin: 0;
        box-shadow: none;
        overflow: visible;
        -webkit-print-color-adjust: exact;
        print-color-adjust: exact;
    }
    
    /* Remove all box-shadows */
    * {
        box-shadow: none !important;
    }
    
    /* Hide Blazor framework UI */
    #blazor-error-ui,
    .blazor-error-ui,
    .blazor-reconnect-modal,
    [data-blazor-reconnect],
    .error-banner {
        display: none !important;
    }
    
    /* Ensure cards have visible borders instead of shadows */
    .card {
        border: 1px solid #999;
        box-shadow: none;
    }
    
    /* Status badges: add border so they're visible without color */
    .status-badge {
        border: 1px solid #333;
    }
    
    /* Section left borders: increase thickness for monochrome visibility */
    .card.shipped { border-left: 5px solid #333; }
    .card.in-progress { border-left: 5px solid #666; }
    .card.carried-over { border-left: 5px solid #999; }
    
    /* Milestone markers: use distinct border patterns */
    .milestone-marker.completed {
        background-color: #333 !important;
        border-color: #333 !important;
    }
    .milestone-marker.in-progress {
        background-color: white !important;
        border: 3px solid #333 !important;
        border-right-color: transparent !important;
    }
    .milestone-marker.upcoming {
        background-color: white !important;
        border: 2px dashed #666 !important;
    }
    .milestone-marker.delayed {
        background-color: white !important;
        border: 3px double #333 !important;
    }
    
    /* Trend indicators: ensure text labels are visible */
    .trend-label {
        display: inline !important;
    }
    
    /* Progress bars: add border for visibility */
    .progress-track {
        border: 1px solid #666;
    }
    .progress-fill {
        background-color: #333 !important;
    }
}
```

**Commit message:** `feat: add @media print CSS rules for clean PDF output`

**Verification:** `dotnet build` succeeds. Open `http://localhost:5000/` in Chrome/Edge, press Ctrl+P. In print preview: no shadows, no Blazor error UI, dashboard fills page width, colors are preserved (not stripped). Status badges have visible borders. Section cards have distinct left border weights.

### Step 3: Add `.print-mode` CSS rules for screenshot capture

Append `.print-mode` and `.dashboard.print-mode` rules to `wwwroot/css/app.css`. These rules apply when `?print=true` is in the URL — a superset of print concerns optimized specifically for screen-captured screenshots.

**Rules to add:**

```css
/* === Print Mode (activated via ?print=true query parameter) === */

/* Hide all Blazor framework chrome */
.dashboard.print-mode #blazor-error-ui,
.dashboard.print-mode .blazor-error-ui,
.dashboard.print-mode .blazor-reconnect-modal,
.dashboard.print-mode [data-blazor-reconnect] {
    display: none !important;
}

/* Optionally hide the error banner in print mode (assume data is correct for capture) */
.dashboard.print-mode .error-banner {
    display: none !important;
}

/* Remove all box-shadows for flat screenshot appearance */
.dashboard.print-mode * {
    box-shadow: none !important;
}

/* Ensure cards use subtle borders instead of shadows */
.dashboard.print-mode .card {
    border: 1px solid var(--border-color);
}

/*
 * Black-and-white fallback: add visible text labels to trend indicators.
 * In normal mode, .trend-label is hidden (color arrows suffice).
 * In print-mode, .trend-label is shown as a parenthetical.
 */
.trend-label {
    display: none;
}

.dashboard.print-mode .trend-label {
    display: inline;
    font-size: var(--font-size-small);
    color: var(--text-secondary);
    margin-left: 4px;
}

/*
 * Status badge text: ensure the badge text is always readable.
 * Add a 1px border to all status badges for monochrome screenshot fidelity.
 */
.dashboard.print-mode .status-badge {
    border: 1px solid rgba(0, 0, 0, 0.3);
}

/*
 * Section header text indicators for b&w:
 * These are Unicode prefixes that convey section meaning without color.
 * Implemented via CSS ::before pseudo-elements.
 */
.dashboard.print-mode .section-header.shipped::before {
    content: "✓ ";
}
.dashboard.print-mode .section-header.in-progress::before {
    content: "→ ";
}
.dashboard.print-mode .section-header.carried-over::before {
    content: "⚠ ";
}
```

**Important:** The `.trend-label` element must already exist in the `MetricBadge.razor` markup (created in T9). It should render a `<span class="trend-label">` with text like "(up)", "(down)", "(stable)" next to the trend arrow. If T9 has not yet included this span, add a comment in the CSS noting it depends on T9 adding `<span class="trend-label">(up)</span>` to each metric badge. Likewise, the `.section-header.shipped` / `.section-header.in-progress` / `.section-header.carried-over` class combos depend on the section components (T6/T7/T8) applying the appropriate status class to their heading element.

**Commit message:** `feat: add .print-mode CSS rules for screenshot capture`

**Verification:** Navigate to `http://localhost:5000/?print=true`. Inspect elements: no box-shadows, no Blazor UI overlays, error banner hidden, status badges have borders. Take a screenshot at 1280x900 — paste into PowerPoint — confirm it fits a 16:9 slide without resizing.

### Step 4: Add high-contrast print fallbacks for all status indicators

This step adds additional CSS rules (both inside `@media print` and under `.dashboard.print-mode`) that ensure every color-dependent status indicator has a shape, pattern, or text backup for black-and-white reproduction.

**Add to `wwwroot/css/app.css`:**

```css
/* === High-Contrast B&W Fallbacks === */

/*
 * Priority badges: append priority text in print mode
 * since color coding (red/orange/yellow/gray) is lost in B&W.
 * The badge already shows "P0"/"P1"/etc as text, but ensure
 * the border differentiates severity in monochrome.
 */
@media print {
    .priority-badge.priority-p0 {
        border: 2px solid #000;
        font-weight: 700;
    }
    .priority-badge.priority-p1 {
        border: 2px solid #333;
        font-weight: 600;
    }
    .priority-badge.priority-p2 {
        border: 1px solid #666;
    }
    .priority-badge.priority-p3 {
        border: 1px dashed #999;
    }
}

.dashboard.print-mode .priority-badge.priority-p0 {
    border: 2px solid #000;
    font-weight: 700;
}
.dashboard.print-mode .priority-badge.priority-p1 {
    border: 2px solid #333;
    font-weight: 600;
}
.dashboard.print-mode .priority-badge.priority-p2 {
    border: 1px solid #666;
}
.dashboard.print-mode .priority-badge.priority-p3 {
    border: 1px dashed #999;
}

/*
 * Project status badge: ensure the text inside is the primary identifier.
 * In B&W the green/amber/red is lost, but "On Track"/"At Risk"/"Off Track"
 * text is always present. Add distinct border weights per status.
 */
@media print {
    .status-on-track { border: 2px solid #000; }
    .status-at-risk { border: 2px dashed #000; }
    .status-off-track { border: 3px solid #000; font-weight: 700; }
    .status-unknown { border: 1px dotted #999; }
}

.dashboard.print-mode .status-on-track { border: 2px solid #000; }
.dashboard.print-mode .status-at-risk { border: 2px dashed #000; }
.dashboard.print-mode .status-off-track { border: 3px solid #000; font-weight: 700; }
.dashboard.print-mode .status-unknown { border: 1px dotted #999; }

/*
 * Timeline today marker: ensure it's visible in B&W.
 * In color mode it's red dashed. In B&W, make it a thick solid black line.
 */
@media print {
    .today-marker {
        border-left: 3px solid #000 !important;
    }
    .today-marker-label {
        color: #000 !important;
        font-weight: 700;
    }
}

.dashboard.print-mode .today-marker {
    border-left: 3px solid #000;
}
.dashboard.print-mode .today-marker-label {
    color: #000;
    font-weight: 700;
}
```

**Commit message:** `feat: add high-contrast B&W fallbacks for print and screenshot modes`

**Verification:** Open print preview. Verify that: (1) priority badges P0–P3 have progressively lighter/different border styles, (2) project status badges have distinct border patterns (solid vs dashed vs heavy), (3) "Today" marker on timeline is a thick black line. Convert the print preview to grayscale mentally or via browser devtools — all indicators should remain distinguishable by shape/weight/text alone.

## Testing

This task modifies only CSS and a query-parameter boolean in `Dashboard.razor`. No business logic, no data flow, no service layer changes. Testing is primarily visual and structural.

### Manual Verification Checklist

1. **Normal mode (`http://localhost:5000/`):**
   - Dashboard is 1280px wide, centered.
   - All existing styles render correctly (no regressions from CSS additions).
   - `.trend-label` elements are hidden (`display: none`).
   - Section headers do not show Unicode prefixes (✓, →, ⚠).
   - Box-shadows are present on cards.

2. **Print mode (`http://localhost:5000/?print=true`):**
   - Dashboard div has class `dashboard print-mode`.
   - No box-shadows visible on any element.
   - No Blazor error UI or reconnection modal visible.
   - Error banner is hidden.
   - Status badges have visible borders.
   - `.trend-label` spans are visible (if T9 has been implemented).
   - Section headers show Unicode prefixes (if T6/T7/T8 apply status classes to headers).
   - Priority badges have graduated border styles (P0 heaviest).

3. **Browser print preview (Ctrl+P from either mode):**
   - Dashboard fills page width (not stuck at 1280px).
   - No shadows anywhere.
   - Status colors are preserved (not stripped by browser).
   - Milestone markers use distinct border patterns.
   - No Blazor framework elements visible.
   - Clean, professional PDF output.

4. **Screenshot fidelity test:**
   - Set browser window to 1280x900.
   - Navigate to `?print=true`.
   - Take screenshot (Win+Shift+S or browser screenshot tool).
   - Paste into a 16:9 PowerPoint slide.
   - Confirm: no resizing needed, text readable, no artifacts, no Blazor UI overlays.

5. **Grayscale validation:**
   - Take the screenshot from step 4.
   - Convert to grayscale in PowerPoint (Picture Format → Color → Saturation: 0%).
   - Confirm all status badges, priority badges, section borders, milestone markers, and trend indicators remain distinguishable.

### Build Verification

- `dotnet build` completes with zero errors and zero warnings after both files are modified.
- `dotnet run` starts successfully, page loads at both `http://localhost:5000/` and `http://localhost:5000/?print=true` with no browser console errors.

### Regression Boundary

This PR should NOT affect:
- Data loading or deserialization (DashboardDataService is untouched).
- Component rendering logic (no `.razor` markup changes except the print-mode class toggle).
- FileSystemWatcher behavior.
- Any component other than `Dashboard.razor`.
- The `appsettings.json` or `Program.cs` configuration.

## References
- Architecture: Architecture.md
- PM Spec: 

## Status
- [ ] Implementation
- [ ] Tests Written
- [ ] Ready for Review