### PR TITLE
PrincipalEngineer: In-Progress Items with Progress Bars Component

### DIFF
--- a/.agentsquad/in-progress-items-with-progress-bars-component.task
+++ b/.agentsquad/in-progress-items-with-progress-bars-component.task
@@ -1,0 +1,4 @@
+agent: PrincipalEngineer
+task: In-Progress Items with Progress Bars Component
+complexity: Medium
+status: in-progress

--- a/src/ReportingDashboard/Components/Sections/InProgressItems.razor
+++ b/src/ReportingDashboard/Components/Sections/InProgressItems.razor
@@ -25,7 +25,7 @@
                     </div>
                 }
                 <div class="card-footer">
-                    <div class="progress-bar">
+                    <div class="progress-track">
                         <div class="progress-fill" style="width: @(GetPercent(item))%"></div>
                     </div>
                     <span class="progress-label">@(GetPercent(item))%</span>

--- a/src/ReportingDashboard/Components/Sections/InProgressItems.razor
+++ b/src/ReportingDashboard/Components/Sections/InProgressItems.razor
@@ -8,7 +8,24 @@
             <span class="item-count">@SafeItems.Count</span>
         </div>
 
-        @* Card rendering added in Step 2; progress bars in Step 3 *@
+        @foreach (var item in SafeItems)
+        {
+            <div class="work-item-card in-progress">
+                <div class="card-header">
+                    <h3>@item.Title</h3>
+                    @if (!string.IsNullOrWhiteSpace(item.Category))
+                    {
+                        <span class="category-tag">@item.Category</span>
+                    }
+                </div>
+                @if (!string.IsNullOrWhiteSpace(item.Description))
+                {
+                    <div class="card-body">
+                        <p>@item.Description</p>
+                    </div>
+                }
+            </div>
+        }
     </section>
 }
 

--- a/src/ReportingDashboard/Components/Sections/InProgressItems.razor
+++ b/src/ReportingDashboard/Components/Sections/InProgressItems.razor
@@ -24,6 +24,12 @@
                         <p>@item.Description</p>
                     </div>
                 }
+                <div class="card-footer">
+                    <div class="progress-bar">
+                        <div class="progress-fill" style="width: @(GetPercent(item))%"></div>
+                    </div>
+                    <span class="progress-label">@(GetPercent(item))%</span>
+                </div>
             </div>
         }
     </section>

--- a/src/ReportingDashboard/Components/Sections/InProgressItems.razor
+++ b/src/ReportingDashboard/Components/Sections/InProgressItems.razor
@@ -1,16 +1,22 @@
-<section class="in-progress-items">
-    <!-- Full implementation in T6 -->
-    @if (Items.Count > 0)
-    {
-        <h2>In Progress <span class="item-count">@Items.Count</span></h2>
-        @foreach (var item in Items)
-        {
-            <div class="work-item-stub">@item.Title — @(item.PercentComplete ?? 0)%</div>
-        }
-    }
-</section>
+@using ReportingDashboard.Models
+
+@if (SafeItems.Count > 0)
+{
+    <section class="dashboard-section in-progress-section">
+        <div class="section-header">
+            <h2>In Progress</h2>
+            <span class="item-count">@SafeItems.Count</span>
+        </div>
+
+        @* Card rendering added in Step 2; progress bars in Step 3 *@
+    </section>
+}
 
 @code {
     [Parameter]
-    public List<WorkItem> Items { get; set; } = [];
+    public List<WorkItem>? Items { get; set; }
+
+    private List<WorkItem> SafeItems => Items ?? [];
+
+    private int GetPercent(WorkItem item) => Math.Clamp(item.PercentComplete ?? 0, 0, 100);
 }


### PR DESCRIPTION
## Task Assignment
**Assigned To:** PrincipalEngineer
**Complexity:** Medium
**Branch:** `agent/principalengineer/t6-in-progress-items-with-progress-bars-component`

## Requirements
Closes #462

# PR: In-Progress Items with Progress Bars Component

## Summary

