### PR TITLE
PrincipalEngineer 1: Auto-Refresh on Data File Change

### DIFF
--- a/src/ReportingDashboard/Components/Pages/Dashboard.razor
+++ b/src/ReportingDashboard/Components/Pages/Dashboard.razor
@@ -1,31 +1,59 @@
 @page "/"
+@using ReportingDashboard.Models
+@using ReportingDashboard.Services
 @using Microsoft.AspNetCore.Components.Web
 @inject DashboardDataService DataService
-@rendermode RenderMode.InteractiveServer
+@implements IDisposable
+@rendermode @(new InteractiveServerRenderMode())
 
 <div class="dashboard-container">
-    @if (!string.IsNullOrEmpty(_data.ErrorMessage))
+    @if (!string.IsNullOrEmpty(data?.ErrorMessage))
     {
         <div class="error-banner">
-            <strong>⚠ Data Error:</strong> @_data.ErrorMessage
+            <h2>⚠ Unable to Load Dashboard</h2>
+            <p>@data.ErrorMessage</p>
+            <p>Check that data.json exists and contains valid JSON.</p>
         </div>
     }
-    else
+    else if (data is not null)
     {
-        <ProjectHeader Project="@_data.Project" />
-        <MonthlySummary Summary="@_data.CurrentMonth" />
-        <MilestoneTimeline Milestones="@_data.Milestones" />
-        <ShippedItems Items="@_data.Shipped" />
-        <InProgressItems Items="@_data.InProgress" />
-        <CarriedOverItems Items="@_data.CarriedOver" />
+        <ProjectHeader Project="data.Project" />
+        <MonthlySummary CurrentMonth="data.CurrentMonth" />
+        <MilestoneTimeline Milestones="data.Milestones" />
+        <ShippedItems Items="data.Shipped" />
+        <InProgressItems Items="data.InProgress" />
+        <CarriedOverItems Items="data.CarriedOver" />
     }
 </div>
 
 @code {
-    private DashboardData _data = new();
+    private DashboardData? data;
 
     protected override async Task OnInitializedAsync()
     {
-        _data = await DataService.GetDashboardDataAsync();
+        data = await DataService.GetDashboardDataAsync();
+        DataService.OnDataChanged += OnDataFileChanged;
+    }
+
+    private async void OnDataFileChanged()
+    {
+        try
+        {
+            await InvokeAsync(async () =>
+            {
+                data = await DataService.GetDashboardDataAsync();
+                StateHasChanged();
+            });
+        }
+        catch (ObjectDisposedException)
+        {
+            // Circuit disconnected between OnDataChanged firing and Dispose().
+            // Safe to ignore — the component is already torn down.
+        }
+    }
+
+    public void Dispose()
+    {
+        DataService.OnDataChanged -= OnDataFileChanged;
     }
 }


### PR DESCRIPTION
## Task Assignment
**Assigned To:** PrincipalEngineer 1
**Complexity:** Medium
**Branch:** `agent/principalengineer-1/t-465-auto-refresh-on-data-file-change`

## Requirements
Closes #465

## Auto-Refresh on Data File Change

### Summary

This PR adds live auto-refresh capability to the Reporting Dashboard by wiring a `FileSystemWatcher` into `DashboardDataService` that monitors `data.json` for changes and pushes updates to the browser via Blazor Server's SignalR circuit. When a user saves `data.json` in their editor, the dashboard re-renders within ~500ms without requiring a manual browser refresh. This eliminates the edit → save → Alt-Tab → F5 loop during report authoring, enabling a seamless live-preview workflow.

The implementation modifies two existing files: `DashboardDataService.cs` (add watcher + debounced event) and `Dashboard.razor` (subscribe to event + re-render). No new files, no new dependencies, no changes to the data model or CSS.

**Closes #465 | Parent: #456 | Depends on: #457**

---

### Acceptance Criteria

- [ ] When `data.json` is saved in a text editor, the browser-rendered dashboard updates automatically within 1 second without manual refresh.
- [ ] Rapid successive saves (e.g., Ctrl+S spam) are debounced to a single reload using a 500ms `System.Threading.Timer`.
- [ ] The `OnDataChanged` event is exposed as `public event Action? OnDataChanged` on `DashboardDataService`.
- [ ] `DashboardDataService` implements `IDisposable`, disposing the `FileSystemWatcher` and debounce `Timer`.
- [ ] `Dashboard.razor` implements `IDisposable`, unsubscribing from `OnDataChanged` in `Dispose()` to prevent memory leaks and stale circuit references.
- [ ] The initial page load (`OnInitializedAsync`) continues to work identically — data is read from `data.json` and rendered on first load with no regression.
- [ ] If `data.json` is deleted or becomes malformed while the watcher is active, the dashboard renders the error banner (existing `ErrorMessage` behavior) rather than crashing.
- [ ] The `FileSystemWatcher` monitors only the specific `data.json` file (not the entire directory tree).
- [ ] No new NuGet packages are introduced.
- [ ] `dotnet build` completes with zero errors and zero warnings.

---

### Implementation Steps

#### Step 1: Add FileSystemWatcher and debounce timer to `DashboardDataService.cs`

**File:** `src/ReportingDashboard/Services/DashboardDataService.cs`

Add the following members to the existing `DashboardDataService` class:

