### PR TITLE
PrincipalEngineer: Shipped Items Section Component

### DIFF
--- a/.agentsquad/shipped-items-section-component.task
+++ b/.agentsquad/shipped-items-section-component.task
@@ -1,0 +1,4 @@
+agent: PrincipalEngineer
+task: Shipped Items Section Component
+complexity: Medium
+status: in-progress

--- a/src/ReportingDashboard/Components/Sections/ShippedItems.razor
+++ b/src/ReportingDashboard/Components/Sections/ShippedItems.razor
@@ -7,6 +7,31 @@
             <h2>Shipped</h2>
             <span class="item-count">@SafeItems.Count</span>
         </div>
+
+        @foreach (var item in SafeItems)
+        {
+            <div class="work-item-card completed">
+                <div class="card-header">
+                    <h3>@item.Title</h3>
+                    @if (!string.IsNullOrEmpty(item.Category))
+                    {
+                        <span class="category-tag">@item.Category</span>
+                    }
+                </div>
+                @if (!string.IsNullOrEmpty(item.Description))
+                {
+                    <div class="card-body">
+                        <p>@item.Description</p>
+                    </div>
+                }
+                <div class="card-footer">
+                    <div class="progress-bar">
+                        <div class="progress-fill" style="width: 100%"></div>
+                    </div>
+                    <span class="progress-label">✓ 100%</span>
+                </div>
+            </div>
+        }
     </section>
 }
 

--- a/src/ReportingDashboard/Components/Sections/ShippedItems.razor
+++ b/src/ReportingDashboard/Components/Sections/ShippedItems.razor
@@ -1,16 +1,18 @@
-<section class="shipped-items">
-    <!-- Full implementation in T5 -->
-    @if (Items.Count > 0)
-    {
-        <h2>Shipped <span class="item-count">@Items.Count</span></h2>
-        @foreach (var item in Items)
-        {
-            <div class="work-item-stub">@item.Title</div>
-        }
-    }
-</section>
+@using ReportingDashboard.Models
+
+@if (SafeItems.Count > 0)
+{
+    <section class="dashboard-section shipped-section">
+        <div class="section-header">
+            <h2>Shipped</h2>
+            <span class="item-count">@SafeItems.Count</span>
+        </div>
+    </section>
+}
 
 @code {
     [Parameter]
-    public List<WorkItem> Items { get; set; } = [];
+    public List<WorkItem>? Items { get; set; }
+
+    private List<WorkItem> SafeItems => Items ?? [];
 }


### PR DESCRIPTION
## Task Assignment
**Assigned To:** PrincipalEngineer
**Complexity:** Medium
**Branch:** `agent/principalengineer/t5-shipped-items-section-component`

## Requirements
Closes #461

# PR: Shipped Items Section Component

## Summary

