### PR TITLE
PrincipalEngineer 3: HeatmapRow and HeatmapCell Components

### DIFF
--- a/.agentsquad/heatmaprow-and-heatmapcell-components.task
+++ b/.agentsquad/heatmaprow-and-heatmapcell-components.task
@@ -1,0 +1,4 @@
+agent: PrincipalEngineer 3
+task: HeatmapRow and HeatmapCell Components
+complexity: Medium
+status: in-progress

--- a/src/ReportingDashboard/Components/HeatmapCell.razor
+++ b/src/ReportingDashboard/Components/HeatmapCell.razor
@@ -1,4 +1,4 @@
-<div class="hm-cell @CssPrefix-cell @(IsCurrentMonth ? "apr" : "")">
+<div class="@CellClass">
     @if (Items is not null && Items.Count > 0)
     {
         @foreach (var item in Items)
@@ -8,12 +8,26 @@
     }
     else
     {
-        <div style="color:#AAA; text-align:center;">-</div>
+        <div style="color:#AAA;text-align:center">-</div>
     }
 </div>
 
 @code {
-    [Parameter] public List<string> Items { get; set; } = new();
-    [Parameter] public string CssPrefix { get; set; } = string.Empty;
-    [Parameter] public bool IsCurrentMonth { get; set; }
+    [Parameter]
+    public List<string>? Items { get; set; }
+
+    [Parameter]
+    public string CssPrefix { get; set; } = string.Empty;
+
+    [Parameter]
+    public bool IsCurrentMonth { get; set; }
+
+    private string CellClass
+    {
+        get
+        {
+            var baseClass = $"hm-cell {CssPrefix}-cell";
+            return IsCurrentMonth ? $"{baseClass} apr" : baseClass;
+        }
+    }
 }

