### PR TITLE
PrincipalEngineer: Carried-Over Items Section Component

### DIFF
--- a/.agentsquad/carried-over-items-section-component.task
+++ b/.agentsquad/carried-over-items-section-component.task
@@ -1,0 +1,4 @@
+agent: PrincipalEngineer
+task: Carried-Over Items Section Component
+complexity: Medium
+status: in-progress

--- a/Components/CarriedOverSection.razor
+++ b/Components/CarriedOverSection.razor
@@ -1,5 +1,17 @@
-<div class="work-item-section carried-over">
-    <!-- CarriedOverSection: implemented in T8 -->
+@using ReportingDashboard.Models
+
+<div class="carried-over-section">
+    <div class="section-header">
+        <span class="section-title">Carried Over</span>
+        <span class="section-count">(@(Items?.Count ?? 0))</span>
+    </div>
+
+    @if (Items is not null && Items.Count > 0)
+    {
+        <div class="items-list">
+            @* Cards will be implemented in Step 2 *@
+        </div>
+    }
 </div>
 
 @code {

--- a/Components/CarriedOverSection.razor
+++ b/Components/CarriedOverSection.razor
@@ -36,6 +36,13 @@
                             <span class="target-value">@item.OriginalTarget</span>
                         </div>
                     }
+                    @if (!string.IsNullOrWhiteSpace(item.Reason))
+                    {
+                        <div class="reason-callout">
+                            <span class="reason-label">Reason:</span>
+                            <span class="reason-text">@item.Reason</span>
+                        </div>
+                    }
                 </div>
             }
         </div>

--- a/Components/CarriedOverSection.razor
+++ b/Components/CarriedOverSection.razor
@@ -9,7 +9,35 @@
     @if (Items is not null && Items.Count > 0)
     {
         <div class="items-list">
-            @* Cards will be implemented in Step 2 *@
+            @foreach (var item in Items)
+            {
+                <div class="work-item-card">
+                    <div class="card-header">
+                        <span class="item-title">@item.Title</span>
+                        <div class="badges">
+                            @if (!string.IsNullOrWhiteSpace(item.Category))
+                            {
+                                <span class="badge category-badge">@item.Category</span>
+                            }
+                            @if (!string.IsNullOrWhiteSpace(item.Priority))
+                            {
+                                <span class="badge priority-badge priority-@(item.Priority.ToLowerInvariant())">@item.Priority</span>
+                            }
+                        </div>
+                    </div>
+                    @if (!string.IsNullOrWhiteSpace(item.Description))
+                    {
+                        <div class="item-description">@item.Description</div>
+                    }
+                    @if (!string.IsNullOrWhiteSpace(item.OriginalTarget))
+                    {
+                        <div class="original-target">
+                            <span class="target-label">Original Target:</span>
+                            <span class="target-value">@item.OriginalTarget</span>
+                        </div>
+                    }
+                </div>
+            }
         </div>
     }
 </div>

--- a/Components/CarriedOverSection.razor.css
+++ b/Components/CarriedOverSection.razor.css
@@ -109,3 +109,26 @@
     color: var(--text-primary, #212529);
     margin-left: 4px;
 }