This PR implements the `ShippedItems.razor` Blazor component that renders a "Shipped" section displaying all completed/shipped work items for the current reporting period. The component receives a `List<WorkItem>` parameter from the parent `Dashboard.razor` page and renders each item as a card with a green left border (`4px solid #2E7D32` via `--status-completed`), item title, description, optional category tag badge, and a 100% completion progress bar. The section includes an h2 heading with an item count badge. When the list is empty or null, the section is hidden gracefully. All content is statically visible (no hover states or tooltips) for screenshot capture at 1200px width. Zero JavaScript — pure Blazor Server rendering using CSS classes defined in the CSS Architecture PR (#458).

**Depends on:** #457 (T1 — Project Foundation, which creates the stub `ShippedItems.razor` with the `Items` parameter and the `WorkItem` model)
**Depends on:** #458 (T2 — CSS Architecture, which creates `.work-item-card`, `.completed`, `.progress-bar`, `.progress-fill`, `.category-tag`, `.section-header`, `.item-count` CSS classes)
**Closes:** #461, #449

## Acceptance Criteria

- [ ] A "Shipped" section renders with an h2 heading reading "Shipped" and a count badge showing the number of items.
- [ ] Each shipped `WorkItem` is rendered as a card with a green left border (`border-left: 4px solid var(--status-completed)`).
- [ ] Each card displays the item's title in bold, description as body text, and an optional category tag badge.
- [ ] Each card displays a 100% completion progress bar (full green fill) since all shipped items are complete.
- [ ] Items are rendered in the order they appear in the `Items` list (no re-sorting).
- [ ] When the `Items` list is empty or null, the entire section is hidden — no empty box, no heading, no broken layout.
- [ ] Category tags are rendered as inline pill badges; items without a `Category` value show no badge (not "N/A" or empty badge).
- [ ] No information is hidden behind hover states or tooltips — all content is statically visible for screenshot capture.
- [ ] The component uses the `WorkItem` record from `ReportingDashboard.Models` — it does not redefine or duplicate the model.
- [ ] The section is visually separated from adjacent sections with appropriate spacing.
- [ ] `dotnet build` completes with zero errors and zero warnings after this change.

## Implementation Steps

### Step 1: Replace the stub with the component skeleton, parameter, and empty-state guard

Replace the contents of the existing stub `src/ReportingDashboard/Components/Sections/ShippedItems.razor` (created by T1) with the full component structure. Define the `[Parameter] public List<WorkItem> Items` property with a default empty list, add a null-coalescing computed property `private List<WorkItem> SafeItems => Items ?? [];`, wrap all markup in `@if (SafeItems.Count > 0)` guard, and render the outer `<section class="dashboard-section shipped-section">` with a section header containing `<h2>Shipped</h2>` and `<span class="item-count">@SafeItems.Count</span>`.

**Produces:** A component that renders the section heading with count when items exist, and renders nothing when items are empty/null. Builds with zero errors.

### Step 2: Implement the work item card rendering with title, description, category, and progress bar

Inside the section, add a `@foreach (var item in SafeItems)` loop that renders each work item as a `<div class="work-item-card completed">` containing: a `.card-header` with the item title in an `<h3>` and an optional category badge `<span class="category-tag">@item.Category</span>` (rendered only when `Category` is non-null/non-empty), a `.card-body` with the description paragraph, and a `.card-footer` with a progress bar at 100% — `<div class="progress-bar"><div class="progress-fill" style="width: 100%"></div></div>` with a `<span class="progress-label">100%</span>`.

**Produces:** Full card rendering for each shipped item with green border, title, description, category tag, and filled progress bar. All CSS classes come from the existing `dashboard.css` (T2).

### Step 3: Polish edge cases and verify build

Ensure graceful handling of all optional fields: `Description` renders only when non-empty (otherwise omit the paragraph, don't show blank space), `Category` badge omitted when null/empty. Add a "Complete" status indicator text or checkmark (✓) next to the progress bar for screenshot clarity. Verify the component integrates with `Dashboard.razor` (which passes `data.Shipped` to the `Items` parameter) and confirm `dotnet build` produces zero errors and zero warnings.

**Produces:** Final polished component with all edge cases handled, ready for visual testing.

## Testing

Testing is manual/visual per the project's testing strategy:

1. **Build verification**: `dotnet build` completes with zero errors and zero warnings.
2. **Happy path (3-5 items)**: Load sample "Project Atlas" data with 3-5 shipped items. Verify each card shows a green left border, title in bold, description text, category badge (where present), and a full green progress bar reading "100%".
3. **Zero items**: Set `shipped` to `[]` in `data.json`. Verify the entire section disappears — no heading, no empty container, no extra whitespace.
4. **Null items**: Remove the `shipped` key entirely from `data.json`. Verify no crash, section hidden gracefully.
5. **Missing optional fields**: Test items with `category` omitted — verify no badge renders, no empty pill. Test items with `description` omitted — verify no empty paragraph.
6. **Single item**: Set `shipped` to contain exactly 1 item. Verify the section renders correctly with heading showing count "1".
7. **Long content**: Test with a long title (50+ chars) and long description (200+ chars). Verify text wraps within the card without overflow at 1200px width.
8. **Screenshot test**: Take a full-page screenshot at 1200px width in Chrome. The shipped section should be clearly visible with green borders, readable text, and no clipped or overlapping elements.
9. **Print test**: Ctrl+P in Chrome. Verify the shipped section renders cleanly without page breaks splitting individual cards.

## References
- Architecture: Architecture.md
- PM Spec: 

## Status
- [ ] Implementation
- [ ] Tests Written
- [ ] Ready for Review