### PR TITLE
PrincipalEngineer: Monthly Execution Heatmap Components

### DIFF
--- a/.agentsquad/monthly-execution-heatmap-components.task
+++ b/.agentsquad/monthly-execution-heatmap-components.task
@@ -1,0 +1,4 @@
+agent: PrincipalEngineer
+task: Monthly Execution Heatmap Components
+complexity: High
+status: in-progress

--- a/src/ReportingDashboard/Components/Heatmap.razor
+++ b/src/ReportingDashboard/Components/Heatmap.razor
@@ -1,0 +1,26 @@
+@namespace ReportingDashboard.Components
+@using ReportingDashboard.Models
+
+<div class="hm-wrap">
+    <div class="hm-title">Monthly Execution Heatmap – Shipped · In Progress · Carryover · Blockers</div>
+    <div class="hm-grid" style="grid-template-columns:160px repeat(@Months.Count,1fr);grid-template-rows:36px repeat(4,1fr);">
+        <div class="hm-corner">STATUS</div>
+        @foreach (var month in Months)
+        {
+            var isCurrentMonth = month.Equals(CurrentMonth, StringComparison.OrdinalIgnoreCase);
+            var headerClass = isCurrentMonth ? "hm-col-hdr apr-hdr" : "hm-col-hdr";
+            var label = isCurrentMonth ? $"📍 {month} – Now" : month;
+            <div class="@headerClass">@label</div>
+        }
+        <HeatmapRow CategoryLabel="✅ SHIPPED" CssPrefix="ship" Items="@HeatmapData?.Shipped" Months="@Months" CurrentMonth="@CurrentMonth" />
+        <HeatmapRow CategoryLabel="🔄 IN PROGRESS" CssPrefix="prog" Items="@HeatmapData?.InProgress" Months="@Months" CurrentMonth="@CurrentMonth" />
+        <HeatmapRow CategoryLabel="⏳ CARRYOVER" CssPrefix="carry" Items="@HeatmapData?.Carryover" Months="@Months" CurrentMonth="@CurrentMonth" />
+        <HeatmapRow CategoryLabel="🚨 BLOCKERS" CssPrefix="block" Items="@HeatmapData?.Blockers" Months="@Months" CurrentMonth="@CurrentMonth" />
+    </div>
+</div>
+
+@code {
+    [Parameter] public HeatmapData? HeatmapData { get; set; }
+    [Parameter] public List<string> Months { get; set; } = new();
+    [Parameter] public string CurrentMonth { get; set; } = "";
+}

--- a/src/ReportingDashboard/Components/HeatmapCell.razor
+++ b/src/ReportingDashboard/Components/HeatmapCell.razor
@@ -1,0 +1,23 @@
+@namespace ReportingDashboard.Components
+
+<div class="hm-cell @CellClass">
+    @if (Items is null || Items.Count == 0)
+    {
+        <div style="color:#AAA;text-align:center;">-</div>
+    }
+    else
+    {
+        @foreach (var item in Items)
+        {
+            <div class="it">@item</div>
+        }
+    }
+</div>
+
+@code {
+    [Parameter] public List<string>? Items { get; set; }
+    [Parameter] public string CssPrefix { get; set; } = "ship";
+    [Parameter] public bool IsCurrentMonth { get; set; }
+
+    private string CellClass => $"{CssPrefix}-cell{(IsCurrentMonth ? " apr" : "")}";
+}