+
+.reason-callout {
+    margin-top: 8px;
+    padding: 8px 12px;
+    background: #fff8f0;
+    border-left: 3px solid var(--status-carried-over, #fd7e14);
+    border-radius: 0 4px 4px 0;
+    font-size: var(--font-size-body, 13px);
+    line-height: 1.5;
+    color: var(--text-primary, #212529);
+    box-sizing: border-box;
+}
+
+.reason-label {
+    font-weight: 700;
+    color: var(--status-carried-over, #fd7e14);
+    margin-right: 4px;
+}
+
+.reason-text {
+    font-weight: 400;
+    color: var(--text-primary, #212529);
+}

--- a/Components/CarriedOverSection.razor.css
+++ b/Components/CarriedOverSection.razor.css
@@ -17,6 +17,7 @@
     font-size: var(--font-size-section-header, 16px);
     font-weight: 700;
     color: var(--text-primary, #212529);
+    background: var(--bg-card, #ffffff);
 }
 
 .section-count {
@@ -50,6 +51,10 @@
     font-weight: 600;
     font-size: 13px;
     color: var(--text-primary, #212529);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: calc(100% - 160px);
 }
 
 .item-description {
@@ -57,12 +62,14 @@
     color: var(--text-secondary, #6c757d);
     margin-top: 4px;
     line-height: 1.4;
+    background: var(--bg-card, #ffffff);
 }
 
 .badges {
     display: flex;
     gap: 6px;
     align-items: center;
+    flex-shrink: 0;
 }
 
 .badge {
@@ -73,6 +80,7 @@
     font-weight: 600;
     background: var(--border-color, #dee2e6);
     color: var(--text-primary, #212529);
+    box-sizing: border-box;
 }
 
 .priority-p0 {
@@ -98,6 +106,7 @@
 .original-target {
     margin-top: 6px;
     font-size: var(--font-size-body, 13px);
+    background: var(--bg-card, #ffffff);
 }
 
 .target-label {
@@ -120,6 +129,8 @@
     line-height: 1.5;
     color: var(--text-primary, #212529);
     box-sizing: border-box;
+    word-wrap: break-word;
+    overflow-wrap: break-word;
 }
 
 .reason-label {

--- a/Components/CarriedOverSection.razor.css
+++ b/Components/CarriedOverSection.razor.css
@@ -30,3 +30,82 @@
     flex-direction: column;
     gap: 10px;
 }
+
+.work-item-card {
+    border-left: 4px solid var(--status-carried-over, #fd7e14);
+    background: var(--bg-card, #ffffff);
+    padding: 12px 14px;
+    border-radius: 6px;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+    box-sizing: border-box;
+}
+
+.card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.item-title {
+    font-weight: 600;
+    font-size: 13px;
+    color: var(--text-primary, #212529);
+}
+
+.item-description {
+    font-size: var(--font-size-body, 13px);
+    color: var(--text-secondary, #6c757d);
+    margin-top: 4px;
+    line-height: 1.4;
+}
+
+.badges {
+    display: flex;
+    gap: 6px;
+    align-items: center;
+}
+
+.badge {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 10px;
+    font-size: var(--font-size-small, 11px);
+    font-weight: 600;
+    background: var(--border-color, #dee2e6);
+    color: var(--text-primary, #212529);
+}
+
+.priority-p0 {
+    background: var(--priority-p0, #dc3545);
+    color: white;
+}
+
+.priority-p1 {
+    background: var(--priority-p1, #fd7e14);
+    color: white;
+}
+
+.priority-p2 {
+    background: var(--priority-p2, #ffc107);
+    color: #212529;
+}
+
+.priority-p3 {
+    background: var(--priority-p3, #6c757d);
+    color: white;
+}
+
+.original-target {
+    margin-top: 6px;
+    font-size: var(--font-size-body, 13px);
+}
+
+.target-label {
+    font-weight: 600;
+    color: var(--text-secondary, #6c757d);
+}
+
+.target-value {
+    color: var(--text-primary, #212529);
+    margin-left: 4px;
+}

--- a/Components/CarriedOverSection.razor.css
+++ b/Components/CarriedOverSection.razor.css
@@ -1,0 +1,32 @@
+.carried-over-section {
+    background: var(--bg-card, #ffffff);
+    border-radius: 8px;
+    box-shadow: var(--shadow-card, 0 1px 3px rgba(0, 0, 0, 0.08));
+    padding: 16px;
+    box-sizing: border-box;
+}
+
+.section-header {
+    display: flex;
+    align-items: baseline;
+    gap: 6px;
+    margin-bottom: 12px;
+}
+
+.section-title {
+    font-size: var(--font-size-section-header, 16px);
+    font-weight: 700;
+    color: var(--text-primary, #212529);
+}
+
+.section-count {
+    font-size: var(--font-size-body, 13px);
+    font-weight: 400;
+    color: var(--text-secondary, #6c757d);
+}
+
+.items-list {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}


### PR DESCRIPTION
## Task Assignment
**Assigned To:** PrincipalEngineer
**Complexity:** Medium
**Branch:** `agent/principalengineer/t8-carried-over-items-section-component`

## Requirements
Closes #409

# PR: Carried-Over Items Section Component

**Issue:** #397 | **Task:** T8 | **Complexity:** Medium | **Depends On:** T1 (#402)

## Summary

Implements the `CarriedOverSection.razor` component and its scoped CSS stylesheet for the Executive Reporting Dashboard. This component renders a vertically-stacked list of carried-over work items — items that missed their original target date and were deferred to the current reporting period. Each item is displayed as a card with an amber/orange left border, title, description, category badge, priority badge, original target date, and a prominently styled reason callout block that draws executive attention to why the item slipped.

The reason callout is the distinguishing feature of this component: per US-5, the carry-over reason must be "prominently displayed (not hidden or truncated)." The reason block uses a distinct subtle background, a "Reason:" label in bold, and full-width layout to ensure it is the most visually prominent element on each card — designed to surface accountability information in the executive screenshot.

This PR creates exactly two files:
- `Components/CarriedOverSection.razor` — the Blazor component
- `Components/CarriedOverSection.razor.css` — scoped styles

It does **not** modify any existing files. The existing `Components/CarriedOverSection.razor` stub from T1 will be replaced with the full implementation. The `Dashboard.razor` integration (wiring `<CarriedOverSection Items="@data.CarriedOver" />`) is the responsibility of the Dashboard page task, not this PR.

## Acceptance Criteria

### Component Contract
- [ ] `CarriedOverSection.razor` declares a `[Parameter] public List<CarriedOverItem>? Items { get; set; }` property.
- [ ] A null or empty `Items` list renders gracefully — either nothing or a section header with "(0)" count and an empty body. No crash, no broken layout.
- [ ] The component is in the `ReportingDashboard.Components` namespace (implicit via file location in `Components/`).
- [ ] The component references the existing `CarriedOverItem` record from `ReportingDashboard.Models` and does **not** redefine it.

### Section Header
- [ ] A section heading displays "Carried Over" as the title, styled at `var(--font-size-section-header)` (16px) minimum.
- [ ] The item count is displayed alongside the heading (e.g., "Carried Over (2)").

### Work Item Cards
- [ ] Each item renders as a card with an amber/orange left border using `var(--status-carried-over, #fd7e14)`.
- [ ] Each card displays: **title** in bold, **description** in regular weight, **category** as a badge, and **priority** as a badge (colored per priority level using `--priority-p0` through `--priority-p3`).
- [ ] Each card displays the **original target date** with a "Original Target:" label (e.g., "Original Target: February 2026").
- [ ] Cards are laid out vertically with consistent spacing between them.
- [ ] All card elements have explicit background colors (no transparent backgrounds per US-9).

### Reason Callout Block
- [ ] Each card includes a reason callout block that is visually distinct from the rest of the card content.
- [ ] The callout displays a bold "Reason:" label followed by the full carry-over reason text.
- [ ] The reason text is **not** truncated, not muted, not displayed in small font — it must be at least as legible as the card description text (≥ 12px).
- [ ] The callout has a subtle but visible background color (e.g., a light amber/orange tint such as `rgba(253, 126, 20, 0.08)` or `#fff8f0`) to draw attention.
- [ ] The callout has a left border or top border accent in the carried-over status color for additional visual emphasis.
- [ ] The callout spans the full width of the card content area.

### Visual Quality
- [ ] The component renders cleanly within the 1280px dashboard width without overflow or scrollbars.
- [ ] Typography meets minimums: card titles ≥ 12px, section header ≥ 16px, reason text ≥ 12px.
- [ ] All styles are in the scoped `CarriedOverSection.razor.css` file.
- [ ] The component uses no JavaScript, no animations, no transitions.
- [ ] `dotnet build` succeeds with zero errors after adding both files.

## Implementation Steps

### Step 1: Create component scaffold with parameter, null guard, and section header

Create `Components/CarriedOverSection.razor` with the foundational structure.

**What to implement:**
- Add `@using ReportingDashboard.Models` at the top (or rely on `_Imports.razor` if it already includes this namespace).
- Declare the parameter: `[Parameter] public List<CarriedOverItem>? Items { get; set; }`.
- Add a null/empty guard at the top of the markup: if `Items` is null or count is 0, render either nothing or a minimal section shell.
- Render the section header inside `<div class="carried-over-section">`:
  ```razor
  <div class="section-header">
      <span class="section-title">Carried Over</span>
      <span class="section-count">(@(Items?.Count ?? 0))</span>
  </div>
  ```
- Stub the items list area: `<div class="items-list"><!-- cards go here --></div>`.

Create `Components/CarriedOverSection.razor.css` with the root container and section header rules:
```css
.carried-over-section {
    background: var(--bg-card, #ffffff);
    border-radius: 8px;
    box-shadow: var(--shadow-card, 0 1px 3px rgba(0, 0, 0, 0.08));
    padding: 16px;
    box-sizing: border-box;
}

.section-header {
    display: flex;
    align-items: baseline;
    gap: 6px;
    margin-bottom: 12px;
}

.section-title {
    font-size: var(--font-size-section-header, 16px);
    font-weight: 700;
    color: var(--text-primary, #212529);
}

.section-count {
    font-size: var(--font-size-body, 13px);
    font-weight: 400;
    color: var(--text-secondary, #6c757d);
}
```

**Commit message:** `feat: scaffold CarriedOverSection component with parameter and section header`

**Verification:** `dotnet build` succeeds. Component can be referenced from any parent with null or empty data without crashing.

### Step 2: Implement work item cards with title, description, badges, and original target date

Build out the card markup and styling for each carried-over item inside the `items-list` container.

**Razor markup:**
```razor
<div class="items-list">
    @foreach (var item in Items!)
    {
        <div class="work-item-card">
            <div class="card-header">
                <span class="item-title">@item.Title</span>
                <div class="badges">
                    @if (!string.IsNullOrWhiteSpace(item.Category))
                    {
                        <span class="badge category-badge">@item.Category</span>
                    }
                    @if (!string.IsNullOrWhiteSpace(item.Priority))
                    {
                        <span class="badge priority-badge priority-@(item.Priority.ToLowerInvariant())">@item.Priority</span>
                    }
                </div>
            </div>
            @if (!string.IsNullOrWhiteSpace(item.Description))
            {
                <div class="item-description">@item.Description</div>
            }
            <div class="original-target">
                <span class="target-label">Original Target:</span>
                <span class="target-value">@item.OriginalTarget</span>
            </div>
            <!-- Reason callout added in Step 3 -->
        </div>
    }
</div>
```

**CSS rules to add to `CarriedOverSection.razor.css`:**
- `.items-list` — `display: flex; flex-direction: column; gap: 10px;`.
- `.work-item-card` — `border-left: 4px solid var(--status-carried-over, #fd7e14)`, `background: var(--bg-card, #ffffff)`, `padding: 12px 14px`, `border-radius: 6px`, `box-shadow: 0 1px 2px rgba(0,0,0,0.05)`, `box-sizing: border-box`.
- `.card-header` — `display: flex; justify-content: space-between; align-items: center;`.
- `.item-title` — `font-weight: 600; font-size: 13px; color: var(--text-primary, #212529);`.
- `.item-description` — `font-size: var(--font-size-body, 13px); color: var(--text-secondary, #6c757d); margin-top: 4px; line-height: 1.4;`.
- `.badges` — `display: flex; gap: 6px; align-items: center;`.
- `.badge` — `display: inline-block; padding: 2px 8px; border-radius: 10px; font-size: var(--font-size-small, 11px); font-weight: 600; background: var(--border-color, #dee2e6); color: var(--text-primary, #212529);`.
- `.priority-p0` — `background: var(--priority-p0, #dc3545); color: white;`.
- `.priority-p1` — `background: var(--priority-p1, #fd7e14); color: white;`.
- `.priority-p2` — `background: var(--priority-p2, #ffc107); color: #212529;`.
- `.priority-p3` — `background: var(--priority-p3, #6c757d); color: white;`.
- `.original-target` — `margin-top: 6px; font-size: var(--font-size-body, 13px);`.
- `.target-label` — `font-weight: 600; color: var(--text-secondary, #6c757d);`.
- `.target-value` — `color: var(--text-primary, #212529); margin-left: 4px;`.

**Commit message:** `feat: implement carried-over work item cards with badges and target date`

**Verification:** `dotnet build` succeeds. Cards render with amber left border, title, description, badges, and original target date.

### Step 3: Implement the reason callout block

Add the prominently-styled reason callout inside each `.work-item-card`, after the `.original-target` div.

**Razor markup:**
```razor
@if (!string.IsNullOrWhiteSpace(item.Reason))
{
    <div class="reason-callout">
        <span class="reason-label">Reason:</span>
        <span class="reason-text">@item.Reason</span>
    </div>
}
```

**CSS rules for the callout:**
```css
.reason-callout {
    margin-top: 8px;
    padding: 8px 12px;
    background: #fff8f0;
    border-left: 3px solid var(--status-carried-over, #fd7e14);
    border-radius: 0 4px 4px 0;
    font-size: var(--font-size-body, 13px);
    line-height: 1.5;
    color: var(--text-primary, #212529);
    box-sizing: border-box;
}

.reason-label {
    font-weight: 700;
    color: var(--status-carried-over, #fd7e14);
    margin-right: 4px;
}

.reason-text {
    font-weight: 400;
    color: var(--text-primary, #212529);
}
```

**Design rationale for the callout:**
- The `#fff8f0` background is a very light warm tint that is visible but doesn't compete with the card's white background — it draws the eye without being garish in an executive screenshot.
- The 3px left border in the carried-over status color creates a visual "nested accent" effect — the card has a 4px amber left border, and inside it the reason callout echoes that color with its own left border.
- The "Reason:" label is bold and colored in the status color, making it immediately scannable.
- The text is `font-size: 13px` (same as body) — deliberately not smaller or muted, per the PM spec requirement that the reason is "prominently displayed (not hidden or truncated)."
- No `max-height`, no `overflow: hidden`, no `text-overflow: ellipsis` — the full reason text always renders.

**Commit message:** `feat: add prominent reason callout block to CarriedOverSection cards`

**Verification:** `dotnet build` succeeds. Reason block renders with warm background, bold label, full untruncated text. Visually distinct from the description text above it.

### Step 4: Edge case handling and final visual polish

Address edge cases and ensure screenshot readiness.

**Edge case handling in the Razor markup:**
- Null `item.Category` — already handled by `@if (!string.IsNullOrWhiteSpace(...))` guard from Step 2.
- Null `item.Description` — already handled by guard.
- Null `item.Reason` — already handled by guard. If reason is null, the callout block does not render (acceptable — the card still shows the item without a reason).
- Null `item.Priority` — already handled by guard.
- Null `item.OriginalTarget` — add a guard: `@if (!string.IsNullOrWhiteSpace(item.OriginalTarget))` around the `.original-target` div.
- Very long reason text (200+ characters) — verify text wraps naturally within the card. No truncation. Add `word-wrap: break-word; overflow-wrap: break-word;` to `.reason-callout` to prevent extremely long unbroken strings from overflowing.
- Very long titles — add `overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: calc(100% - 160px);` to `.item-title` to prevent title from overlapping the badges.

**Additional CSS polish:**
```css
.reason-callout {
    word-wrap: break-word;
    overflow-wrap: break-word;
}

.item-title {
    overflow: hidden;
    text-overflow: ellipsis;
    white-space: nowrap;
    max-width: calc(100% - 160px);
}
```

**Visual verification checklist:**
- All elements have explicit backgrounds (no transparency bleed in screenshots).
- Amber left border is visible and consistent across all cards.
- Reason callout background (`#fff8f0`) is visible against the white card background.
- Priority badges use correct colors: P0 (red), P1 (orange), P2 (yellow), P3 (gray).
- Section fits within 1280px width.
- With 2 items (standard sample data volume), section does not exceed its allocated vertical space.
- No `transition`, `animation`, or `transform` properties exist.
- All color values reference CSS custom properties with fallbacks.
- `box-sizing: border-box` on all padded/bordered elements.

**Commit message:** `feat: finalize CarriedOverSection edge cases and visual polish`

**Verification:** `dotnet build` succeeds with zero errors and zero warnings. Component handles null properties, empty strings, and long text without crashing or overflowing.

## Testing

### Manual Verification

| # | Scenario | Steps | Expected Result |
|---|----------|-------|-----------------|
| 1 | **Standard rendering** | Load dashboard with sample data containing 2 carried-over items with reasons | Both cards render with amber left border, badges, original target date, and prominent reason callout |
| 2 | **Reason callout visibility** | Inspect the reason block visually | Background is a visible warm tint, "Reason:" label is bold and orange-colored, text is full-size (13px), not truncated |
| 3 | **Empty list** | Set `"carriedOver": []` in data.json | Section renders with "Carried Over (0)" header or is hidden. No crash |
| 4 | **Null list** | Remove `"carriedOver"` key entirely from data.json | DashboardDataService coerces to empty list (T2 validation). Component receives empty list, renders gracefully |
| 5 | **Long reason text** | Set an item's reason to a 300-character string | Text wraps naturally within the callout. No overflow, no truncation, no horizontal scrollbar |
| 6 | **Missing reason** | Set an item's `reason` to `null` or `""` | Card renders without the reason callout block. No crash, no empty box |
| 7 | **Missing optional fields** | Item with null category, null description, null originalTarget | Card renders with only title, priority badge, and reason callout. No crash |
| 8 | **All priority levels** | Items with P0, P1, P2, P3 priorities | Each badge shows correct color: red, orange, yellow, gray |
| 9 | **Screenshot at 1280x900** | Browser window at 1280x900, take screenshot | Section fits within viewport allocation, all text legible, reason callout clearly visible |
| 10 | **Auto-refresh** | Change a reason text in data.json and save | Reason callout updates within 5 seconds (via T3 file watching) |
| 11 | **Print mode** | Add `?print=true` to URL | Section renders cleanly with explicit backgrounds preserved (no transparency artifacts) |

### Recommended Unit Tests (bUnit + xUnit)

| Test | What It Verifies |
|------|-----------------|
| **Null items renders empty** | `Items = null` → no `.work-item-card` elements in rendered markup |
| **Empty list renders empty** | `Items = []` → no `.work-item-card` elements |
| **Correct item count in header** | 2 items → header contains "(2)" |
| **Card count matches items** | 2 items → exactly 2 `.work-item-card` elements |
| **Title rendered in bold** | Item with title "Automated Regression Suite" → `.item-title` contains that text |
| **Description rendered** | Item with description → `.item-description` contains that text |
| **Category badge rendered** | Item with category "Testing" → `.category-badge` contains "Testing" |
| **Priority badge with correct class** | Item with priority "P1" → badge has class `priority-p1` |
| **Original target rendered** | Item with originalTarget "February 2026" → `.target-value` contains "February 2026" |
| **Reason callout rendered** | Item with reason text → `.reason-callout` element present with `.reason-label` and `.reason-text` |
| **Reason label says "Reason:"** | `.reason-label` text content is "Reason:" |
| **Full reason text not truncated** | 200-character reason → `.reason-text` contains the full string |
| **Null reason omits callout** | Item with null reason → no `.reason-callout` element |
| **Null description omits description** | Item with null description → no `.item-description` element |
| **Null originalTarget omits target** | Item with null originalTarget → no `.original-target` element |
| **Null category omits badge** | Item with null category → no `.category-badge` element |

## References
- Architecture: Architecture.md
- PM Spec: 

## Status
- [ ] Implementation
- [ ] Tests Written
- [ ] Ready for Review