This PR implements the `InProgressItems.razor` Blazor component that renders an "In Progress" section displaying all currently active work items with visual progress bars. The component receives a `List<WorkItem>` parameter from the parent `Dashboard.razor` page and renders each item as a card with a blue left border (`4px solid #1565C0` via `--status-in-progress`), item title, description, optional category tag badge, and a pure CSS progress bar whose fill width is bound to the item's `PercentComplete` value. The section includes an h2 heading with an item count badge. When the list is empty or null, the section is hidden gracefully. Progress bars handle edge cases: 0% renders an empty track with "0%" label, 100% renders a fully filled green bar, and null `PercentComplete` defaults to 0%. All content is statically visible (no hover states or tooltips) for screenshot capture at 1200px width. Zero JavaScript — pure Blazor Server rendering using CSS classes defined in the CSS Architecture PR (#458).

**Depends on:** #457 (T1 — Project Foundation, which creates the stub `InProgressItems.razor` with the `Items` parameter and the `WorkItem` model)
**Depends on:** #458 (T2 — CSS Architecture, which creates `.work-item-card`, `.in-progress`, `.progress-bar`, `.progress-fill`, `.category-tag`, `.section-header`, `.item-count` CSS classes)
**Closes:** #462, #450

## Acceptance Criteria

- [ ] An "In Progress" section renders with an h2 heading reading "In Progress" and a count badge showing the number of items.
- [ ] Each in-progress `WorkItem` is rendered as a card with a blue left border (`border-left: 4px solid var(--status-in-progress)`).
- [ ] Each card displays the item's title in bold, description as body text, and an optional category tag badge.
- [ ] Each card displays a CSS progress bar whose inner fill width is set to `PercentComplete`% via inline `style="width: {value}%"`.
- [ ] A percentage text label (e.g., "65%") is displayed adjacent to or within the progress bar.
- [ ] Progress bars render proportionally: 65% fills 65% of the bar track width using pure CSS (no JavaScript).
- [ ] Items are rendered in the order they appear in the `Items` list (no re-sorting).
- [ ] When `PercentComplete` is `null`, the progress bar defaults to 0% (empty track, "0%" label).
- [ ] When `PercentComplete` is `0`, the progress bar renders as an empty track with "0%" label — no invisible or broken bar.
- [ ] When `PercentComplete` is `100`, the progress bar renders fully filled with "100%" label — visually distinct as nearly complete.
- [ ] When the `Items` list is empty or null, the entire section is hidden — no heading, no empty container, no broken layout.
- [ ] Category tags are rendered as inline pill badges; items without a `Category` value show no badge (not "N/A" or empty pill).
- [ ] No information is hidden behind hover states or tooltips — all content is statically visible for screenshot capture.
- [ ] The component uses the `WorkItem` record from `ReportingDashboard.Models` — it does not redefine or duplicate the model.
- [ ] The section is visually separated from adjacent sections with appropriate spacing.
- [ ] `dotnet build` completes with zero errors and zero warnings after this change.

## Implementation Steps

### Step 1: Replace the stub with the component skeleton, parameter, and empty-state guard

Replace the contents of the existing stub `src/ReportingDashboard/Components/Sections/InProgressItems.razor` (created by T1) with the full component structure. Define the `[Parameter] public List<WorkItem>? Items { get; set; }` property, add a computed property `private List<WorkItem> SafeItems => Items ?? [];`, and a helper method `private int GetPercent(WorkItem item) => item.PercentComplete ?? 0;` that coalesces null to 0. Wrap all markup in `@if (SafeItems.Count > 0)` guard. Render the outer `<section class="dashboard-section in-progress-section">` with a section header containing `<h2>In Progress</h2>` and `<span class="item-count">@SafeItems.Count</span>`. Add the `@using ReportingDashboard.Models` directive at the top.

**Produces:** A component that renders the section heading with count when items exist, and renders nothing when items are empty/null. Builds with zero errors.

### Step 2: Implement the work item card rendering with title, description, and category tag