--- a/src/ReportingDashboard/Components/HeatmapRow.razor
+++ b/src/ReportingDashboard/Components/HeatmapRow.razor
@@ -1,0 +1,25 @@
+@namespace ReportingDashboard.Components
+
+<div class="hm-row-hdr @($"{CssPrefix}-hdr")">@CategoryLabel</div>
+@foreach (var month in Months)
+{
+    var monthItems = GetMonthItems(month);
+    var isCurrent = month.Equals(CurrentMonth, StringComparison.OrdinalIgnoreCase);
+    <HeatmapCell Items="@monthItems" CssPrefix="@CssPrefix" IsCurrentMonth="@isCurrent" />
+}
+
+@code {
+    [Parameter] public string CategoryLabel { get; set; } = "";
+    [Parameter] public string CssPrefix { get; set; } = "ship";
+    [Parameter] public Dictionary<string, List<string>>? Items { get; set; }
+    [Parameter] public List<string> Months { get; set; } = new();
+    [Parameter] public string CurrentMonth { get; set; } = "";
+
+    private List<string>? GetMonthItems(string month)
+    {
+        if (Items is null)
+            return null;
+
+        return Items.TryGetValue(month.ToLowerInvariant(), out var items) ? items : null;
+    }
+}

--- a/src/ReportingDashboard/Components/Sections/Heatmap.razor
+++ b/src/ReportingDashboard/Components/Sections/Heatmap.razor
@@ -1,0 +1,51 @@
+@namespace ReportingDashboard.Components.Sections
+@using ReportingDashboard.Models
+
+<div class="hm-wrap">
+    <div class="hm-title">Monthly Execution Heatmap &mdash; Shipped &bull; In Progress &bull; Carryover &bull; Blockers</div>
+    <div class="hm-grid" style="grid-template-columns: 160px repeat(@Months.Count, 1fr); grid-template-rows: 36px repeat(4, 1fr);">
+        @* Corner cell *@
+        <div class="hm-corner">STATUS</div>
+
+        @* Column headers *@
+        @foreach (var month in Months)
+        {
+            var isCurrent = string.Equals(month, CurrentMonth, StringComparison.OrdinalIgnoreCase);
+            <div class="hm-col-hdr @(isCurrent ? "apr-hdr" : "")">@month</div>
+        }
+
+        @* Shipped row *@
+        <HeatmapRow CategoryLabel="✅ Shipped"
+                    CssPrefix="ship"
+                    Items="@HeatmapData?.Shipped"
+                    Months="@Months"
+                    CurrentMonth="@CurrentMonth" />
+
+        @* In Progress row *@
+        <HeatmapRow CategoryLabel="🔵 In Progress"
+                    CssPrefix="prog"
+                    Items="@HeatmapData?.InProgress"
+                    Months="@Months"
+                    CurrentMonth="@CurrentMonth" />
+
+        @* Carryover row *@
+        <HeatmapRow CategoryLabel="🟡 Carryover"
+                    CssPrefix="carry"
+                    Items="@HeatmapData?.Carryover"
+                    Months="@Months"
+                    CurrentMonth="@CurrentMonth" />
+
+        @* Blockers row *@
+        <HeatmapRow CategoryLabel="🔴 Blockers"
+                    CssPrefix="block"
+                    Items="@HeatmapData?.Blockers"
+                    Months="@Months"
+                    CurrentMonth="@CurrentMonth" />
+    </div>
+</div>
+
+@code {
+    [Parameter] public HeatmapData? HeatmapData { get; set; }
+    [Parameter] public List<string> Months { get; set; } = new();
+    [Parameter] public string CurrentMonth { get; set; } = "";
+}

--- a/src/ReportingDashboard/Components/Sections/HeatmapCell.razor
+++ b/src/ReportingDashboard/Components/Sections/HeatmapCell.razor
@@ -1,0 +1,21 @@
+@namespace ReportingDashboard.Components.Sections
+
+<div class="hm-cell @CssPrefix-cell @(IsCurrentMonth ? "apr" : "")">
+    @if (Items is not null && Items.Count > 0)
+    {
+        @foreach (var item in Items)
+        {
+            <div class="it">@item</div>
+        }
+    }
+    else
+    {
+        <span style="color:#AAA">-</span>
+    }
+</div>
+
+@code {
+    [Parameter] public List<string>? Items { get; set; }
+    [Parameter] public string CssPrefix { get; set; } = "";
+    [Parameter] public bool IsCurrentMonth { get; set; }
+}

