### PR TITLE
PrincipalEngineer: Monthly Summary Metrics Component

### DIFF
--- a/.agentsquad/monthly-summary-metrics-component.task
+++ b/.agentsquad/monthly-summary-metrics-component.task
@@ -1,0 +1,4 @@
+agent: PrincipalEngineer
+task: Monthly Summary Metrics Component
+complexity: Medium
+status: in-progress

--- a/src/ReportingDashboard/Components/Sections/MonthlySummary.razor
+++ b/src/ReportingDashboard/Components/Sections/MonthlySummary.razor
@@ -1,28 +1,21 @@
-<section class="monthly-summary">
-    @if (CurrentMonth is not null)
-    {
-        <div class="metrics-strip">
-            <div class="metric-card">
-                <span class="metric-value">@CurrentMonth.TotalItems</span>
-                <span class="metric-label">Total Items</span>
-            </div>
-            <div class="metric-card">
-                <span class="metric-value">@CurrentMonth.CompletedItems</span>
-                <span class="metric-label">Completed</span>
-            </div>
-            <div class="metric-card">
-                <span class="metric-value">@CurrentMonth.CarriedItems</span>
-                <span class="metric-label">Carried Over</span>
-            </div>
-            <div class="metric-card health-@(CurrentMonth.OverallHealth ?? "unknown")">
-                <span class="metric-value">@(CurrentMonth.OverallHealth ?? "N/A")</span>
-                <span class="metric-label">Overall Health</span>
-            </div>
-        </div>
-    }
-</section>
+@namespace ReportingDashboard.Components.Sections
+@using ReportingDashboard.Models
+
+@if (Summary is not null)
+{
+    <section class="section">
+        @if (!string.IsNullOrWhiteSpace(Summary.Month))
+        {
+            <h2>Monthly Summary — @Summary.Month</h2>
+        }
+        else
+        {
+            <h2>Monthly Summary</h2>
+        }
+    </section>
+}
 
 @code {
     [Parameter]
-    public MonthSummary? CurrentMonth { get; set; }
+    public MonthSummary? Summary { get; set; }
 }

--- a/src/ReportingDashboard/Components/Sections/MonthlySummary.razor
+++ b/src/ReportingDashboard/Components/Sections/MonthlySummary.razor
@@ -12,10 +12,46 @@
         {
             <h2>Monthly Summary</h2>
         }
+
+        <div class="metrics-grid">
+            <div class="metric-card">
+                <span class="metric-value">@Summary.TotalItems</span>
+                <span class="metric-label">Total Items</span>
+            </div>
+            <div class="metric-card">
+                <span class="metric-value">@Summary.CompletedItems</span>
+                <span class="metric-label">Completed</span>
+            </div>
+            <div class="metric-card">
+                <span class="metric-value">@Summary.CarriedItems</span>
+                <span class="metric-label">Carried Over</span>
+            </div>
+            <div class="metric-card">
+                <span class="metric-value @GetHealthCssClass(Summary.OverallHealth)">@FormatHealth(Summary.OverallHealth)</span>
+                <span class="metric-label">Overall Health</span>
+            </div>
+        </div>
     </section>
 }
 
 @code {
     [Parameter]
     public MonthSummary? Summary { get; set; }
+
+    private static string GetHealthCssClass(string? health) => health switch
+    {
+        "on-track" => "health-on-track",
+        "at-risk" => "health-at-risk",
+        "behind" => "health-behind",
+        _ => ""
+    };
+
+    private static string FormatHealth(string? health) => health switch
+    {
+        "on-track" => "On Track",
+        "at-risk" => "At Risk",
+        "behind" => "Behind",
+        null => "N/A",
+        _ => char.ToUpperInvariant(health[0]) + health[1..]
+    };
 }

--- a/src/ReportingDashboard/Components/Sections/MonthlySummary.razor
+++ b/src/ReportingDashboard/Components/Sections/MonthlySummary.razor
@@ -52,6 +52,6 @@
         "at-risk" => "At Risk",
         "behind" => "Behind",
         null => "N/A",
-        _ => char.ToUpperInvariant(health[0]) + health[1..]
+        _ => string.IsNullOrEmpty(health) ? "N/A" : char.ToUpperInvariant(health[0]) + health[1..]
     };
 }


