### PR TITLE
PrincipalEngineer: Key Metrics Bar and Badge Components

### DIFF
--- a/.agentsquad/key-metrics-bar-and-badge-components.task
+++ b/.agentsquad/key-metrics-bar-and-badge-components.task
@@ -1,0 +1,4 @@
+agent: PrincipalEngineer
+task: Key Metrics Bar and Badge Components
+complexity: Low
+status: in-progress

--- a/Components/MetricBadge.razor
+++ b/Components/MetricBadge.razor
@@ -8,10 +8,30 @@
             <span class="metric-label">@Metric.Label</span>
         }
         <span class="metric-value">@(Metric.Value ?? "-")</span>
+        <div class="trend-indicator">
+            <span class="trend-arrow @GetTrendClass(Metric.Trend)"></span>
+            <span class="trend-text @GetTrendClass(Metric.Trend)-text">@GetTrendLabel(Metric.Trend)</span>
+        </div>
     </div>
 }
 
 @code {
     [Parameter]
     public KeyMetric? Metric { get; set; }
+
+    private static string GetTrendClass(string? trend) => trend?.ToLowerInvariant() switch
+    {
+        "up" => "trend-up",
+        "down" => "trend-down",
+        "stable" => "trend-stable",
+        _ => "trend-stable"
+    };
+
+    private static string GetTrendLabel(string? trend) => trend?.ToLowerInvariant() switch
+    {
+        "up" => "Up",
+        "down" => "Down",
+        "stable" => "Stable",
+        _ => "Stable"
+    };
 }

--- a/Components/MetricBadge.razor
+++ b/Components/MetricBadge.razor
@@ -7,10 +7,10 @@
         {
             <span class="metric-label">@Metric.Label</span>
         }
-        <span class="metric-value">@(Metric.Value ?? "-")</span>
+        <span class="metric-value">@(string.IsNullOrWhiteSpace(Metric.Value) ? "\u2014" : Metric.Value)</span>
         <div class="trend-indicator">
             <span class="trend-arrow @GetTrendClass(Metric.Trend)"></span>
-            <span class="trend-text @GetTrendClass(Metric.Trend)-text">@GetTrendLabel(Metric.Trend)</span>
+            <span class="trend-text @GetTrendClass(Metric.Trend)">@GetTrendLabel(Metric.Trend)</span>
         </div>
     </div>
 }

--- a/Components/MetricBadge.razor
+++ b/Components/MetricBadge.razor
@@ -3,6 +3,11 @@
 @if (Metric is not null)
 {
     <div class="metric-badge">
+        @if (!string.IsNullOrWhiteSpace(Metric.Label))
+        {
+            <span class="metric-label">@Metric.Label</span>
+        }
+        <span class="metric-value">@(Metric.Value ?? "-")</span>
     </div>
 }
 