--- a/src/ReportingDashboard/Components/Sections/HeatmapRow.razor
+++ b/src/ReportingDashboard/Components/Sections/HeatmapRow.razor
@@ -1,0 +1,24 @@
+@namespace ReportingDashboard.Components.Sections
+
+<div class="hm-row-hdr @CssPrefix-hdr">@CategoryLabel</div>
+@foreach (var month in Months)
+{
+    <HeatmapCell Items="@GetMonthItems(month)"
+                 CssPrefix="@CssPrefix"
+                 IsCurrentMonth="@(string.Equals(month, CurrentMonth, StringComparison.OrdinalIgnoreCase))" />
+}
+
+@code {
+    [Parameter] public string CategoryLabel { get; set; } = "";
+    [Parameter] public string CssPrefix { get; set; } = "";
+    [Parameter] public Dictionary<string, List<string>>? Items { get; set; }
+    [Parameter] public List<string> Months { get; set; } = new();
+    [Parameter] public string CurrentMonth { get; set; } = "";
+
+    private List<string>? GetMonthItems(string month)
+    {
+        if (Items is null) return null;
+        var key = month.ToLowerInvariant();
+        return Items.TryGetValue(key, out var items) ? items : null;
+    }
+}

--- a/src/ReportingDashboard/Models/HeatmapData.cs
+++ b/src/ReportingDashboard/Models/HeatmapData.cs
@@ -1,18 +1,9 @@
-using System.Text.Json.Serialization;
-
 namespace ReportingDashboard.Models;
 
-public class HeatmapData
+public record HeatmapData
 {
-    [JsonPropertyName("shipped")]
-    public Dictionary<string, List<string>> Shipped { get; set; } = new();
-
-    [JsonPropertyName("inProgress")]
-    public Dictionary<string, List<string>> InProgress { get; set; } = new();
-
-    [JsonPropertyName("carryover")]
-    public Dictionary<string, List<string>> Carryover { get; set; } = new();
-
-    [JsonPropertyName("blockers")]
-    public Dictionary<string, List<string>> Blockers { get; set; } = new();
+    public Dictionary<string, List<string>> Shipped { get; init; } = new();
+    public Dictionary<string, List<string>> InProgress { get; init; } = new();
+    public Dictionary<string, List<string>> Carryover { get; init; } = new();
+    public Dictionary<string, List<string>> Blockers { get; init; } = new();
 }


### PR DESCRIPTION
## Task Assignment
**Assigned To:** PrincipalEngineer
**Complexity:** High
**Branch:** `agent/principalengineer/t4-monthly-execution-heatmap-components`

## Requirements
Closes #513

## Summary

This PR implements the Monthly Execution Heatmap — the largest visual section of the Executive Reporting Dashboard, filling all remaining vertical space below the timeline. It consists of three Blazor components: `Heatmap.razor` (container with title, CSS Grid, corner cell, and column headers), `HeatmapRow.razor` (status row with category-styled header and per-month cells), and `HeatmapCell.razor` (individual cell rendering bulleted work items or an empty dash).