### PR DESCRIPTION
## Task Assignment
**Assigned To:** PrincipalEngineer
**Complexity:** Medium
**Branch:** `agent/principalengineer/t8-monthly-summary-metrics-component`

## Requirements
Closes #464

# PR: Monthly Summary Metrics Component

## Summary

This PR implements the `MonthlySummary.razor` Blazor component that renders a 4-card flexbox metrics strip displaying the current month's key performance indicators: Total Items, Completed Items, Carried Items, and Overall Health. The component receives a `MonthSummary?` parameter from the parent `Dashboard.razor` page. Each metric card displays a large numeric value (28px+ via `--font-size-metric`) with a descriptive label underneath. The Overall Health card renders its value as a color-coded status indicator: green for `"on-track"`, orange for `"at-risk"`, red for `"behind"`. When the `Summary` parameter is null (e.g., `currentMonth` key missing from `data.json`), the entire section is hidden gracefully — no empty cards, no broken layout. An optional month label (from `MonthSummary.Month`) renders as a section subheading when present. All styling uses CSS classes from the existing `dashboard.css` (T2): `.metrics-grid`, `.metric-card`, `.metric-value`, `.metric-label`, `.health-on-track`, `.health-at-risk`, `.health-behind`. Zero JavaScript — pure Blazor Server rendering.

**Depends on:** #457 (T1 — Project Foundation, which creates the stub `MonthlySummary.razor` with the `Summary` parameter and the `MonthSummary` model)
**Depends on:** #458 (T2 — CSS Architecture, which creates `.metrics-grid`, `.metric-card`, `.metric-value`, `.metric-label`, `.health-*` CSS classes)
**Closes:** #464, #452

## Acceptance Criteria

- [ ] A monthly summary section renders as a 4-card horizontal strip using CSS flexbox/grid (`grid-template-columns: repeat(4, 1fr)`).
- [ ] Card 1 displays `TotalItems` as a large number (28px+ font) with "Total Items" label below.
- [ ] Card 2 displays `CompletedItems` as a large number with "Completed" label below.
- [ ] Card 3 displays `CarriedItems` as a large number with "Carried Over" label below.
- [ ] Card 4 displays `OverallHealth` as a color-coded text value with "Overall Health" label below.
- [ ] Overall Health text is colored green (`--status-on-track` / `.health-on-track`) for `"on-track"`, orange (`--status-at-risk` / `.health-at-risk`) for `"at-risk"`, red (`--status-behind` / `.health-behind`) for `"behind"`, and default text color for unknown/null values.
- [ ] Numeric values are displayed using the `.metric-value` class (28px+ font, bold) and labels using `.metric-label` (13px, secondary color).
- [ ] When the `Summary` parameter is null, the entire section is hidden — no heading, no empty grid, no broken layout.
- [ ] When `OverallHealth` is null or an unrecognized value, the health card renders the raw value (or "N/A") without crashing and uses default text color (no status highlighting).
- [ ] An optional month label (e.g., "April 2026") renders as section context when `MonthSummary.Month` is non-null.
- [ ] All four cards are equal width and visually balanced at 1200px dashboard width.
- [ ] No information is hidden behind hover states or tooltips — all content statically visible for screenshot capture.
- [ ] The component uses the `MonthSummary` record from `ReportingDashboard.Models` — it does not redefine or duplicate the model.
- [ ] `dotnet build` completes with zero errors and zero warnings after this change.

## Implementation Steps

### Step 1: Replace the stub with the component skeleton, parameter, and null-guard

Replace the contents of the existing stub `src/ReportingDashboard/Components/Sections/MonthlySummary.razor` (created by T1) with the full component structure. Add the `@namespace ReportingDashboard.Components.Sections` and `@using ReportingDashboard.Models` directives. Define the `[Parameter] public MonthSummary? Summary { get; set; }` property. Wrap all markup in `@if (Summary is not null)` guard so the section renders nothing when data is missing. Render the outer `<section class="section">` with an `<h2>` heading: if `Summary.Month` is non-null, render "Monthly Summary — @Summary.Month"; otherwise render "Monthly Summary". Verify `dotnet build` succeeds.

**Produces:** A component that renders a section heading when data exists and renders nothing when null. Builds with zero errors.

### Step 2: Implement the 4-card metrics grid with numeric values and labels