--- a/src/ReportingDashboard/Components/HeatmapRow.razor
+++ b/src/ReportingDashboard/Components/HeatmapRow.razor
@@ -1,18 +1,43 @@
-<div class="hm-row-hdr @CssPrefix-hdr">@CategoryLabel</div>
-@foreach (var month in Months)
-{
-    var isCurrentMonth = month.Equals(CurrentMonth, StringComparison.OrdinalIgnoreCase);
-    var monthKey = month.ToLowerInvariant();
-    var items = Items.TryGetValue(monthKey, out var list) ? list :
-                Items.TryGetValue(month, out var list2) ? list2 : new List<string>();
+<div class="hm-row-hdr @HeaderClass">@CategoryLabel</div>
 
-    <HeatmapCell Items="@items" CssPrefix="@CssPrefix" IsCurrentMonth="@isCurrentMonth" />
+@if (Months is not null)
+{
+    @foreach (var month in Months)
+    {
+        var items = GetItemsForMonth(month);
+        <HeatmapCell Items="@items" CssPrefix="@CssPrefix" IsCurrentMonth="@CheckIsCurrentMonth(month)" />
+    }
 }
 
 @code {
-    [Parameter] public string CategoryLabel { get; set; } = string.Empty;
-    [Parameter] public string CssPrefix { get; set; } = string.Empty;
-    [Parameter] public Dictionary<string, List<string>> Items { get; set; } = new();
-    [Parameter] public List<string> Months { get; set; } = new();
-    [Parameter] public string CurrentMonth { get; set; } = string.Empty;
+    [Parameter]
+    public string CategoryLabel { get; set; } = string.Empty;
+
+    [Parameter]
+    public string CssPrefix { get; set; } = string.Empty;
+
+    [Parameter]
+    public Dictionary<string, List<string>>? Items { get; set; }
+
+    [Parameter]
+    public List<string>? Months { get; set; }
+
+    [Parameter]
+    public string CurrentMonth { get; set; } = string.Empty;
+
+    private string HeaderClass => $"{CssPrefix}-hdr";
+
+    private List<string> GetItemsForMonth(string month)
+    {
+        if (Items is null)
+            return new List<string>();
+
+        var key = month.ToLowerInvariant();
+        return Items.TryGetValue(key, out var items) ? items : new List<string>();
+    }
+
+    private bool CheckIsCurrentMonth(string month)
+    {
+        return month.Equals(CurrentMonth, StringComparison.OrdinalIgnoreCase);
+    }
 }

--- a/src/ReportingDashboard/Components/HeatmapRow.razor
+++ b/src/ReportingDashboard/Components/HeatmapRow.razor
@@ -25,6 +25,9 @@
     [Parameter]
     public string CurrentMonth { get; set; } = string.Empty;
 
+    [Parameter]
+    public string CategoryKey { get; set; } = string.Empty;
+
     private string HeaderClass => $"{CssPrefix}-hdr";
 
     private List<string> GetItemsForMonth(string month)


### PR DESCRIPTION
## Task Assignment
**Assigned To:** PrincipalEngineer 3
**Complexity:** Medium
**Branch:** `agent/principalengineer-3/t-575-heatmaprow-and-heatmapcell-components`

## Requirements
Closes #575

# PR: HeatmapRow and HeatmapCell Components

## Summary

This PR implements `HeatmapRow.razor` and `HeatmapCell.razor` — the two leaf-level components that render the data rows and individual cells of the Monthly Execution Heatmap grid. `HeatmapRow` renders a category-specific row header (e.g., "✅ SHIPPED" with green styling) followed by one `HeatmapCell` per month. `HeatmapCell` renders work items as a bulleted list with colored dots, applies current-month highlight backgrounds, and shows a gray dash for empty cells.

This PR **only modifies** `src/ReportingDashboard/Components/HeatmapRow.razor` and `src/ReportingDashboard/Components/HeatmapCell.razor`. All required CSS classes (`.hm-row-hdr`, `.ship-hdr`, `.prog-hdr`, `.carry-hdr`, `.block-hdr`, `.hm-cell`, `.ship-cell`, `.prog-cell`, `.carry-cell`, `.block-cell`, `.apr`, `.it`) and models (`HeatmapData`) already exist from the foundation scaffolding PR (#570). The parent `Heatmap.razor` container (#574) passes data into these components.

**Parent Issue:** #562
**Depends On:** #570 (Project Foundation & Scaffolding)
**Source Issue:** #575
**Reference:** `OriginalDesignConcept.html` in repository root for exact visual spec

---

## Acceptance Criteria

### HeatmapRow.razor — Row Header

- [ ] The component renders a `<div class="hm-row-hdr {CssPrefix}-hdr">` as the first element, containing the `CategoryLabel` text (e.g., "✅ SHIPPED").
- [ ] Row header styling uses the existing CSS classes with category-specific colors:
  - Shipped (`.ship-hdr`): text `#1B7A28`, background `#E8F5E9`
  - In Progress (`.prog-hdr`): text `#1565C0`, background `#E3F2FD`
  - Carryover (`.carry-hdr`): text `#B45309`, background `#FFF8E1`
  - Blockers (`.block-hdr`): text `#991B1B`, background `#FEF2F2`
- [ ] Row header text is 11px bold uppercase with 0.7px letter-spacing (from existing CSS).

### HeatmapRow.razor — Cell Delegation

- [ ] The component iterates over the `Months` list and renders one `<HeatmapCell>` per month.
- [ ] For each month, it looks up items from the `Items` dictionary using the lowercase month key (e.g., `"jan"`, `"feb"`). If the key is missing, it passes an empty list.
- [ ] Each `HeatmapCell` receives: `Items` (the list of strings for that month), `CssPrefix` (the row's CSS prefix), and `IsCurrentMonth` (bool).
- [ ] Current month detection uses case-insensitive comparison: `month.Equals(CurrentMonth, StringComparison.OrdinalIgnoreCase)`.

### HeatmapRow.razor — Parameters

- [ ] `HeatmapRow.razor` declares these `[Parameter]` properties:
  - `string CategoryLabel` — display text for the row header (e.g., "✅ SHIPPED")
  - `string CssPrefix` — CSS class prefix (`"ship"`, `"prog"`, `"carry"`, `"block"`)
  - `Dictionary<string, List<string>> Items` — month-keyed dictionary of work item strings
  - `List<string> Months` — ordered list of month abbreviations
  - `string CurrentMonth` — the currently highlighted month
- [ ] The component handles null `Items` dictionary gracefully (treats as empty, no crash).
- [ ] The component handles null or empty `Months` list gracefully (renders only the row header, no cells).

### HeatmapCell.razor — Work Item Rendering

- [ ] Each cell renders as a `<div class="hm-cell {CssPrefix}-cell">` (with additional `apr` class when `IsCurrentMonth` is true).
- [ ] When `Items` has one or more entries, each item renders as a `<div class="it">` containing the item text.
- [ ] Item text is 12px, color `#333`, with `padding: 2px 0 2px 12px` and `line-height: 1.35` (from existing `.it` CSS).
- [ ] The colored bullet dot is rendered via the existing `.it::before` CSS pseudo-element (6x6px circle, positioned absolute at `left: 0; top: 7px`). The dot color is determined by the `{CssPrefix}-cell .it::before` CSS rule:
  - Shipped: `#34A853` (green)
  - In Progress: `#0078D4` (blue)
  - Carryover: `#F4B400` (amber)
  - Blockers: `#EA4335` (red)

### HeatmapCell.razor — Current Month Highlighting

- [ ] When `IsCurrentMonth` is true, the cell div gets the additional CSS class `apr`, producing the class string `hm-cell {prefix}-cell apr`.
- [ ] The current-month highlight background colors come from existing CSS:
  - Shipped: `#D8F2DA`
  - In Progress: `#DAE8FB`
  - Carryover: `#FFF0B0`
  - Blockers: `#FFE4E4`

### HeatmapCell.razor — Empty Cell

- [ ] When `Items` is null or empty, the cell renders a single centered gray dash: `<div style="color:#AAA;text-align:center">-</div>`.
- [ ] No `.it` divs are rendered for empty cells.

### HeatmapCell.razor — Parameters

- [ ] `HeatmapCell.razor` declares these `[Parameter]` properties:
  - `List<string> Items` — list of work item strings to display
  - `string CssPrefix` — CSS class prefix for theming
  - `bool IsCurrentMonth` — whether to apply the current-month highlight class

### Build Verification

- [ ] `dotnet build` succeeds with zero errors after all changes.
- [ ] No new files are created; only `HeatmapRow.razor` and `HeatmapCell.razor` are modified.

---

## Implementation Steps

### Step 1: Implement HeatmapCell.razor with item rendering, empty state, and current-month highlight

Replace the existing placeholder content in `HeatmapCell.razor` with the full component implementation. Declare three `[Parameter]` properties (`Items`, `CssPrefix`, `IsCurrentMonth`). Compute the cell CSS class string combining `hm-cell`, the prefix-specific class (`{CssPrefix}-cell`), and the optional `apr` modifier. Render either the item list (`.it` divs) or the gray dash for empty cells.

**Deliverables:**
- `HeatmapCell.razor` `@code` block with three `[Parameter]` properties and a computed `CellClass` string property.
- Conditional markup: `@if (Items is not null && Items.Count > 0)` renders `<div class="it">@item</div>` per item; `@else` renders `<div style="color:#AAA;text-align:center">-</div>`.
- The outer div uses `<div class="@CellClass">`.

**Commit message:** `feat: implement HeatmapCell with item list, empty dash, and current-month highlight`

### Step 2: Implement HeatmapRow.razor with row header and cell delegation

Replace the existing placeholder content in `HeatmapRow.razor` with the full component. Declare five `[Parameter]` properties (`CategoryLabel`, `CssPrefix`, `Items`, `Months`, `CurrentMonth`). Render the row header div with combined CSS classes (`hm-row-hdr {CssPrefix}-hdr`). Iterate over `Months`, look up the items for each month from the `Items` dictionary using `month.ToLowerInvariant()` as the key, and render a `<HeatmapCell>` for each month.

**Deliverables:**
- `HeatmapRow.razor` `@code` block with five `[Parameter]` properties.
- `<div class="hm-row-hdr @HeaderClass">@CategoryLabel</div>` where `HeaderClass` is `$"{CssPrefix}-hdr"`.
- A `@foreach (var month in Months)` loop that calls a private `GetItemsForMonth(string month)` helper. This helper performs a case-insensitive dictionary lookup: tries `month.ToLowerInvariant()` as the key, returns `new List<string>()` if not found.
- Each loop iteration renders `<HeatmapCell Items="@items" CssPrefix="@CssPrefix" IsCurrentMonth="@IsCurrentMonth(month)" />`.
- Private `IsCurrentMonth(string month)` method using `StringComparison.OrdinalIgnoreCase`.
- Null guards: if `Months` is null or empty, only the header renders. If `Items` is null, all cells get empty lists.

**Commit message:** `feat: implement HeatmapRow with header styling and per-month cell delegation`

### Step 3: Verify build and integration with parent Heatmap component

Run `dotnet build` to confirm zero errors. Verify that `HeatmapRow` parameter names match what `Heatmap.razor` (from PR #574) passes: `CategoryLabel`, `CssPrefix`, `Items`, `Months`, `CurrentMonth`. If the parent component also passes a `CategoryKey` parameter, add it as an optional `[Parameter]` on `HeatmapRow` to avoid Blazor runtime warnings about unmatched parameters. Run the app with `dotnet run` and visually confirm the heatmap grid renders four colored rows with correct item data from `data.json`.

**Deliverables:**
- Successful `dotnet build` with zero errors.
- Confirmation that parameter names align with the parent `Heatmap.razor` component's usage.
- Visual verification at `http://localhost:5000` that all four heatmap rows render with correct colors, items, empty dashes, and current-month highlighting.

**Commit message:** `feat: verify HeatmapRow and HeatmapCell integration with Heatmap container`

---

## Testing

### Build Verification
- `dotnet build` succeeds with zero errors after all changes.
- `dotnet run` starts and renders the heatmap rows at `http://localhost:5000`.

### HeatmapRow — Row Header Rendering
- Each of the four rows renders a header cell with the correct label text and CSS class:
  - "✅ SHIPPED" with `.ship-hdr`
  - "🔄 IN PROGRESS" with `.prog-hdr`
  - "⚠️ CARRYOVER" with `.carry-hdr`
  - "🚫 BLOCKERS" with `.block-hdr`
- Header cells are styled per the existing CSS (category-specific background and text colors).

### HeatmapRow — Cell Count
- Each row renders exactly `Months.Count` `HeatmapCell` components (4 by default with sample data).
- The total grid children per row = 1 header + N cells.

### HeatmapRow — Dictionary Lookup
- Items are correctly resolved from the dictionary using lowercase month keys (e.g., `"apr"` matches the key in `data.json`).
- A month key not present in the dictionary produces an empty cell (gray dash), not a crash.
- A null `Items` dictionary produces all empty cells, not a `NullReferenceException`.

### HeatmapCell — Item List
- Cells with items render one `.it` div per item with the item text.
- The colored bullet dot appears via the `::before` pseudo-element (verify visually against `OriginalDesignConcept.html`).
- Item text is 12px, color `#333`.

### HeatmapCell — Empty State
- Cells with no items (empty list or null) render a single gray dash (`-` in `#AAA`), centered.
- No `.it` divs are rendered for empty cells.

### HeatmapCell — Current Month Highlight
- The cell for the current month (matching `CurrentMonth` from `data.json`) has the `apr` CSS class applied.
- The highlighted cell has a deeper background color per its category (e.g., Shipped current month = `#D8F2DA`).
- Non-current month cells do not have the `apr` class.

### Edge Cases
- **Empty months array:** HeatmapRow renders only the header, no cells. No crash.
- **Null Items dictionary:** All cells render as empty (gray dash). No crash.
- **Month key casing mismatch:** `"Apr"` in Months and `"apr"` in Items dictionary keys still resolves correctly via `ToLowerInvariant()`.
- **`currentMonth` not in months array:** No cell gets the `apr` highlight class. All cells use default styling.
- **Single item in cell:** Renders one `.it` div with the bullet dot.
- **8+ items in cell:** Items render but overflow is clipped by existing `.hm-cell` CSS (`overflow: hidden`).

### Visual Fidelity
- Side-by-side comparison with `OriginalDesignConcept.html`: row header colors, cell background colors, bullet dot colors, current-month highlight shading, and empty cell dashes all match the reference design.
- The four rows stack correctly within the CSS Grid from the parent `Heatmap.razor` container.

## References
- Architecture: Architecture.md
- PM Spec: 

## Status
- [ ] Implementation
- [ ] Tests Written
- [ ] Ready for Review