Inside the section, add a `@foreach (var item in SafeItems)` loop that renders each work item as a `<div class="work-item-card in-progress">`. Inside each card: a `.card-header` containing the item title in an `<h3>` and an optional category badge `<span class="category-tag">@item.Category</span>` rendered only when `!string.IsNullOrWhiteSpace(item.Category)`. Below the header, a `.card-body` containing the description in a `<p>` tag, rendered only when `!string.IsNullOrWhiteSpace(item.Description)`. This step does not yet include the progress bar.

**Produces:** Card rendering for each in-progress item with blue border, title, description, and category tag. All CSS classes come from the existing `dashboard.css` (T2). Builds with zero errors.

### Step 3: Add the pure CSS progress bar with percentage binding and edge case handling

Inside each card's `.card-footer`, add the progress bar markup: `<div class="progress-bar"><div class="progress-fill" style="width: @(GetPercent(item))%"></div></div>` paired with a `<span class="progress-label">@(GetPercent(item))%</span>`. The `GetPercent` helper ensures null values render as 0. For visual clarity at 0%, the progress track (outer div) always renders with its background color and border so the user sees an empty track rather than nothing. At 100%, the fill spans the full width. Clamp the display value between 0 and 100 by updating `GetPercent` to `Math.Clamp(item.PercentComplete ?? 0, 0, 100)` to guard against out-of-range values in `data.json`.

**Produces:** Complete progress bar with proportional fill, percentage label, and robust handling of null/0/100/out-of-range values.

### Step 4: Polish edge cases and verify build

Verify all edge cases are handled: items with no `Description` render no empty paragraph, items with no `Category` render no empty badge, items with `PercentComplete` of null/0/50/100/negative/over-100 all render correctly. Ensure the progress bar fill transitions smoothly (no CSS transition needed — static rendering for screenshots). Confirm the component integrates with `Dashboard.razor` (which passes `data.InProgress` to the `Items` parameter). Run `dotnet build` and verify zero errors and zero warnings.

**Produces:** Final polished component with all edge cases handled, ready for visual testing and integration.

## Testing

Testing is manual/visual per the project's testing strategy:

1. **Build verification**: `dotnet build` completes with zero errors and zero warnings.
2. **Happy path (3-5 items with varied percentages)**: Load sample "Project Atlas" data with items at 0%, 25%, 50%, 75%, and 100%. Verify each card shows a blue left border, title in bold, description text, category badge (where present), and a proportionally filled progress bar with correct percentage label.
3. **Zero-percent item**: Include an item with `"percentComplete": 0`. Verify the progress track is visible (background color showing), the fill is absent or zero-width, and the label reads "0%".
4. **Hundred-percent item**: Include an item with `"percentComplete": 100`. Verify the progress bar is fully filled and the label reads "100%".
5. **Null percent item**: Include an item with no `percentComplete` field in JSON. Verify it defaults to 0% — empty track, "0%" label, no crash.
6. **Out-of-range values**: Test with `"percentComplete": -10` and `"percentComplete": 150`. Verify clamping to 0% and 100% respectively — no overflow or broken layout.
7. **Zero items**: Set `inProgress` to `[]` in `data.json`. Verify the entire section disappears — no heading, no empty container, no extra whitespace.
8. **Null items**: Remove the `inProgress` key entirely from `data.json`. Verify no crash, section hidden gracefully.
9. **Missing optional fields**: Test items with `category` omitted — verify no badge renders. Test items with `description` omitted — verify no empty paragraph.
10. **Single item**: Set `inProgress` to contain exactly 1 item. Verify the section renders correctly with heading showing count "1".
11. **Long content**: Test with a long title (50+ chars) and long description (200+ chars). Verify text wraps within the card without overflow at 1200px width.
12. **Screenshot test**: Take a full-page screenshot at 1200px width in Chrome. The in-progress section should be clearly visible with blue borders, readable progress bars at correct widths, and no clipped or overlapping elements.
13. **Print test**: Ctrl+P in Chrome. Verify the in-progress section renders cleanly, progress bars are visible in print output, and no page breaks split individual cards.

## References
- Architecture: Architecture.md
- PM Spec: 

## Status
- [ ] Implementation
- [ ] Tests Written
- [ ] Ready for Review