Inside the section, add a `<div class="metrics-grid">` containing four `<div class="metric-card">` elements. Each card contains:
- Card 1: `<span class="metric-value">@Summary.TotalItems</span>` and `<span class="metric-label">Total Items</span>`
- Card 2: `<span class="metric-value">@Summary.CompletedItems</span>` and `<span class="metric-label">Completed</span>`
- Card 3: `<span class="metric-value">@Summary.CarriedItems</span>` and `<span class="metric-label">Carried Over</span>`
- Card 4: `<span class="metric-value @GetHealthCssClass(Summary.OverallHealth)">@FormatHealth(Summary.OverallHealth)</span>` and `<span class="metric-label">Overall Health</span>`

**Produces:** Complete 4-card metrics strip with large numbers, labels, and health status. All CSS classes from existing `dashboard.css`.

### Step 3: Add health color-coding helper methods and edge case handling

In the `@code` block, add two private helper methods:
- `GetHealthCssClass(string? health)` — returns `"health-on-track"` for `"on-track"`, `"health-at-risk"` for `"at-risk"`, `"health-behind"` for `"behind"`, and empty string `""` for null/unknown values (no color applied, falls back to default text color).
- `FormatHealth(string? health)` — returns a display-friendly string: `"on-track"` → `"On Track"`, `"at-risk"` → `"At Risk"`, `"behind"` → `"Behind"`, null → `"N/A"`, and any other value returns the raw string with `ToUpperInvariant()` on the first character for presentability.

Verify all edge cases: null health renders "N/A" in default color, unknown health value renders raw text without crash, zero numeric values display as "0" (not blank).

**Produces:** Final polished component with color-coded health status, proper null handling, and display formatting. Ready for integration and visual testing.

### Step 4: Verify integration with Dashboard.razor and end-to-end rendering

Confirm the component integrates with `Dashboard.razor` (which passes `data.CurrentMonth` to the `Summary` parameter via `<MonthlySummary Summary="@_data.CurrentMonth" />`). Verify `data.json` includes a `currentMonth` object with all fields (`month`, `totalItems`, `completedItems`, `carriedItems`, `overallHealth`). Run `dotnet build` for zero errors/warnings. The metrics strip should appear near the top of the dashboard, below the project header, providing an at-a-glance quantitative snapshot.

**Produces:** Fully integrated, visually verified component rendering in the dashboard layout.

## Testing

Testing is manual/visual per the project's testing strategy:

1. **Build verification**: `dotnet build` completes with zero errors and zero warnings.
2. **Happy path (all fields populated)**: Load sample "Project Atlas" data with `currentMonth` containing all fields. Verify 4 equal-width cards render with: "12" / Total Items, "5" / Completed, "2" / Carried Over, "On Track" (green) / Overall Health.
3. **Health: on-track**: Set `"overallHealth": "on-track"`. Verify the health value text is green (`#2E7D32`).
4. **Health: at-risk**: Set `"overallHealth": "at-risk"`. Verify the health value text is orange (`#E65100`).
5. **Health: behind**: Set `"overallHealth": "behind"`. Verify the health value text is red (`#C62828`).
6. **Health: null**: Remove the `overallHealth` key from `currentMonth`. Verify "N/A" renders in default text color — no crash, no broken layout.
7. **Health: unknown value**: Set `"overallHealth": "delayed"`. Verify "Delayed" renders in default text color — no crash.
8. **Null currentMonth**: Remove the entire `currentMonth` key from `data.json`. Verify the entire section disappears — no heading, no empty grid, no extra whitespace.
9. **Zero values**: Set all numeric fields to `0`. Verify "0" renders (not blank) in all three numeric cards.
10. **Month label present**: Set `"month": "April 2026"`. Verify heading reads "Monthly Summary — April 2026".
11. **Month label absent**: Remove the `month` key. Verify heading reads "Monthly Summary" (no dash, no "null").
12. **Large numbers**: Set `totalItems` to `999`. Verify the number fits within the card at 1200px width without overflow.
13. **Screenshot test**: Take a full-page screenshot at 1200px width in Chrome. The metrics strip should show 4 equal cards with prominent numbers, readable labels, and the health value in the correct color.
14. **Print test**: Ctrl+P in Chrome. Verify the metrics strip renders cleanly with colored health value preserved (via `print-color-adjust: exact`), no page break splitting the 4-card row.

## References
- Architecture: Architecture.md
- PM Spec: 

## Status
- [ ] Implementation
- [ ] Tests Written
- [ ] Ready for Review