--- a/Components/MetricBadge.razor
+++ b/Components/MetricBadge.razor
@@ -1,6 +1,10 @@
-<div class="metric-badge">
-    <!-- MetricBadge: implemented in T9 -->
-</div>
+@using ReportingDashboard.Models
+
+@if (Metric is not null)
+{
+    <div class="metric-badge">
+    </div>
+}
 
 @code {
     [Parameter]

--- a/Components/MetricBadge.razor.css
+++ b/Components/MetricBadge.razor.css
@@ -32,3 +32,57 @@
     background-color: var(--bg-card, #ffffff);
     white-space: nowrap;
 }
+
+.trend-indicator {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 4px;
+    margin-top: 6px;
+    background-color: var(--bg-card, #ffffff);
+}
+
+.trend-arrow {
+    display: inline-block;
+    width: 0;
+    height: 0;
+    background-color: transparent;
+}
+
+.trend-up {
+    border-left: 5px solid transparent;
+    border-right: 5px solid transparent;
+    border-bottom: 7px solid var(--status-shipped, #28a745);
+}
+
+.trend-down {
+    border-left: 5px solid transparent;
+    border-right: 5px solid transparent;
+    border-top: 7px solid var(--status-off-track, #dc3545);
+}
+
+.trend-stable {
+    width: 12px;
+    height: 3px;
+    background-color: var(--text-secondary, #6c757d);
+    border: none;
+}
+
+.trend-text {
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.3px;
+    background-color: var(--bg-card, #ffffff);
+}
+
+.trend-up-text {
+    color: var(--status-shipped, #28a745);
+}
+
+.trend-down-text {
+    color: var(--status-off-track, #dc3545);
+}
+
+.trend-stable-text {
+    color: var(--text-secondary, #6c757d);
+}

--- a/Components/MetricBadge.razor.css
+++ b/Components/MetricBadge.razor.css
@@ -1,0 +1,14 @@
+.metric-badge {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 14px 12px;
+    background-color: var(--bg-card, #ffffff);
+    border-radius: 8px;
+    box-shadow: var(--shadow-card, 0 1px 3px rgba(0, 0, 0, 0.08));
+    text-align: center;
+    box-sizing: border-box;
+    min-width: 0;
+}

--- a/Components/MetricBadge.razor.css
+++ b/Components/MetricBadge.razor.css
@@ -1,45 +1,49 @@
 .metric-badge {
-    flex: 1;
     display: flex;
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    padding: 14px 12px;
+    flex: 1 1 0;
+    max-width: 220px;
+    min-width: 0;
+    padding: 12px 16px;
     background-color: var(--bg-card, #ffffff);
     border-radius: 8px;
     box-shadow: var(--shadow-card, 0 1px 3px rgba(0, 0, 0, 0.08));
     text-align: center;
-    box-sizing: border-box;
-    min-width: 0;
 }
 
 .metric-label {
     font-size: var(--font-size-small, 11px);
-    font-weight: 500;
-    color: var(--text-secondary, #6c757d);
+    color: var(--text-secondary, #6b7280);
     text-transform: uppercase;
     letter-spacing: 0.5px;
-    line-height: 1.3;
+    font-weight: 600;
     margin-bottom: 4px;
-    background-color: var(--bg-card, #ffffff);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 100%;
 }
 
 .metric-value {
     font-size: 22px;
     font-weight: 700;
-    color: var(--text-primary, #212529);
-    line-height: 1.2;
-    background-color: var(--bg-card, #ffffff);
+    color: var(--text-primary, #1f2937);
     white-space: nowrap;
+    line-height: 1.2;
+    margin-bottom: 6px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 100%;
 }
 
 .trend-indicator {
     display: flex;
+    flex-direction: row;
     align-items: center;
-    justify-content: center;
-    gap: 4px;
-    margin-top: 6px;
-    background-color: var(--bg-card, #ffffff);
+    gap: 6px;
+    margin-top: 2px;
 }
 
 .trend-arrow {
@@ -49,40 +53,61 @@
     background-color: transparent;
 }
 
-.trend-up {
+.trend-arrow.trend-up {
     border-left: 5px solid transparent;
     border-right: 5px solid transparent;
-    border-bottom: 7px solid var(--status-shipped, #28a745);
+    border-bottom: 7px solid var(--status-shipped, #22c55e);
 }
 
-.trend-down {
+.trend-arrow.trend-down {
     border-left: 5px solid transparent;
     border-right: 5px solid transparent;
-    border-top: 7px solid var(--status-off-track, #dc3545);
+    border-top: 7px solid var(--status-off-track, #ef4444);
 }
 
-.trend-stable {
+.trend-arrow.trend-stable {
     width: 12px;
     height: 3px;
-    background-color: var(--text-secondary, #6c757d);
-    border: none;
+    background-color: #9ca3af;
 }
 
 .trend-text {
-    font-size: 10px;
+    font-size: var(--font-size-small, 11px);
     font-weight: 600;
-    letter-spacing: 0.3px;
-    background-color: var(--bg-card, #ffffff);
 }
 
-.trend-up-text {
-    color: var(--status-shipped, #28a745);
+.trend-text.trend-up {
+    color: var(--status-shipped, #22c55e);
 }
 
-.trend-down-text {
-    color: var(--status-off-track, #dc3545);
+.trend-text.trend-down {
+    color: var(--status-off-track, #ef4444);
 }
 
-.trend-stable-text {
-    color: var(--text-secondary, #6c757d);
+.trend-text.trend-stable {
+    color: #9ca3af;
+}
+
+@media print {
+    .metric-badge {
+        box-shadow: none;
+        border: 1px solid #e5e7eb;
+        background-color: #ffffff;
+    }
+
+    .trend-arrow.trend-up {
+        border-bottom-color: #16a34a;
+    }
+
+    .trend-arrow.trend-down {
+        border-top-color: #dc2626;
+    }
+
+    .trend-text.trend-up {
+        color: #16a34a;
+    }
+
+    .trend-text.trend-down {
+        color: #dc2626;
+    }
 }

--- a/Components/MetricBadge.razor.css
+++ b/Components/MetricBadge.razor.css
@@ -12,3 +12,23 @@
     box-sizing: border-box;
     min-width: 0;
 }
+
+.metric-label {
+    font-size: var(--font-size-small, 11px);
+    font-weight: 500;
+    color: var(--text-secondary, #6c757d);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    line-height: 1.3;
+    margin-bottom: 4px;
+    background-color: var(--bg-card, #ffffff);
+}
+
+.metric-value {
+    font-size: 22px;
+    font-weight: 700;
+    color: var(--text-primary, #212529);
+    line-height: 1.2;
+    background-color: var(--bg-card, #ffffff);
+    white-space: nowrap;
+}

--- a/Components/MetricsBar.razor
+++ b/Components/MetricsBar.razor
@@ -1,6 +1,14 @@
-<div class="metrics-bar">
-    <!-- MetricsBar: implemented in T9 -->
-</div>
+@using ReportingDashboard.Models
+
+@if (Metrics is not null && Metrics.Count > 0)
+{
+    <div class="metrics-bar">
+        @foreach (var metric in Metrics)
+        {
+            <MetricBadge Metric="@metric" />
+        }
+    </div>
+}
 
 @code {
     [Parameter]

--- a/Components/MetricsBar.razor
+++ b/Components/MetricsBar.razor
@@ -3,9 +3,9 @@
 @if (Metrics is not null && Metrics.Count > 0)
 {
     <div class="metrics-bar">
-        @foreach (var metric in Metrics)
+        @foreach (var item in Metrics)
         {
-            <MetricBadge Metric="@metric" />
+            <MetricBadge Metric="@item" />
         }
     </div>
 }

--- a/Components/MetricsBar.razor.css
+++ b/Components/MetricsBar.razor.css
@@ -1,0 +1,11 @@
+.metrics-bar {
+    display: flex;
+    justify-content: space-evenly;
+    align-items: stretch;
+    gap: 12px;
+    padding: 0;
+    margin-top: 12px;
+    background-color: var(--bg-page, #f4f6f9);
+    width: 100%;
+    box-sizing: border-box;
+}

--- a/Components/MetricsBar.razor.css
+++ b/Components/MetricsBar.razor.css
@@ -1,11 +1,22 @@
 .metrics-bar {
     display: flex;
+    flex-direction: row;
     justify-content: space-evenly;
     align-items: stretch;
-    gap: 12px;
-    padding: 0;
-    margin-top: 12px;
+    gap: 16px;
+    flex-wrap: nowrap;
+    overflow: hidden;
+    margin-top: 20px;
+    padding: 12px 0;
     background-color: var(--bg-page, #f4f6f9);
     width: 100%;
-    box-sizing: border-box;
+}
+
+@media print {
+    .metrics-bar {
+        gap: 8px;
+        margin-top: 12px;
+        padding: 8px 0;
+        background-color: #ffffff;
+    }
 }


### PR DESCRIPTION
## Task Assignment
**Assigned To:** PrincipalEngineer
**Complexity:** Low
**Branch:** `agent/principalengineer/t9-key-metrics-bar-and-badge-components`

## Requirements
Closes #410

# PR: Key Metrics Bar and Badge Components

**Issue:** #398 | **Task:** T9 | **Complexity:** Low | **Depends On:** T1 (#402)

## Summary

Implements two companion components — `MetricsBar.razor` and `MetricBadge.razor` — along with their scoped CSS stylesheets for the Executive Reporting Dashboard. Together these render the bottom strip of the dashboard: a horizontal flexbox row of compact metric cards showing project health indicators like velocity, bug rate, and capacity utilization.

`MetricsBar` is the container component accepting `List<KeyMetric>` and arranging `MetricBadge` children in an evenly-spaced row. `MetricBadge` is the leaf component accepting a single `KeyMetric` and rendering three elements vertically: a small muted label above, a large bold value in the center, and a CSS-only trend indicator below. Trend arrows are rendered entirely with the CSS border-trick (no icon libraries, no SVGs, no Unicode characters that vary across systems): `up` shows a green upward triangle, `down` shows a red downward triangle, and `stable` shows a gray horizontal dash.

The metric badges are visually distinct from work item cards — smaller, centered, without left-border color coding — and are sized to be legible when the dashboard is captured at 1280x900 for PowerPoint embedding.

This PR creates exactly four files:
- `Components/MetricsBar.razor` — container component
- `Components/MetricsBar.razor.css` — container scoped styles
- `Components/MetricBadge.razor` — individual badge component
- `Components/MetricBadge.razor.css` — badge scoped styles

It does **not** modify any existing files. The existing `MetricsBar.razor` and `MetricBadge.razor` stubs from T1 will be replaced with full implementations. The `Dashboard.razor` page is expected to already pass `data.Metrics` to MetricsBar via a `[Parameter]`.

## Acceptance Criteria

### MetricsBar Component Contract
- [ ] `MetricsBar.razor` declares a `[Parameter] public List<KeyMetric>? Metrics { get; set; }` property.
- [ ] A null or empty `Metrics` parameter renders nothing (empty fragment — no empty row, no placeholder). No crash.
- [ ] The component is in the `ReportingDashboard.Components` namespace (implicit via file location in `Components/`).
- [ ] The component references the existing `KeyMetric` record from `ReportingDashboard.Models` and does **not** redefine it.
- [ ] Each `KeyMetric` in the list is rendered as a `<MetricBadge Metric="@item" />` child component.

### MetricsBar Layout
- [ ] Badges are arranged in a horizontal row using CSS flexbox.
- [ ] Badges are evenly spaced across the available width (using `justify-content: space-evenly` or equal `flex: 1` distribution).
- [ ] The row spans the full 1280px dashboard width (minus any padding).
- [ ] The metrics bar has a consistent vertical margin separating it from the content grid above.
- [ ] The bar has an explicit background color (inherits from page or uses its own) — no transparent background.
- [ ] The bar renders cleanly with 3–6 metrics without wrapping or overflow.

### MetricBadge Component Contract
- [ ] `MetricBadge.razor` declares a `[Parameter] public KeyMetric? Metric { get; set; }` property.
- [ ] A null `Metric` parameter renders nothing. No crash.
- [ ] The component is in the `ReportingDashboard.Components` namespace.
- [ ] The component references the existing `KeyMetric` record from `ReportingDashboard.Models` and does **not** redefine it.

### MetricBadge — Label
- [ ] The metric label is displayed as small, muted text **above** the value.
- [ ] Font size is `var(--font-size-small, 11px)`.
- [ ] Font color is `var(--text-secondary, #6c757d)`.
- [ ] Text is centered horizontally within the badge.

### MetricBadge — Value
- [ ] The metric value is displayed as **large, bold** text in the center of the badge.
- [ ] Font size is at least 20px (large enough to be legible at 1280x900 screenshot resolution).
- [ ] Font weight is 700.
- [ ] Font color is `var(--text-primary, #212529)`.
- [ ] The value string is rendered as-is from JSON (e.g., "42 pts", "2.1%", "85%") — no formatting or parsing.

### MetricBadge — Trend Indicator
- [ ] The trend indicator is rendered **below** the value, centered.
- [ ] **"up"** → green upward-pointing CSS triangle using the border trick, color `var(--status-shipped, #28a745)`.
- [ ] **"down"** → red downward-pointing CSS triangle using the border trick, color `var(--status-off-track, #dc3545)`.
- [ ] **"stable"** → gray horizontal dash (a small rectangle), color `var(--text-secondary, #6c757d)`.
- [ ] Any unrecognized trend string → renders as "stable" (gray dash fallback).
- [ ] Null or empty trend → renders as "stable" (gray dash fallback).
- [ ] Trend indicators are **CSS-only** — no icon fonts, no SVG, no image files, no Unicode arrows.
- [ ] A small text label next to or below the arrow (e.g., "up", "down", "stable") is optional but recommended for black-and-white printing legibility.

### MetricBadge — Visual Style
- [ ] Each badge is a compact card with `background-color: var(--bg-card, #ffffff)`.
- [ ] Badge has `border-radius: 8px` and `box-shadow: var(--shadow-card)`.
- [ ] Badge is visually distinct from work item cards — centered layout, no left-border color coding, smaller footprint.
- [ ] All elements within the badge have explicit background colors — no transparent backgrounds.
- [ ] **No animations**, no transitions, no hover effects.
- [ ] All styles are in the scoped `.razor.css` files.

### Build and Integration
- [ ] `dotnet build` succeeds with zero errors after adding all four files.
- [ ] The MetricsBar renders at the bottom of the dashboard below the content grid when `data.Metrics` is non-empty.

## Implementation Steps

### Step 1: Scaffold both components with parameters, null guards, and empty containers

Create all four files with foundational structure.

**`Components/MetricsBar.razor`:**
```razor
@if (Metrics is not null && Metrics.Count > 0)
{
    <div class="metrics-bar">
        @foreach (var metric in Metrics)
        {
            <MetricBadge Metric="@metric" />
        }
    </div>
}

@code {
    [Parameter]
    public List<KeyMetric>? Metrics { get; set; }
}
```

**`Components/MetricsBar.razor.css`:**
```css
.metrics-bar {
    display: flex;
    justify-content: space-evenly;
    align-items: stretch;
    gap: 12px;
    padding: 0;
    margin-top: 12px;
    background-color: var(--bg-page, #f4f6f9);
    width: 100%;
    box-sizing: border-box;
}
```

**`Components/MetricBadge.razor`:**
```razor
@if (Metric is not null)
{
    <div class="metric-badge">
        @* Label, value, trend go here *@
    </div>
}

@code {
    [Parameter]
    public KeyMetric? Metric { get; set; }
}
```

**`Components/MetricBadge.razor.css`:**
```css
.metric-badge {
    flex: 1;
    display: flex;
    flex-direction: column;
    align-items: center;
    justify-content: center;
    padding: 14px 12px;
    background-color: var(--bg-card, #ffffff);
    border-radius: 8px;
    box-shadow: var(--shadow-card, 0 1px 3px rgba(0, 0, 0, 0.08));
    text-align: center;
    box-sizing: border-box;
    min-width: 0;
}
```

**Commit message:** `feat: scaffold MetricsBar and MetricBadge components with layout containers`

**Verification:** `dotnet build` succeeds. MetricsBar renders an evenly-spaced row of empty badge cards when passed a non-empty metric list. Renders nothing for null/empty.

### Step 2: Implement MetricBadge label and value display

Fill in the MetricBadge card with the label and value elements.

**Update `Components/MetricBadge.razor` markup:**
```razor
@if (Metric is not null)
{
    <div class="metric-badge">
        @if (!string.IsNullOrWhiteSpace(Metric.Label))
        {
            <span class="metric-label">@Metric.Label</span>
        }
        <span class="metric-value">@(Metric.Value ?? "—")</span>
    </div>
}
```

**Add to `Components/MetricBadge.razor.css`:**
```css
.metric-label {
    font-size: var(--font-size-small, 11px);
    font-weight: 500;
    color: var(--text-secondary, #6c757d);
    text-transform: uppercase;
    letter-spacing: 0.5px;
    line-height: 1.3;
    margin-bottom: 4px;
    background-color: var(--bg-card, #ffffff);
}

.metric-value {
    font-size: 22px;
    font-weight: 700;
    color: var(--text-primary, #212529);
    line-height: 1.2;
    background-color: var(--bg-card, #ffffff);
    white-space: nowrap;
}
```

**Design decisions:**
- The value font size is 22px — above the 20px minimum for screenshot legibility and large enough to be the visual anchor of each badge.
- `white-space: nowrap` on the value prevents wrapping for strings like "2.1%" or "42 pts".
- The label uses `text-transform: uppercase` and `letter-spacing: 0.5px` to create a small-caps look that visually distinguishes labels from values. This is a common dashboard pattern that communicates hierarchy (small muted label → large bold value).
- Null value renders a dash (`"—"`) rather than an empty space, so the badge layout doesn't collapse.
- Null or empty label is simply omitted — the badge still renders value and trend.

**Commit message:** `feat: implement MetricBadge label and value display with typography`

**Verification:** `dotnet build` succeeds. Each badge shows the label in small muted uppercase above, and the value in large bold text below. Layout is vertically centered within the card.

### Step 3: Implement CSS-only trend indicator arrows with fallback logic

Add the trend indicator below the value, using the CSS border-trick for triangles and a simple rectangle for the stable dash.

**Update `Components/MetricBadge.razor` — add trend indicator after the value span:**
```razor
@if (Metric is not null)
{
    <div class="metric-badge">
        @if (!string.IsNullOrWhiteSpace(Metric.Label))
        {
            <span class="metric-label">@Metric.Label</span>
        }
        <span class="metric-value">@(Metric.Value ?? "—")</span>
        <div class="trend-indicator">
            <span class="trend-arrow @GetTrendClass(Metric.Trend)"></span>
            <span class="trend-text @GetTrendClass(Metric.Trend)-text">@GetTrendLabel(Metric.Trend)</span>
        </div>
    </div>
}
```

**Add to the `@code` block:**
```csharp
@code {
    [Parameter]
    public KeyMetric? Metric { get; set; }

    private static string GetTrendClass(string? trend) => trend?.ToLowerInvariant() switch
    {
        "up" => "trend-up",
        "down" => "trend-down",
        "stable" => "trend-stable",
        _ => "trend-stable"
    };

    private static string GetTrendLabel(string? trend) => trend?.ToLowerInvariant() switch
    {
        "up" => "Up",
        "down" => "Down",
        "stable" => "Stable",
        _ => "Stable"
    };
}
```

**CSS rules for trend indicators — add to `Components/MetricBadge.razor.css`:**
```css
.trend-indicator {
    display: flex;
    align-items: center;
    justify-content: center;
    gap: 4px;
    margin-top: 6px;
    background-color: var(--bg-card, #ffffff);
}

.trend-arrow {
    display: inline-block;
    width: 0;
    height: 0;
    background-color: transparent;
}

/* Up arrow: green upward-pointing triangle */
.trend-up {
    border-left: 5px solid transparent;
    border-right: 5px solid transparent;
    border-bottom: 7px solid var(--status-shipped, #28a745);
}

/* Down arrow: red downward-pointing triangle */
.trend-down {
    border-left: 5px solid transparent;
    border-right: 5px solid transparent;
    border-top: 7px solid var(--status-off-track, #dc3545);
}

/* Stable: gray horizontal dash */
.trend-stable {
    width: 12px;
    height: 3px;
    background-color: var(--text-secondary, #6c757d);
    border: none;
}

.trend-text {
    font-size: 10px;
    font-weight: 600;
    letter-spacing: 0.3px;
    background-color: var(--bg-card, #ffffff);
}

.trend-up-text {
    color: var(--status-shipped, #28a745);
}

.trend-down-text {
    color: var(--status-off-track, #dc3545);
}

.trend-stable-text {
    color: var(--text-secondary, #6c757d);
}
```

**Design decisions:**
- The CSS border-trick creates triangles without any images or icon dependencies. An upward triangle uses `border-bottom` to form the visible colored face while `border-left` and `border-right` are transparent to form the angled sides. Downward is the inverse using `border-top`.
- The `trend-stable` class overrides the zero width/height triangle defaults with `width: 12px; height: 3px` to form a horizontal dash rectangle.
- A small text label ("Up", "Down", "Stable") is rendered next to the arrow. This ensures the trend is communicated in black-and-white printing scenarios where the green/red colors are lost. The text is 10px — small enough not to dominate, large enough to be readable.
- The `.trend-arrow` base class sets `background-color: transparent` because the triangle shapes are created by border rendering, not background fill. This is the one case where transparent is correct — the element has zero intrinsic dimensions (for triangles) and the visual is entirely from borders.
- Unknown or null trend values map to "stable" (gray dash), matching the architecture spec's fallback behavior.

**Commit message:** `feat: implement CSS-only trend arrows with color coding and text labels`

**Verification:** `dotnet build` succeeds. Each badge shows the trend arrow below the value: green up-triangle for "up", red down-triangle for "down", gray dash for "stable". Test by changing trend values in `data.json`.

### Step 4: Edge case handling, responsive badge sizing, and screenshot verification

Address remaining edge cases and ensure the metrics bar looks correct at various metric counts.

**Edge cases to handle:**

1. **Single metric** — the badge should not stretch to fill the entire row width. Add `max-width: 200px` to `.metric-badge` to cap individual badge width, with `flex: 1` still distributing available space evenly.

2. **Many metrics (7+)** — badges may become too narrow to display values legibly. The flexbox `gap: 12px` keeps minimum spacing. At 7+ metrics in 1280px, each badge gets ~160px which is still legible at 22px font. Beyond 8, values may start to overlap — this is an acceptable limitation documented in the sample `data.json` (recommended: 3–6 metrics).

3. **Very long value string** (e.g., "1,234,567 story points") — the `white-space: nowrap` prevents wrapping but the text may overflow the badge. Add `overflow: hidden; text-overflow: ellipsis;` to `.metric-value` as a safety net, though realistic values ("42 pts", "85%") are always short.

4. **Very long label** — allow natural wrapping for labels since they are already small. No `white-space: nowrap` on `.metric-label`.

5. **Null metric in the list** — the MetricBadge null guard handles this. A null entry in the list simply produces no badge, and the remaining badges redistribute evenly.

6. **All fields null/empty on a KeyMetric** — the badge renders with a dash for value and "Stable" for trend. Label is hidden. Acceptable minimal rendering.

**Additional CSS polish for `MetricsBar.razor.css`:**
```css
.metrics-bar {
    /* Existing rules plus: */
    flex-wrap: nowrap;
    overflow: hidden;
}
```

**Additional safety for `MetricBadge.razor.css`:**
```css
.metric-badge {
    /* Add: */
    max-width: 220px;
}

.metric-value {
    /* Add: */
    overflow: hidden;
    text-overflow: ellipsis;
    max-width: 100%;
}
```

**Screenshot verification checklist:**
- Metrics bar spans the full dashboard width below the content grid.
- Badges are evenly distributed with consistent gaps.
- Labels are small, muted, and uppercase above each value.
- Values are large, bold, and legible at screenshot resolution.
- Green up-arrow, red down-arrow, and gray dash all render correctly.
- Trend text labels are visible for black-and-white print legibility.
- No transparent backgrounds — all badge backgrounds are white card color.
- No animations, no transitions, no hover effects.
- At 1280x900 with 3–4 metrics (standard load), the bar sits comfortably at the bottom of the dashboard without overflow.
- The bar is visually distinct from the work item cards above (centered layout, no left-border color, compact shape).

**Commit message:** `feat: finalize MetricsBar edge cases and screenshot polish`

**Verification:** `dotnet build` succeeds. Full visual check at 1280x900 with sample data. Metrics bar is the correct visual footer anchoring the bottom of the dashboard.

## Testing

### Manual Verification

| # | Scenario | Steps | Expected Result |
|---|----------|-------|-----------------|
| 1 | **Standard rendering** | Load dashboard with sample data (3–4 metrics) | Horizontal row of badges with labels, values, and trend arrows |
| 2 | **Empty list** | Set `metrics` to `[]` in data.json | No metrics bar rendered — no empty row |
| 3 | **Null list** | Remove `metrics` key from data.json | No metrics bar rendered. No crash. |
| 4 | **Single metric** | Set `metrics` to one item | One centered badge, max-width capped, no layout break |
| 5 | **Six metrics** | Set `metrics` to six items | Six evenly-spaced badges fitting within 1280px |
| 6 | **Trend: up** | Metric with `"trend": "up"` | Green upward triangle + "Up" text label |
| 7 | **Trend: down** | Metric with `"trend": "down"` | Red downward triangle + "Down" text label |
| 8 | **Trend: stable** | Metric with `"trend": "stable"` | Gray horizontal dash + "Stable" text label |
| 9 | **Trend: unknown** | Metric with `"trend": "improving"` | Gray dash + "Stable" text (fallback) |
| 10 | **Trend: null** | Metric with `"trend": null` or missing | Gray dash + "Stable" text (fallback) |
| 11 | **Null value** | Metric with `"value": null` | Badge shows "—" dash in value position |
| 12 | **Empty label** | Metric with `"label": ""` | Label is omitted. Value and trend still display. |
| 13 | **Long value** | Metric with `"value": "1,234,567 story points"` | Value truncates with ellipsis if it overflows badge width |
| 14 | **Screenshot at 1280x900** | Browser at 1280x900, capture screenshot | Metrics bar at bottom, all values legible, trend arrows visible |
| 15 | **Auto-refresh** | Change a metric value in data.json and save | Badge value updates within 5 seconds |
| 16 | **Print mode** | Navigate to `?print=true` | Metrics bar renders with explicit backgrounds, no artifacts |

### Recommended Unit Tests (bUnit + xUnit)

| Test | What It Verifies |
|------|-----------------|
| **MetricsBar: null renders nothing** | `Metrics = null` → no `.metrics-bar` element |
| **MetricsBar: empty list renders nothing** | `Metrics = []` → no `.metrics-bar` element |
| **MetricsBar: correct badge count** | 4 metrics → 4 `.metric-badge` elements |
| **MetricsBar: single metric renders** | 1 metric → 1 `.metric-badge` element |
| **MetricBadge: null renders nothing** | `Metric = null` → no `.metric-badge` element |
| **MetricBadge: label rendered** | Metric with label "Velocity" → `.metric-label` contains "Velocity" |
| **MetricBadge: empty label hidden** | Metric with null label → no `.metric-label` element |
| **MetricBadge: value rendered** | Metric with value "42 pts" → `.metric-value` contains "42 pts" |
| **MetricBadge: null value shows dash** | Metric with null value → `.metric-value` contains "—" |
| **MetricBadge: trend up class** | Trend "up" → `.trend-arrow` has class `trend-up` |
| **MetricBadge: trend down class** | Trend "down" → `.trend-arrow` has class `trend-down` |
| **MetricBadge: trend stable class** | Trend "stable" → `.trend-arrow` has class `trend-stable` |
| **MetricBadge: unknown trend fallback** | Trend "improving" → `.trend-arrow` has class `trend-stable` |
| **MetricBadge: null trend fallback** | Trend null → `.trend-arrow` has class `trend-stable` |
| **MetricBadge: trend up text** | Trend "up" → `.trend-text` contains "Up" |
| **MetricBadge: trend down text** | Trend "down" → `.trend-text` contains "Down" |
| **MetricBadge: trend stable text** | Trend "stable" → `.trend-text` contains "Stable" |
| **MetricBadge: value string rendered as-is** | Value "2.1%" → `.metric-value` contains exact string "2.1%" (no parsing/reformatting) |
| **MetricsBar: badges in source order** | Metrics ["A", "B", "C"] → three badges with labels in order A, B, C |

## References
- Architecture: Architecture.md
- PM Spec: 

## Status
- [ ] Implementation
- [ ] Tests Written
- [ ] Ready for Review