- A `public event Action? OnDataChanged` field.
- A private `FileSystemWatcher _watcher` initialized in the constructor, configured to monitor the resolved `data.json` path with `NotifyFilter = NotifyFilters.LastWrite` and `Filter` set to the filename only.
- A private `System.Threading.Timer _debounceTimer` used to coalesce rapid file-change events into a single `OnDataChanged` invocation.
- A private `OnFileChanged` handler wired to `_watcher.Changed` that resets the debounce timer to 500ms on each event. When the timer fires, it invokes `OnDataChanged`.
- Make the class implement `IDisposable`. In `Dispose()`, disable and dispose both `_watcher` and `_debounceTimer`.
- Set `_watcher.EnableRaisingEvents = true` at the end of the constructor to begin monitoring.

The constructor already resolves the data file path (from config or default `wwwroot/data/data.json`). Use `Path.GetDirectoryName()` and `Path.GetFileName()` from that resolved path for the watcher's `Path` and `Filter` properties.

**Produces:** A service that raises `OnDataChanged` exactly once per edit cycle (debounced), and cleanly disposes filesystem resources.

#### Step 2: Subscribe to `OnDataChanged` in `Dashboard.razor` and implement `IDisposable`

**File:** `src/ReportingDashboard/Components/Pages/Dashboard.razor`

Modify the `@code` block:

- Add `@implements IDisposable` directive to the component.
- In `OnInitializedAsync()`, after the existing `GetDashboardDataAsync()` call, subscribe to `DataService.OnDataChanged += OnDataFileChanged`.
- Add a private `async void OnDataFileChanged()` method that:
  1. Calls `await InvokeAsync(async () => { data = await DataService.GetDashboardDataAsync(); StateHasChanged(); })` to marshal the re-read and re-render onto the Blazor synchronization context.
- Add a `public void Dispose()` method that unsubscribes: `DataService.OnDataChanged -= OnDataFileChanged`.

Key detail: `InvokeAsync` is mandatory because `FileSystemWatcher` fires on a threadpool thread, not the Blazor sync context. Without it, `StateHasChanged()` will throw.

**Produces:** A dashboard page that live-updates when `data.json` changes and cleanly unsubscribes on circuit disconnect.

#### Step 3: Guard against race conditions and validate error resilience

**File:** `src/ReportingDashboard/Services/DashboardDataService.cs`

Add defensive handling in the debounce callback:

- Wrap the `OnDataChanged?.Invoke()` call in a try-catch to prevent subscriber exceptions (e.g., a disposed Blazor circuit) from killing the watcher.
- In `GetDashboardDataAsync()`, verify the existing try-catch around `File.ReadAllTextAsync` / `JsonSerializer.Deserialize` covers `IOException` (file locked by editor during save) in addition to `FileNotFoundException` and `JsonException`. If the file is locked, retry once after 100ms before returning an error.
- Add a `volatile bool _disposed` flag checked in the debounce callback to avoid invoking events after disposal.

**Produces:** A robust watcher that survives file-locked states, editor save storms, and Blazor circuit disconnects without throwing unhandled exceptions.

#### Step 4: Verify no-regression on initial load and end-to-end auto-refresh

**Files:** Both modified files.

- Run `dotnet build` — confirm zero errors, zero warnings.
- Run the application with `dotnet run`, navigate to `http://localhost:5000`, confirm the dashboard renders identically to before this PR (initial load regression check).
- With the browser open, edit `data.json` (e.g., change the project name or a metric value), save the file, and confirm the browser updates within ~1 second without manual refresh.
- Save the file 5 times in rapid succession — confirm only one re-render occurs (debounce verification).
- Delete `data.json` while the app is running — confirm the error banner appears.
- Restore `data.json` — confirm the dashboard re-renders with valid data.

**Produces:** Verified, shippable PR with no regressions.

---

### Testing

**Manual verification (primary — consistent with project testing strategy):**

| Scenario | Expected Result |
|----------|----------------|
| Normal startup and page load | Dashboard renders from `data.json` identically to pre-PR behavior |
| Edit `data.json` and save | Dashboard auto-updates in browser within ~1 second |
| Rapid-save `data.json` 5x in 1 second | Single re-render occurs (debounce working) |
| Delete `data.json` while running | Error banner displays; no unhandled exception |
| Restore `data.json` after deletion | Dashboard re-renders with restored data |
| Malformed JSON saved to `data.json` | Error banner displays with friendly message |
| Close browser tab, edit `data.json` | No server-side exceptions from stale circuit |
| Stop server (`Ctrl+C`) | Clean shutdown, no `ObjectDisposedException` from watcher/timer |
| `dotnet watch` hot reload | Auto-refresh coexists with hot reload without interference |

**If automated tests are added later (bUnit):**

- Unit test `DashboardDataService`: mock file system, trigger watcher event, assert `OnDataChanged` fires exactly once after debounce period.
- Unit test debounce: trigger 10 rapid change events, assert `OnDataChanged` fires exactly once.
- Unit test `Dispose()`: confirm watcher and timer are disposed, no events fire post-disposal.
- Integration test: write to `data.json` on disk, assert `GetDashboardDataAsync()` returns updated content.

## References
- Architecture: Architecture.md
- PM Spec: 

## Status
- [ ] Implementation
- [ ] Tests Written
- [ ] Ready for Review