### PR TITLE
PrincipalEngineer: Self-Contained Executable Publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# Executive Reporting Dashboard
+
+A single-page Blazor Server dashboard that visualizes project milestones, delivery status, and monthly execution progress. Designed for pixel-perfect 1920×1080 screenshots destined for PowerPoint executive decks. All content is driven by a single `data.json` file — no code changes required to update the dashboard.
+
+## Quick Start
+
+**Prerequisites:** [.NET 8 SDK](https://dotnet.microsoft.com/download/dotnet/8.0) installed on Windows 10/11.

--- a/ReportingDashboard.sln
+++ b/ReportingDashboard.sln
@@ -1,0 +1,6 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ReportingDashboard", "src\ReportingDashboard\ReportingDashboard.csproj", "{30A027B2-F0C8-4A58-81A1-30FEFD8178A9}"
+EndProject
+Global
+EndGlobal

--- a/scripts/verify-publish.ps1
+++ b/scripts/verify-publish.ps1
@@ -1,0 +1,150 @@
+#!/usr/bin/env pwsh
+# Verification script for self-contained executable publishing (Step 4 of 4)
+#
+# IMPORTANT: Run from the REPOSITORY ROOT directory:
+#   .\scripts\verify-publish.ps1
+#
+# The script expects the following repo layout:
+#   <repo-root>/src/ReportingDashboard/ReportingDashboard.csproj
+#   <repo-root>/README.md
+
+$ErrorActionPreference = "Stop"
+$projectPath = "src/ReportingDashboard/ReportingDashboard.csproj"
+$maxSizeMB = 100
+$allPassed = $true
+
+# Validate working directory
+if (-not (Test-Path $projectPath)) {
+    Write-Host "[ERROR] Cannot find $projectPath. This script must be run from the repository root." -ForegroundColor Red
+    exit 1
+}
+
+# Dynamically resolve TargetFramework from the .csproj
+$csprojXml = [xml](Get-Content $projectPath)
+$tfm = $csprojXml.Project.PropertyGroup.TargetFramework | Where-Object { $_ } | Select-Object -First 1
+if (-not $tfm) {
+    Write-Host "[ERROR] Could not resolve TargetFramework from $projectPath" -ForegroundColor Red
+    exit 1
+}
+Write-Host "Resolved TargetFramework: $tfm" -ForegroundColor Cyan
+
+$rid = "win-x64"
+
+function Write-Check($name, $passed, $detail) {
+    $icon = if ($passed) { "[PASS]" } else { "[FAIL]"; $script:allPassed = $false }
+    Write-Host "$icon $name" -ForegroundColor $(if ($passed) { "Green" } else { "Red" })
+    if ($detail) { Write-Host "       $detail" -ForegroundColor Gray }
+}
+
+# Extracts the publish output directory from dotnet publish stdout.
+# MSBuild emits a line like: "ReportingDashboard -> C:\...\publish\"
+function Get-PublishDir($publishOutput) {
+    $match = [regex]::Match($publishOutput, '->\s*(.+[/\\]publish[/\\]?)\s*$', 'Multiline')
+    if ($match.Success) {
+        return $match.Groups[1].Value.Trim().TrimEnd('\', '/')
+    }
+    # Fallback: derive from conventions
+    $fallback = "src/ReportingDashboard/bin/Release/$tfm/$rid/publish"
+    Write-Host "  [WARN] Could not parse publish path from output; using fallback: $fallback" -ForegroundColor Yellow
+    return $fallback
+}
+
+# 1. Verify dotnet build succeeds
+Write-Host "`n=== Build Regression Check ===" -ForegroundColor Cyan
+$buildOutput = & dotnet build $projectPath -c Release --nologo 2>&1 | Out-String
+$buildExitCode = $LASTEXITCODE
+Write-Check "dotnet build succeeds" ($buildExitCode -eq 0) "Exit code: $buildExitCode"
+
+# Check no new PackageReference entries
+$csproj = Get-Content $projectPath -Raw
+$hasPackageRefs = $csproj -match "<PackageReference"
+Write-Check "No external NuGet packages" (-not $hasPackageRefs) $(if ($hasPackageRefs) { "Found <PackageReference> in .csproj" } else { "Zero <PackageReference> entries" })
+
+# Check ExcludeFromSingleFile is present for data.json
+$hasExclude = $csproj -match 'ExcludeFromSingleFile\s*=\s*"true"'
+Write-Check "data.json ExcludeFromSingleFile in .csproj" $hasExclude $(if ($hasExclude) { "ExcludeFromSingleFile='true' found" } else { "MISSING: data.json will be embedded in single-file exe" })
+
+# Check Condition guard on data.json Content item
+$hasCondition = $csproj -match "Condition\s*=\s*`"Exists\('data\.json'\)`""
+Write-Check "data.json Content has Exists condition" $hasCondition $(if ($hasCondition) { "Condition guard present" } else { "MISSING: build may warn when data.json doesn't exist" })
+
+# 2. Run publish (full CLI)
+Write-Host "`n=== Publish Verification (CLI) ===" -ForegroundColor Cyan
+$publishOutput = & dotnet publish $projectPath -c Release -r $rid --self-contained true -p:PublishSingleFile=true --nologo 2>&1 | Out-String
+$publishExitCode = $LASTEXITCODE
+Write-Check "dotnet publish succeeds" ($publishExitCode -eq 0) "Exit code: $publishExitCode"
+
+if ($publishExitCode -ne 0) {
+    Write-Host "`nPublish output:`n$publishOutput" -ForegroundColor Yellow
+    exit 1
+}
+
+# Resolve the actual publish directory from MSBuild output
+$publishDir = Get-PublishDir $publishOutput
+Write-Host "Resolved publish directory: $publishDir" -ForegroundColor Cyan
+
+# 3. Check executable exists and size
+if (Test-Path $publishDir) {
+    $exe = Get-ChildItem $publishDir -Filter "*.exe" | Select-Object -First 1
+} else {
+    $exe = $null
+}
+$exeExists = $null -ne $exe
+Write-Check "Single executable exists" $exeExists $(if ($exeExists) { $exe.Name } else { "No .exe found in $publishDir" })
+
+if ($exeExists) {
+    $sizeMB = [math]::Round($exe.Length / 1MB, 2)
+    $sizeOk = $sizeMB -lt $maxSizeMB
+    Write-Check "Executable under ${maxSizeMB}MB" $sizeOk "${sizeMB}MB"
+}
+
+# 4. Check data.json is external (not embedded)
+# Note: data.json is created by a separate task (#677). If it exists in the project,
+# it should appear alongside the exe. If it doesn't exist yet, this check is skipped.
+$dataJsonInProject = Test-Path "src/ReportingDashboard/data.json"
+if ($dataJsonInProject) {
+    $dataJsonPath = Join-Path $publishDir "data.json"
+    $dataJsonExists = Test-Path $dataJsonPath
+    Write-Check "data.json exists alongside exe (not embedded)" $dataJsonExists $(if ($dataJsonExists) { "Found: $dataJsonPath" } else { "Missing: $dataJsonPath" })
+} else {
+    Write-Host "[SKIP] data.json not yet in project (created by dependency task #677)" -ForegroundColor Yellow
+}
+
+# 5. Verify publish profile shorthand works
+Write-Host "`n=== Publish Profile Verification ===" -ForegroundColor Cyan
+$profileOutput = & dotnet publish $projectPath -p:PublishProfile=win-x64 --nologo 2>&1 | Out-String
+$profileExitCode = $LASTEXITCODE
+Write-Check "dotnet publish via PublishProfile succeeds" ($profileExitCode -eq 0) "Exit code: $profileExitCode"
+
+if ($profileExitCode -eq 0) {
+    $profilePublishDir = Get-PublishDir $profileOutput
+    Write-Host "Profile publish directory: $profilePublishDir" -ForegroundColor Cyan
+}
+
+# 6. List publish directory contents
+Write-Host "`n=== Publish Directory Contents ===" -ForegroundColor Cyan
+if (Test-Path $publishDir) {
+    Get-ChildItem $publishDir | ForEach-Object {
+        $sizeMB = [math]::Round($_.Length / 1MB, 2)
+        Write-Host "  $($_.Name) ($sizeMB MB)" -ForegroundColor Gray
+    }
+} else {
+    Write-Host "  Publish directory not found: $publishDir" -ForegroundColor Yellow
+}
+
+# 7. Check pubxml exists
+$pubxmlPath = "src/ReportingDashboard/Properties/PublishProfiles/win-x64.pubxml"
+Write-Check "win-x64.pubxml exists" (Test-Path $pubxmlPath) $pubxmlPath
+
+# 8. Check README exists
+Write-Check "README.md exists at repo root" (Test-Path "README.md") "README.md"
+
+# Summary
+Write-Host "`n=== Summary ===" -ForegroundColor Cyan
+if ($allPassed) {
+    Write-Host "ALL CHECKS PASSED" -ForegroundColor Green
+    exit 0
+} else {
+    Write-Host "SOME CHECKS FAILED - review output above" -ForegroundColor Red
+    exit 1
+}

--- a/src/ReportingDashboard/Properties/PublishProfiles/win-x64.pubxml
+++ b/src/ReportingDashboard/Properties/PublishProfiles/win-x64.pubxml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <PropertyGroup>
+    <Configuration>Release</Configuration>
+    <Platform>Any CPU</Platform>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <SelfContained>true</SelfContained>
+    <PublishSingleFile>true</PublishSingleFile>
+    <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
+  </PropertyGroup>
+</Project>

--- a/src/ReportingDashboard/ReportingDashboard.csproj
+++ b/src/ReportingDashboard/ReportingDashboard.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>ReportingDashboard</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Content Include="data.json"
+             Condition="Exists('data.json')"
+             CopyToOutputDirectory="PreserveNewest"
+             CopyToPublishDirectory="PreserveNewest"
+             ExcludeFromSingleFile="true" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Task Assignment
**Assigned To:** PrincipalEngineer
**Complexity:** Low
**Branch:** `agent/principalengineer/t5-self-contained-executable-publishing`

## Requirements
Closes #680

# PR: Self-Contained Executable Publishing for ReportingDashboard

## Summary

Configures the ReportingDashboard Blazor Server project for self-contained single-file publishing targeting Windows x64. Adds a publish profile (`win-x64.pubxml`), updates the `.csproj` to ensure `data.json` remains external to the published executable (so end users can edit it alongside the `.exe`), and adds a `README.md` documenting the data schema, usage instructions, and publishing workflow. This enables stakeholders to run the dashboard from a single executable without installing the .NET SDK.

Closes #680 | Parent: #675 | Depends on: #676

---

## Acceptance Criteria

- [ ] `Properties/PublishProfiles/win-x64.pubxml` exists with Release configuration, `win-x64` runtime identifier, `SelfContained=true`, and `PublishSingleFile=true`.
- [ ] Running `dotnet publish -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true` from `src/ReportingDashboard/` produces a single executable under 100 MB in the publish output directory.
- [ ] `data.json` is **not** embedded inside the single-file executable — it is copied to the publish output directory as a standalone file that users can edit.
- [ ] The published executable, when run alongside the external `data.json`, starts successfully on `http://localhost:5000` and renders the dashboard.
- [ ] `README.md` exists at the repository root and documents:
  - Full `data.json` schema with all fields described (title, subtitle, backlogUrl, timeline with tracks/milestones, heatmap with months/categories/items, nowDate, currentMonth).
  - Usage instructions for `dotnet run` (development) and `dotnet publish` (self-contained distribution).
  - How to edit `data.json` to update dashboard content without code changes.
- [ ] The `.csproj` contains an explicit item or property ensuring `data.json` is excluded from single-file embedding and instead copied to the output directory (`CopyToPublishDirectory`).
- [ ] No new external NuGet package references are introduced.

---

## Implementation Steps

### Step 1: Scaffold publish profile directory and create `win-x64.pubxml`

Create `src/ReportingDashboard/Properties/PublishProfiles/win-x64.pubxml` with the following configuration:

```xml
<?xml version="1.0" encoding="utf-8"?>
<Project>
  <PropertyGroup>
    <Configuration>Release</Configuration>
    <Platform>Any CPU</Platform>
    <PublishDir>bin\Release\net8.0\win-x64\publish\</PublishDir>
    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
    <SelfContained>true</SelfContained>
    <PublishSingleFile>true</PublishSingleFile>
    <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
  </PropertyGroup>
</Project>
```

This enables `dotnet publish -p:PublishProfile=win-x64` as a shorthand for the full CLI flags.

**Produces:** `Properties/PublishProfiles/win-x64.pubxml` — committable on its own.

---

### Step 2: Modify `.csproj` to externalize `data.json` during publish

Update `src/ReportingDashboard/ReportingDashboard.csproj` to add an item group that ensures `data.json` is copied to the publish output directory as a standalone file rather than being embedded in the single-file bundle:

```xml
<ItemGroup>
  <Content Include="data.json" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" ExcludeFromSingleFile="true" />
</ItemGroup>
```

Key attributes:
- `CopyToOutputDirectory="PreserveNewest"` — ensures `data.json` appears next to the executable in both `dotnet run` and `dotnet publish` scenarios.
- `CopyToPublishDirectory="PreserveNewest"` — explicitly copies to publish output.
- `ExcludeFromSingleFile="true"` — prevents the file from being embedded inside the single-file executable, keeping it editable.

If `data.json` is currently in `wwwroot/`, also verify the `DashboardDataService` resolves the file path from `AppContext.BaseDirectory` (the directory containing the executable), which works correctly for both development and published single-file scenarios.

**Produces:** Modified `.csproj` with data externalization — committable as a discrete change.

---

### Step 3: Create `README.md` with schema documentation and usage instructions

Create `README.md` at the repository root with the following sections:

1. **Overview** — One-paragraph description of the Executive Reporting Dashboard purpose and design.
2. **Quick Start** — `dotnet run` command, expected URL (`http://localhost:5000`), and screenshot workflow.
3. **Publishing a Self-Contained Executable** — Step-by-step instructions for `dotnet publish -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true` (or `dotnet publish -p:PublishProfile=win-x64`), expected output location, and how to distribute the `.exe` + `data.json` together.
4. **Configuring `data.json`** — Full schema reference table covering every field:
   - `title` (string) — Dashboard heading
   - `subtitle` (string) — Org/workstream/date subheading
   - `backlogUrl` (string) — Link to ADO backlog
   - `timeline.startDate` / `endDate` (ISO 8601 date) — Timeline range
   - `timeline.nowDate` (optional ISO 8601 date) — Override for NOW line; defaults to system date
   - `timeline.tracks[]` — Array of track objects with `id`, `name`, `color`, and `milestones[]`
   - `milestones[].date`, `.label`, `.type` (Checkpoint | PoC | Production)
   - `heatmap.months[]` (string array) — Ordered month column headers
   - `heatmap.currentMonth` (optional string) — Month to highlight; auto-detected if omitted
   - `heatmap.categories[]` — Array with `name`, `cssClass`, `icon`, and `items` (object keyed by month name → string array)
5. **Editing Data** — Explain that users edit `data.json` in any text editor, restart the app (or refresh if hot-reload is enabled), and the dashboard reflects changes immediately.

**Produces:** `README.md` at repo root — committable independently.

---

### Step 4: Verify publish output and executable size

Run the full publish pipeline and validate:

1. Execute `dotnet publish src/ReportingDashboard/ReportingDashboard.csproj -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true`.
2. Confirm the publish output directory contains:
   - A single `.exe` file (e.g., `ReportingDashboard.exe`) under 100 MB.
   - A standalone `data.json` file alongside the executable (not embedded).
   - Any required native `.dll` files that cannot be bundled (if any).
3. Run the published executable and verify the dashboard loads at `http://localhost:5000` with the demo data rendered correctly.
4. Edit the external `data.json` (e.g., change the title), restart the executable, and confirm the change is reflected.

**Produces:** Verified publish output — no file changes, but validates the prior three steps work end-to-end.

---

## Testing

### Manual Verification Checklist

| # | Test Case | Expected Result |
|---|-----------|-----------------|
| 1 | `dotnet publish -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true` completes without errors | Exit code 0, publish directory populated |
| 2 | Published `.exe` file size | Under 100 MB |
| 3 | `data.json` exists as a separate file in publish output directory | File is present alongside `.exe`, not embedded |
| 4 | Run published `.exe` directly (no .NET SDK on PATH) | Dashboard loads at `http://localhost:5000` |
| 5 | Modify `data.json` next to published `.exe`, restart | Dashboard reflects the updated content |
| 6 | Delete `data.json` from publish directory, run `.exe` | Friendly error message displayed (not a crash/stack trace) |
| 7 | `dotnet publish -p:PublishProfile=win-x64` uses the publish profile | Same output as the full CLI command |
| 8 | `dotnet run` in dev still works after `.csproj` changes | Dashboard loads normally in development mode |
| 9 | `README.md` documents all `data.json` fields | Every field from the schema is described |
| 10 | `README.md` includes both `dotnet run` and `dotnet publish` instructions | Both workflows are documented with exact commands |

### Build Regression Check

- Confirm `dotnet build` succeeds with no warnings related to the new `Content` item group.
- Confirm no new `<PackageReference>` entries were added to the `.csproj`.

## References
- Architecture: Architecture.md
- PM Spec: 

## Status
- [ ] Implementation
- [ ] Tests Written
- [ ] Ready for Review