### PR TITLE
PrincipalEngineer: Project Header Component

### DIFF
--- a/.agentsquad/project-header-component.task
+++ b/.agentsquad/project-header-component.task
@@ -1,0 +1,4 @@
+agent: PrincipalEngineer
+task: Project Header Component
+complexity: Low
+status: in-progress

--- a/Components/ProjectHeader.razor
+++ b/Components/ProjectHeader.razor
@@ -5,7 +5,7 @@
     <header class="project-header">
         <div class="header-content">
             <div class="header-left">
-                <h1 class="project-name">@Project.Name</h1>
+                <h1 class="project-name">@(Project.Name ?? "Untitled Project")</h1>
                 @if (!string.IsNullOrWhiteSpace(Project.Executive))
                 {
                     <div class="project-sponsor">@Project.Executive</div>

--- a/Components/ProjectHeader.razor
+++ b/Components/ProjectHeader.razor
@@ -5,7 +5,22 @@
     <header class="project-header">
         <div class="header-content">
             <div class="header-left">
-                @* Title, sponsor, dates - Step 2 *@
+                <h1 class="project-name">@Project.Name</h1>
+                @if (!string.IsNullOrWhiteSpace(Project.Executive))
+                {
+                    <div class="project-sponsor">@Project.Executive</div>
+                }
+                <div class="header-meta">
+                    @if (!string.IsNullOrWhiteSpace(Project.ReportingPeriod))
+                    {
+                        <span class="meta-item reporting-period">@Project.ReportingPeriod</span>
+                    }
+                    @if (!string.IsNullOrWhiteSpace(Project.ReportDate))
+                    {
+                        <span class="meta-separator">|</span>
+                        <span class="meta-item report-date">Report Date: @Project.ReportDate</span>
+                    }
+                </div>
             </div>
             <div class="header-right">
                 @* Status badge - Step 3 *@

--- a/Components/ProjectHeader.razor
+++ b/Components/ProjectHeader.razor
@@ -23,7 +23,9 @@
                 </div>
             </div>
             <div class="header-right">
-                @* Status badge - Step 3 *@
+                <span class="status-badge @GetStatusClass(Project.Status)">
+                    @GetStatusText(Project.Status)
+                </span>
             </div>
         </div>
     </header>
@@ -32,4 +34,15 @@
 @code {
     [Parameter]
     public ProjectInfo? Project { get; set; }
+
+    private static string GetStatusClass(string? status) => status switch
+    {
+        "On Track" => "status-on-track",
+        "At Risk" => "status-at-risk",
+        "Off Track" => "status-off-track",
+        _ => "status-unknown"
+    };
+
+    private static string GetStatusText(string? status) =>
+        string.IsNullOrWhiteSpace(status) ? "Unknown" : status;
 }

--- a/Components/ProjectHeader.razor
+++ b/Components/ProjectHeader.razor
@@ -1,6 +1,18 @@
-<div class="project-header">
-    <!-- ProjectHeader: implemented in T4 -->
-</div>
+@using ReportingDashboard.Models
+
+@if (Project is not null)
+{
+    <header class="project-header">
+        <div class="header-content">
+            <div class="header-left">
+                @* Title, sponsor, dates - Step 2 *@
+            </div>
+            <div class="header-right">
+                @* Status badge - Step 3 *@
+            </div>
+        </div>
+    </header>
+}
 
 @code {
     [Parameter]

--- a/Components/ProjectHeader.razor.css
+++ b/Components/ProjectHeader.razor.css
@@ -11,10 +11,12 @@
     display: flex;
     justify-content: space-between;
     align-items: flex-start;
+    background-color: var(--bg-header, #1a2332);
 }
 
 .header-left {
     flex: 1;
+    min-width: 0;
     background-color: var(--bg-header, #1a2332);
 }
 
@@ -23,6 +25,7 @@
     display: flex;
     align-items: flex-start;
     padding-top: 4px;
+    margin-left: 16px;
     background-color: var(--bg-header, #1a2332);
 }
 
@@ -34,6 +37,9 @@
     padding: 0;
     line-height: 1.2;
     background-color: var(--bg-header, #1a2332);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .project-sponsor {
@@ -42,6 +48,9 @@
     color: rgba(255, 255, 255, 0.8);
     margin-bottom: 8px;
     background-color: var(--bg-header, #1a2332);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .header-meta {

--- a/Components/ProjectHeader.razor.css
+++ b/Components/ProjectHeader.razor.css
@@ -25,3 +25,49 @@
     padding-top: 4px;
     background-color: var(--bg-header, #1a2332);
 }
+
+.project-name {
+    font-size: var(--font-size-title, 24px);
+    font-weight: 700;
+    color: var(--text-on-dark, #ffffff);
+    margin: 0 0 4px 0;
+    padding: 0;
+    line-height: 1.2;
+    background-color: var(--bg-header, #1a2332);
+}
+
+.project-sponsor {
+    font-size: 14px;
+    font-weight: 400;
+    color: rgba(255, 255, 255, 0.8);
+    margin-bottom: 8px;
+    background-color: var(--bg-header, #1a2332);
+}
+
+.header-meta {
+    display: flex;
+    align-items: center;
+    gap: 0;
+    font-size: var(--font-size-body, 13px);
+    color: rgba(255, 255, 255, 0.65);
+    background-color: var(--bg-header, #1a2332);
+}
+
+.meta-item {
+    background-color: var(--bg-header, #1a2332);
+}
+
+.meta-separator {
+    margin: 0 8px;
+    color: rgba(255, 255, 255, 0.4);
+    background-color: var(--bg-header, #1a2332);
+}
+
+.reporting-period {
+    font-weight: 600;
+    color: rgba(255, 255, 255, 0.8);
+}
+
+.report-date {
+    font-weight: 400;
+}

--- a/Components/ProjectHeader.razor.css
+++ b/Components/ProjectHeader.razor.css
@@ -71,3 +71,35 @@
 .report-date {
     font-weight: 400;
 }
+
+.status-badge {
+    display: inline-block;
+    padding: 6px 16px;
+    border-radius: 20px;
+    font-size: var(--font-size-body, 13px);
+    font-weight: 700;
+    letter-spacing: 0.3px;
+    white-space: nowrap;
+    text-align: center;
+    line-height: 1.4;
+}
+
+.status-on-track {
+    background-color: var(--status-shipped, #28a745);
+    color: #ffffff;
+}
+
+.status-at-risk {
+    background-color: var(--status-at-risk, #ffc107);
+    color: #212529;
+}
+
+.status-off-track {
+    background-color: var(--status-off-track, #dc3545);
+    color: #ffffff;
+}
+
+.status-unknown {
+    background-color: #6c757d;
+    color: #ffffff;
+}

--- a/Components/ProjectHeader.razor.css
+++ b/Components/ProjectHeader.razor.css
@@ -1,0 +1,27 @@
+.project-header {
+    background-color: var(--bg-header, #1a2332);
+    color: var(--text-on-dark, #ffffff);
+    padding: 20px 24px;
+    border-radius: 8px 8px 0 0;
+    box-sizing: border-box;
+    width: 100%;
+}
+
+.header-content {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+}
+
+.header-left {
+    flex: 1;
+    background-color: var(--bg-header, #1a2332);
+}
+
+.header-right {
+    flex-shrink: 0;
+    display: flex;
+    align-items: flex-start;
+    padding-top: 4px;
+    background-color: var(--bg-header, #1a2332);
+}


### PR DESCRIPTION
## Task Assignment
**Assigned To:** PrincipalEngineer
**Complexity:** Low
**Branch:** `agent/principalengineer/t4-project-header-component`

## Requirements
Closes #405

# PR: Project Header Component

**Issue:** #393 | **Task:** T4 | **Complexity:** Low | **Depends On:** T1 (#402)

## Summary

Implements the `ProjectHeader.razor` component and its scoped CSS stylesheet for the Executive Reporting Dashboard. This component renders the topmost section of the dashboard — a dark-background header strip that displays the project name, executive sponsor, reporting period, report date, and a color-coded overall status badge. It is the first visual element seen in every executive screenshot and establishes the project identity and health status at a glance.

The header uses a dark background (`--bg-header: #1a2332`) with light text (`--text-on-dark: #ffffff`) to create a strong visual anchor at the top of the 1280px dashboard. The status badge is the component's most important visual element — it maps the `Project.Status` string to a colored pill that communicates "On Track" (green), "At Risk" (amber), or "Off Track" (red) with a gray fallback for unrecognized values. All colors use CSS custom properties defined by T1's global `app.css`.

This PR creates exactly two files:
- `Components/ProjectHeader.razor` — the Blazor component
- `Components/ProjectHeader.razor.css` — scoped styles

It does **not** modify any existing files. The existing `Components/ProjectHeader.razor` stub from T1 will be replaced with the full implementation. The `Dashboard.razor` integration (wiring `<ProjectHeader Project="@data.Project" />`) is expected to already exist from T1's stub or will be completed by the Dashboard page task.

## Acceptance Criteria

### Component Contract
- [ ] `ProjectHeader.razor` declares a `[Parameter] public ProjectInfo? Project { get; set; }` property.
- [ ] A null `Project` parameter renders nothing (empty fragment). No crash, no broken layout.
- [ ] The component is in the `ReportingDashboard.Components` namespace (implicit via file location in `Components/`).
- [ ] The component references the existing `ProjectInfo` record from `ReportingDashboard.Models` and does **not** redefine it.

### Project Name
- [ ] The project name is rendered as an `<h1>` element.
- [ ] Font size is at least 24px (`var(--font-size-title, 24px)`).
- [ ] Font weight is bold (700).
- [ ] Text color is light/white (`var(--text-on-dark, #ffffff)`).

### Executive Sponsor
- [ ] The executive sponsor name is displayed below the project name.
- [ ] Font size is at least 13px (body size or larger).
- [ ] Text is lighter/muted relative to the title (e.g., `rgba(255, 255, 255, 0.8)` or a secondary light color).

### Reporting Period and Date
- [ ] The reporting period (e.g., "March 2026") is clearly visible.
- [ ] The report date (e.g., "2026-04-10") is clearly visible.
- [ ] Both are legible in a 1280x900 screenshot.
- [ ] Layout positions these fields so they do not overlap with the project name or status badge.

### Status Badge
- [ ] A status badge displays the `Project.Status` text value.
- [ ] **"On Track"** → green background (`var(--status-shipped, #28a745)`) with white text.
- [ ] **"At Risk"** → amber background (`var(--status-at-risk, #ffc107)`) with black/dark text (`#212529`).
- [ ] **"Off Track"** → red background (`var(--status-off-track, #dc3545)`) with white text.
- [ ] Any unrecognized status string → gray background (`#6c757d`) with white text.
- [ ] Null or empty status → gray badge with text "Unknown" or the badge is hidden.
- [ ] The badge has rounded corners (pill shape), padding, and font-weight 600–700 for legibility in screenshots.

### Visual Design
- [ ] The header has a dark background using `var(--bg-header, #1a2332)`.
- [ ] All elements within the header have explicit background colors — no transparent backgrounds.
- [ ] The header spans the full 1280px dashboard width.
- [ ] The Segoe UI font stack is inherited from the parent `.dashboard` container.
- [ ] No animations, no transitions, no hover effects.
- [ ] All styles are in the scoped `ProjectHeader.razor.css` file.
- [ ] `dotnet build` succeeds with zero errors after adding both files.

## Implementation Steps

### Step 1: Create component scaffold with parameter, null guard, and layout skeleton

Create `Components/ProjectHeader.razor` with the foundational structure.

**What to implement:**
- Add `@using ReportingDashboard.Models` at the top (or rely on `_Imports.razor` if it already includes this namespace).
- Declare the parameter: `[Parameter] public ProjectInfo? Project { get; set; }`.
- Add a null guard: `@if (Project is null) { return; }` — renders nothing for null data.
- Create the outer container markup:
  ```razor
  @if (Project is not null)
  {
      <header class="project-header">
          <div class="header-content">
              <div class="header-left">
                  <!-- Title, sponsor, dates go here -->
              </div>
              <div class="header-right">
                  <!-- Status badge goes here -->
              </div>
          </div>
      </header>
  }
  ```
- Add an empty `@code { }` block with the parameter declaration.

Create `Components/ProjectHeader.razor.css` with the root container rules:
```css
.project-header {
    background-color: var(--bg-header, #1a2332);
    color: var(--text-on-dark, #ffffff);
    padding: 20px 24px;
    border-radius: 8px 8px 0 0;
    box-sizing: border-box;
    width: 100%;
}

.header-content {
    display: flex;
    justify-content: space-between;
    align-items: flex-start;
}

.header-left {
    flex: 1;
}

.header-right {
    flex-shrink: 0;
    display: flex;
    align-items: flex-start;
    padding-top: 4px;
}
```

**Commit message:** `feat: scaffold ProjectHeader component with layout skeleton`

**Verification:** `dotnet build` succeeds. The component renders a dark header block when given a non-null `ProjectInfo`, and renders nothing for null.

### Step 2: Implement project name, sponsor, and date display

Fill in the `.header-left` section with the project information fields.

**Razor markup:**
```razor
<div class="header-left">
    <h1 class="project-name">@Project.Name</h1>
    @if (!string.IsNullOrWhiteSpace(Project.Executive))
    {
        <div class="project-sponsor">@Project.Executive</div>
    }
    <div class="header-meta">
        @if (!string.IsNullOrWhiteSpace(Project.ReportingPeriod))
        {
            <span class="meta-item reporting-period">@Project.ReportingPeriod</span>
        }
        @if (!string.IsNullOrWhiteSpace(Project.ReportDate))
        {
            <span class="meta-separator">•</span>
            <span class="meta-item report-date">Report Date: @Project.ReportDate</span>
        }
    </div>
</div>
```

**CSS rules to add to `ProjectHeader.razor.css`:**
```css
.project-name {
    font-size: var(--font-size-title, 24px);
    font-weight: 700;
    color: var(--text-on-dark, #ffffff);
    margin: 0 0 4px 0;
    padding: 0;
    line-height: 1.2;
    background-color: transparent;
}

.project-sponsor {
    font-size: 14px;
    font-weight: 400;
    color: rgba(255, 255, 255, 0.8);
    margin-bottom: 8px;
    background-color: var(--bg-header, #1a2332);
}

.header-meta {
    display: flex;
    align-items: center;
    gap: 0;
    font-size: var(--font-size-body, 13px);
    color: rgba(255, 255, 255, 0.65);
    background-color: var(--bg-header, #1a2332);
}

.meta-item {
    background-color: var(--bg-header, #1a2332);
}

.meta-separator {
    margin: 0 8px;
    background-color: var(--bg-header, #1a2332);
}

.reporting-period {
    font-weight: 600;
    color: rgba(255, 255, 255, 0.8);
}

.report-date {
    font-weight: 400;
}
```

**Note on explicit backgrounds:** The PM spec and architecture require "all elements have explicit background colors." For elements inside the dark header, the background matches the header background (`--bg-header`). The `project-name` uses `transparent` because it is a direct child of the header and has no visual need for its own background — the header background shows through correctly. If the code reviewer flags this, it can be changed to `var(--bg-header, #1a2332)` for absolute compliance.

**Commit message:** `feat: add project name, sponsor, and date fields to ProjectHeader`

**Verification:** `dotnet build` succeeds. Header displays project name in large bold white text, sponsor in lighter text below, and reporting period + date in a smaller meta row.

### Step 3: Implement the color-coded status badge with fallback logic

Add the status badge to the `.header-right` section and implement the status-to-CSS-class mapping.

**Razor markup:**
```razor
<div class="header-right">
    <span class="status-badge @GetStatusClass(Project.Status)">
        @GetStatusText(Project.Status)
    </span>
</div>
```

**Add to the `@code` block:**
```csharp
@code {
    [Parameter]
    public ProjectInfo? Project { get; set; }

    private static string GetStatusClass(string? status) => status switch
    {
        "On Track" => "status-on-track",
        "At Risk" => "status-at-risk",
        "Off Track" => "status-off-track",
        _ => "status-unknown"
    };

    private static string GetStatusText(string? status) =>
        string.IsNullOrWhiteSpace(status) ? "Unknown" : status;
}
```

**CSS rules for the status badge:**
```css
.status-badge {
    display: inline-block;
    padding: 6px 16px;
    border-radius: 20px;
    font-size: var(--font-size-body, 13px);
    font-weight: 700;
    letter-spacing: 0.3px;
    white-space: nowrap;
    text-align: center;
    line-height: 1.4;
}

.status-on-track {
    background-color: var(--status-shipped, #28a745);
    color: #ffffff;
}

.status-at-risk {
    background-color: var(--status-at-risk, #ffc107);
    color: #212529;
}

.status-off-track {
    background-color: var(--status-off-track, #dc3545);
    color: #ffffff;
}

.status-unknown {
    background-color: #6c757d;
    color: #ffffff;
}
```

**Design decisions:**
- The switch expression uses C# pattern matching for clarity and compile-time safety.
- `null` and empty status strings both produce the "Unknown" badge text with the gray fallback class.
- The `status-on-track` class uses `--status-shipped` (green `#28a745`) as specified in the architecture — "On Track" shares the green color with shipped items.
- The "At Risk" badge uses black text (`#212529`) on amber to ensure readability — white text on `#ffc107` fails WCAG contrast.
- `border-radius: 20px` creates a pill shape. `padding: 6px 16px` gives it visual weight.
- `white-space: nowrap` prevents the status text from wrapping across lines at narrow widths.

**Commit message:** `feat: implement color-coded status badge with fallback for ProjectHeader`

**Verification:** `dotnet build` succeeds. Change `Project.Status` in `data.json` to each of the four values ("On Track", "At Risk", "Off Track", "Something Else") and verify the badge renders with the correct color, text, and contrast.

### Step 4: Edge cases, visual polish, and screenshot verification

Address remaining edge cases and ensure screenshot fidelity.

**Edge case handling:**
- Null `Project.Name` — render `<h1>` with empty content (acceptable, though the data service should prevent this via validation). Alternatively, show a placeholder: `@(Project.Name ?? "Untitled Project")`.
- Very long project name — verify it wraps gracefully or truncates within the header. Add `overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: calc(100% - 180px);` to `.project-name` if single-line is preferred, or allow natural wrapping for multi-word names.
- Very long executive name — same approach. Likely allow wrapping since it's a smaller element.
- Very long status text (custom value like "Partially On Track") — the `white-space: nowrap` on the badge prevents wrapping, and the pill stretches horizontally. Acceptable behavior for unusual inputs.

**Additional CSS polish:**
- Ensure the header's `border-radius: 8px 8px 0 0` only rounds the top corners, matching a card-style header that flows into the content below.
- Verify the header looks correct when the dashboard has the `print-mode` class (T10 responsibility, but verify no conflicts).
- Add a subtle bottom border or shadow separation between the header and the content below if the design requires it: `box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);` on `.project-header`.

**Screenshot verification checklist:**
- Header spans full 1280px width.
- Dark background contrasts cleanly with the light `--bg-page` dashboard background.
- Project name is at least 24px and bold.
- Sponsor name is visible but secondary.
- Reporting period and date are clearly readable.
- Status badge color is correct for the sample data's "On Track" status.
- No transparency artifacts — all backgrounds are opaque.
- No animations or transitions.
- At 1280x900, the header occupies approximately 80–100px of vertical space, leaving adequate room for the remaining dashboard sections.

**Commit message:** `feat: finalize ProjectHeader edge cases and visual polish`

**Verification:** `dotnet build` succeeds. Full visual check at 1280x900 with sample data. Header is the correct visual anchor at the top of the dashboard.

## Testing

### Manual Verification

| # | Scenario | Steps | Expected Result |
|---|----------|-------|-----------------|
| 1 | **Standard rendering** | Load dashboard with sample data ("On Track" status) | Dark header with white project name, sponsor, dates, and green "On Track" badge |
| 2 | **On Track badge** | Set status to "On Track" in data.json | Green badge (`#28a745`) with white text |
| 3 | **At Risk badge** | Set status to "At Risk" in data.json | Amber badge (`#ffc107`) with black text |
| 4 | **Off Track badge** | Set status to "Off Track" in data.json | Red badge (`#dc3545`) with white text |
| 5 | **Unknown status badge** | Set status to "Delayed" or any non-standard string | Gray badge (`#6c757d`) with white text, displays the raw status text |
| 6 | **Empty status** | Set status to `""` in data.json | Gray badge with "Unknown" text |
| 7 | **Null project** | Temporarily make data service return null Project (or test in isolation) | Component renders nothing — no crash, no empty dark box |
| 8 | **Missing sponsor** | Set executive to `null` or `""` in data.json | Sponsor line is hidden. Name and dates still display correctly |
| 9 | **Missing dates** | Remove reportingPeriod and reportDate from data.json | Meta row is hidden or empty. Name and sponsor still render |
| 10 | **Long project name** | Set name to a 100-character string | Text either wraps or truncates gracefully. No overflow outside the header |
| 11 | **Screenshot at 1280x900** | Browser window at 1280x900, take screenshot | Header spans full width, all text legible, badge color accurate, no scrollbars |
| 12 | **Auto-refresh** | Change the status from "On Track" to "At Risk" in data.json and save | Badge changes from green to amber within 5 seconds |

### Recommended Unit Tests (bUnit + xUnit)

| Test | What It Verifies |
|------|-----------------|
| **Null project renders nothing** | `Project = null` → no `<header>` element in rendered markup |
| **Project name in h1** | Project with name "Phoenix" → `<h1>` element contains "Phoenix" |
| **H1 has correct CSS class** | `<h1>` has class `project-name` |
| **Sponsor rendered** | Project with executive "Sarah Chen" → `.project-sponsor` contains "Sarah Chen" |
| **Sponsor hidden when null** | Project with null executive → no `.project-sponsor` element |
| **Reporting period rendered** | Project with reportingPeriod "March 2026" → `.reporting-period` contains "March 2026" |
| **Report date rendered** | Project with reportDate "2026-04-10" → `.report-date` contains "2026-04-10" |
| **On Track status class** | Status "On Track" → `.status-badge` has class `status-on-track` |
| **At Risk status class** | Status "At Risk" → `.status-badge` has class `status-at-risk` |
| **Off Track status class** | Status "Off Track" → `.status-badge` has class `status-off-track` |
| **Unknown status class** | Status "Delayed" → `.status-badge` has class `status-unknown` |
| **Null status shows Unknown** | Null status → `.status-badge` text is "Unknown" |
| **Empty status shows Unknown** | Empty string status → `.status-badge` text is "Unknown" |
| **Status badge text matches input** | Status "On Track" → badge text content is "On Track" |
| **No h1 for null project** | `Project = null` → no `<h1>` in DOM |

## References
- Architecture: Architecture.md
- PM Spec: 

## Status
- [ ] Implementation
- [ ] Tests Written
- [ ] Ready for Review