The heatmap displays a color-coded grid of work items organized by status (Shipped, In Progress, Carryover, Blockers) and by month, with the current month visually highlighted. All data is driven by `HeatmapData` from `data.json` via the `DashboardDataService` created in the foundation PR (#510).

**Closes #513. Implements requirements from #505 (US-4: View Monthly Execution Heatmap).**

**Depends on:** #510 (Project Foundation & Scaffolding) — requires `HeatmapData` model, `dashboard.css` with all `.hm-*` and row-variant classes, and `Dashboard.razor` stub to wire into.

---

## Acceptance Criteria

- [ ] The heatmap section title reads "Monthly Execution Heatmap - Shipped · In Progress · Carryover · Blockers" in 14px bold uppercase gray (`#888`) with 0.5px letter-spacing.
- [ ] The grid uses CSS Grid with columns `160px repeat(N, 1fr)` where N equals `Months.Count` from `data.json`.
- [ ] The grid uses rows `36px repeat(4, 1fr)` and fills all remaining vertical space below the timeline (`flex: 1; min-height: 0`).
- [ ] The corner cell displays "STATUS" in 11px bold uppercase `#999` on `#F5F5F5` background with right border 1px `#E0E0E0` and bottom border 2px `#CCC`.
- [ ] Column headers display month names in 16px bold on `#F5F5F5` background, centered, with right border 1px `#E0E0E0` and bottom border 2px `#CCC`.
- [ ] The current month column header has class `apr-hdr` applied: background `#FFF0D0`, color `#C07700`.
- [ ] The Shipped row header has color `#1B7A28` on `#E8F5E9` background; cells use `#F0FBF0` (current month `#D8F2DA`); dots are `#34A853`.
- [ ] The In Progress row header has color `#1565C0` on `#E3F2FD` background; cells use `#EEF4FE` (current month `#DAE8FB`); dots are `#0078D4`.
- [ ] The Carryover row header has color `#B45309` on `#FFF8E1` background; cells use `#FFFDE7` (current month `#FFF0B0`); dots are `#F4B400`.
- [ ] The Blockers row header has color `#991B1B` on `#FEF2F2` background; cells use `#FFF5F5` (current month `#FFE4E4`); dots are `#EA4335`.
- [ ] Each data cell renders work items as `<div class="it">` elements with 6px colored dot via `::before` pseudo-element, 12px text in `#333`, line-height 1.35.
- [ ] Empty cells (no items for that month) display a single gray dash "-" in `#AAA`.
- [ ] Row headers display 11px bold uppercase text with 0.7px letter-spacing, border-right 2px `#CCC`, border-bottom 1px `#E0E0E0`.
- [ ] All heatmap data is driven by `data.json` → `heatmap` object with `shipped`, `inProgress`, `carryover`, `blockers` keys containing month-keyed string arrays.
- [ ] The heatmap renders correctly with 4 months (default) and adapts to different month counts (1–6) from `data.json`.
- [ ] `Dashboard.razor` is updated to replace the heatmap placeholder stub with the actual `<Heatmap>` component.

---

## Implementation Steps

### Step 1: Create HeatmapCell.razor — the leaf component

Start with the innermost component since it has no child dependencies. This is the atomic building block for all grid data cells.

**Creates:** `ReportingDashboard/Components/HeatmapCell.razor`

**Component contract:**
```csharp
@namespace ReportingDashboard.Components

[Parameter] public List<string>? Items { get; set; }
[Parameter] public string CssPrefix { get; set; } = "ship";
[Parameter] public bool IsCurrentMonth { get; set; }
```

**Rendering logic:**
- Compute CSS class: `$"{CssPrefix}-cell{(IsCurrentMonth ? " apr" : "")}"`
- Wrap in `<div class="hm-cell @cellClass">`
- If `Items` is null or empty: render `<div style="color:#AAA;text-align:center;">-</div>`
- Otherwise: `@foreach` item in `Items`, render `<div class="it">@item</div>`
- The `.it::before` pseudo-element (6px colored dot) is handled entirely by CSS — no Blazor markup needed for the dot. The dot color is determined by the parent CSS class (`ship-cell .it::before { background: #34A853 }`, etc.) already defined in `dashboard.css`.

**Validation:** Component compiles. Can be tested in isolation by adding a temporary test reference in `Dashboard.razor`.

### Step 2: Create HeatmapRow.razor — the row component

Build the row component that renders a category header and N cells (one per month).

**Creates:** `ReportingDashboard/Components/HeatmapRow.razor`

**Component contract:**
```csharp
@namespace ReportingDashboard.Components

[Parameter] public string CategoryLabel { get; set; } = "";    // e.g., "✅ SHIPPED"
[Parameter] public string CssPrefix { get; set; } = "ship";    // "ship", "prog", "carry", "block"
[Parameter] public Dictionary<string, List<string>>? Items { get; set; }
[Parameter] public List<string> Months { get; set; } = new();
[Parameter] public string CurrentMonth { get; set; } = "";
```

**Rendering logic:**
- Row header: `<div class="hm-row-hdr @($"{CssPrefix}-hdr")">@CategoryLabel</div>`
- For each month in `Months`:
  - Look up items: `Items?.TryGetValue(month.ToLowerInvariant(), out var monthItems)` — if not found, use empty list
  - Determine current month: `bool isCurrent = month.Equals(CurrentMonth, StringComparison.OrdinalIgnoreCase)`
  - Render: `<HeatmapCell Items="@monthItems" CssPrefix="@CssPrefix" IsCurrentMonth="@isCurrent" />`
- The month key lookup uses `ToLowerInvariant()` to match `data.json` keys (e.g., "jan", "feb") against display months (e.g., "Jan", "Feb").

**Validation:** Component compiles. Renders a row header + N cells when given test data.

### Step 3: Create Heatmap.razor — the container component

Build the top-level heatmap component that assembles the title, grid shell, headers, and four rows.

**Creates:** `ReportingDashboard/Components/Heatmap.razor`

**Component contract:**
```csharp
@namespace ReportingDashboard.Components
@using ReportingDashboard.Models

[Parameter] public HeatmapData? HeatmapData { get; set; }
[Parameter] public List<string> Months { get; set; } = new();
[Parameter] public string CurrentMonth { get; set; } = "";
```

**Rendering logic:**
- Outer wrapper: `<div class="hm-wrap">`
- Title: `<div class="hm-title">Monthly Execution Heatmap – Shipped · In Progress · Carryover · Blockers</div>`
- Grid container with dynamic inline style:
  ```html
  <div class="hm-grid" style="grid-template-columns:160px repeat(@Months.Count,1fr);grid-template-rows:36px repeat(4,1fr);">
  ```
- Corner cell: `<div class="hm-corner">STATUS</div>`
- Column headers: `@foreach` month in `Months`:
  ```csharp
  bool isCurrentMonth = month.Equals(CurrentMonth, StringComparison.OrdinalIgnoreCase);
  string headerClass = isCurrentMonth ? "hm-col-hdr apr-hdr" : "hm-col-hdr";
  string label = isCurrentMonth ? $"📍 {month} · Now" : month;
  ```
  Render: `<div class="@headerClass">@label</div>`
- Four `HeatmapRow` components in order:
  1. `<HeatmapRow CategoryLabel="✅ SHIPPED" CssPrefix="ship" Items="@HeatmapData?.Shipped" Months="@Months" CurrentMonth="@CurrentMonth" />`
  2. `<HeatmapRow CategoryLabel="🔄 IN PROGRESS" CssPrefix="prog" Items="@HeatmapData?.InProgress" Months="@Months" CurrentMonth="@CurrentMonth" />`
  3. `<HeatmapRow CategoryLabel="⏳ CARRYOVER" CssPrefix="carry" Items="@HeatmapData?.Carryover" Months="@Months" CurrentMonth="@CurrentMonth" />`
  4. `<HeatmapRow CategoryLabel="🚫 BLOCKERS" CssPrefix="block" Items="@HeatmapData?.Blockers" Months="@Months" CurrentMonth="@CurrentMonth" />`
- Close `</div>` for grid and wrapper.

**Null safety:** If `HeatmapData` is null, each row receives null `Items` → `HeatmapRow` passes empty lists → `HeatmapCell` renders dashes. No crash.

**Validation:** Component compiles. Grid renders with correct column count and row structure.

### Step 4: Wire Heatmap into Dashboard.razor and verify end-to-end

Update the main page to replace the heatmap placeholder with the live component.

**Modifies:** `ReportingDashboard/Components/Pages/Dashboard.razor`

**Changes:**
- Replace the heatmap placeholder `<div class="hm-wrap">Heatmap placeholder</div>` with:
  ```razor
  <Heatmap HeatmapData="@DataService.Data?.Heatmap"
           Months="@(DataService.Data?.Months ?? new())"
           CurrentMonth="@(DataService.Data?.CurrentMonth ?? "")" />
  ```
- Ensure `@using ReportingDashboard.Components` is in `_Imports.razor` (should already be there from T1).

**Validation:** `dotnet build` succeeds. `dotnet run` → navigate to `http://localhost:5000` → heatmap section renders with sample data from `data.json`. Verify:
- Four rows visible (Shipped green, In Progress blue, Carryover amber, Blockers red)
- Current month column header highlighted gold
- Work items appear as bulleted lists with colored dots
- Empty cells show gray dashes
- Grid fills remaining vertical space below timeline

---

## Testing

### Manual Verification (Required)
1. **Visual fidelity:** Compare the rendered heatmap against the heatmap section in `OriginalDesignConcept.html` opened side-by-side. Colors, spacing, typography, and grid structure should match.
2. **Current month highlighting:** Verify the "Apr" column header has gold background (`#FFF0D0`) and `#C07700` text. Verify data cells in the Apr column use deeper shade backgrounds per row (green `#D8F2DA`, blue `#DAE8FB`, amber `#FFF0B0`, red `#FFE4E4`).
3. **Empty cell rendering:** Edit `data.json` to clear all items from a future month. Restart. Verify those cells show "-" in gray `#AAA`.
4. **Dynamic month count:** Edit `data.json` to use 6 months instead of 4. Restart. Verify grid adapts with 6 equal-width columns (plus the 160px row header column). Verify no overflow or scrollbars.
5. **Null heatmap resilience:** Edit `data.json` to remove the `"blockers"` key entirely. Restart. Verify the Blockers row renders with all dashes — no crash, no exception.
6. **Row header styling:** Inspect each row header to verify: 11px bold uppercase, letter-spacing 0.7px, correct category color and background, right border 2px `#CCC`.
7. **Item dot colors:** Inspect `.it::before` pseudo-elements in DevTools. Shipped dots should be `#34A853`, In Progress `#0078D4`, Carryover `#F4B400`, Blockers `#EA4335`.
8. **Grid fills space:** The heatmap should fill all remaining viewport height below the timeline (no gap at the bottom, no overflow beyond 1080px).

### Unit Tests (Recommended)
- **HeatmapCell with items:** Pass `Items = ["Item A", "Item B"]`, `CssPrefix = "ship"`, `IsCurrentMonth = false` → renders 2 `<div class="it">` elements inside `<div class="hm-cell ship-cell">`.
- **HeatmapCell with empty items:** Pass `Items = []` → renders dash text inside `<div class="hm-cell ship-cell">`.
- **HeatmapCell with null items:** Pass `Items = null` → renders dash (no `NullReferenceException`).
- **HeatmapCell current month:** Pass `IsCurrentMonth = true`, `CssPrefix = "prog"` → cell has class `prog-cell apr`.
- **HeatmapRow month key lookup:** Pass `Items = { "jan": ["X"], "feb": [] }`, `Months = ["Jan", "Feb"]` → first cell has 1 item, second cell shows dash. Verify case-insensitive key matching.
- **Heatmap grid column count:** Pass `Months` with 4 entries → grid style contains `repeat(4,1fr)`. Pass 6 entries → `repeat(6,1fr)`.
- **Heatmap current month header:** Pass `Months = ["Jan", "Feb", "Mar", "Apr"]`, `CurrentMonth = "Apr"` → fourth column header has class `hm-col-hdr apr-hdr`, others have only `hm-col-hdr`.
- **Heatmap null HeatmapData:** Pass `HeatmapData = null` → all four rows render with all-dash cells, no exception.

## References
- Architecture: Architecture.md
- PM Spec: 

## Status
- [ ] Implementation
- [ ] Tests Written
- [ ] Ready for Review