### PR TITLE
PrincipalEngineer: Project Foundation & Scaffolding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,19 +1,22 @@
-## .NET / Visual Studio
+## .NET
 bin/
 obj/
-publish/
 .vs/
 *.user
 *.suo
 *.userosscache
 *.sln.docstates
-*.userprefs
+publish/
+out/
 
 ## Build results
 [Dd]ebug/
 [Rr]elease/
 x64/
 x86/
+[Ww][Ii][Nn]32/
+[Aa][Rr][Mm]/
+[Aa][Rr][Mm]64/
 bld/
 [Bb]in/
 [Oo]bj/
@@ -29,36 +32,45 @@ nuget.exe
 !**/[Pp]ackages/build/
 *.nuget.props
 *.nuget.targets
-project.lock.json
-project.fragment.lock.json
 
 ## Visual Studio
 .vs/
 *.rsuser
-*.sln.iml
-launchSettings.json.user
-*.DotSettings.user
+*.sln.docstates
+*_i.c
+*_p.c
+*_h.h
+*.ilk
+*.meta
+*.obj
+*.iobj
+*.pch
+*.pdb
+*.ipdb
+*.pgc
+*.pgd
+*.rsp
+*.sbr
+*.tlb
+*.tli
+*.tlh
+*.tmp
+*.tmp_proj
+*_wpftmp.csproj
+*.vspscc
+*.vssscc
+.builds
+*.pidb
+*.svclog
+*.scc
 
 ## Rider
 .idea/
 *.sln.iml
 
-## OS files
-Thumbs.db
-ehthumbs.db
-Desktop.ini
+## macOS
 .DS_Store
 
 ## User-specific
-*.csproj.user
-*.unityproj.user
-*.tlog
-
-## Build outputs
-msbuild.log
-msbuild.err
-msbuild.wrn
-
-## Self-contained publish output
-*.exe
-!src/**/wwwroot/**
+*.user
+launchSettings.json.user

--- a/ReportingDashboard.sln
+++ b/ReportingDashboard.sln
@@ -1,0 +1,18 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ReportingDashboard", "ReportingDashboard\ReportingDashboard.csproj", "{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/ReportingDashboard/Components/App.razor
+++ b/ReportingDashboard/Components/App.razor
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=1920" />
+    <title>Executive Reporting Dashboard</title>
+    <link rel="stylesheet" href="css/app.css" />
+    <HeadOutlet />
+</head>
+
+<body>
+    <Routes />
+</body>
+
+</html>

--- a/ReportingDashboard/Components/Layout/MainLayout.razor
+++ b/ReportingDashboard/Components/Layout/MainLayout.razor
@@ -1,0 +1,5 @@
+@inherits LayoutComponentBase
+
+<div style="width:1920px;height:1080px;overflow:hidden;display:flex;flex-direction:column;background:#fff;font-family:'Segoe UI',Arial,sans-serif;color:#111;">
+    @Body
+</div>

--- a/ReportingDashboard/Components/Pages/Dashboard.razor
+++ b/ReportingDashboard/Components/Pages/Dashboard.razor
@@ -1,0 +1,30 @@
+@page "/"
+@inject DashboardDataService DataService
+
+@if (_error is not null)
+{
+    <div class="dashboard-error">
+        <div class="dashboard-error-content">
+            <h2>⚠ Dashboard Error</h2>
+            <p>@_error</p>
+        </div>
+    </div>
+}
+else
+{
+    <!-- DashboardHeader will render here -->
+    <!-- TimelineSection will render here -->
+    <!-- HeatmapSection will render here -->
+}
+
+@code {
+    private DashboardData? _data;
+    private string? _error;
+
+    protected override void OnInitialized()
+    {
+        var (data, error) = DataService.Load();
+        _data = data;
+        _error = error;
+    }
+}

--- a/ReportingDashboard/Components/Pages/Dashboard.razor
+++ b/ReportingDashboard/Components/Pages/Dashboard.razor
@@ -10,11 +10,29 @@
         </div>
     </div>
 }
-else
+else if (_data is not null)
 {
     <!-- DashboardHeader will render here -->
+    <div class="hdr">
+        <div>
+            <h1 style="font-size:24px;font-weight:700;margin:0;">@_data.Project.Title</h1>
+            <div class="sub">@_data.Project.Subtitle</div>
+        </div>
+    </div>
+
     <!-- TimelineSection will render here -->
+    <div class="tl-area">
+        <div style="display:flex;align-items:center;justify-content:center;width:100%;color:#888;font-size:14px;">
+            Timeline placeholder — @_data.Tracks.Count track(s) configured
+        </div>
+    </div>
+
     <!-- HeatmapSection will render here -->
+    <div class="hm-wrap">
+        <div style="display:flex;align-items:center;justify-content:center;flex:1;color:#888;font-size:14px;">
+            Heatmap placeholder — @_data.Heatmap.Categories.Count categories × @_data.Heatmap.Months.Count months
+        </div>
+    </div>
 }
 
 @code {

--- a/ReportingDashboard/Components/Routes.razor
+++ b/ReportingDashboard/Components/Routes.razor
@@ -1,0 +1,10 @@
+<Router AppAssembly="typeof(Program).Assembly">
+    <Found Context="routeData">
+        <RouteView RouteData="routeData" DefaultLayout="typeof(Layout.MainLayout)" />
+    </Found>
+    <NotFound>
+        <LayoutView Layout="typeof(Layout.MainLayout)">
+            <p>Page not found.</p>
+        </LayoutView>
+    </NotFound>
+</Router>

--- a/ReportingDashboard/Components/Routes.razor
+++ b/ReportingDashboard/Components/Routes.razor
@@ -4,7 +4,12 @@
     </Found>
     <NotFound>
         <LayoutView Layout="typeof(Layout.MainLayout)">
-            <p>Page not found.</p>
+            <div class="dashboard-error">
+                <div class="dashboard-error-content">
+                    <h2>⚠ Page Not Found</h2>
+                    <p>The requested page does not exist.</p>
+                </div>
+            </div>
         </LayoutView>
     </NotFound>
 </Router>

--- a/ReportingDashboard/Components/_Imports.razor
+++ b/ReportingDashboard/Components/_Imports.razor
@@ -1,0 +1,7 @@
+@using System.Net.Http
+@using Microsoft.AspNetCore.Components.Forms
+@using Microsoft.AspNetCore.Components.Routing
+@using Microsoft.AspNetCore.Components.Web
+@using ReportingDashboard.Models
+@using ReportingDashboard.Services
+@using ReportingDashboard.Components

--- a/ReportingDashboard/Models/DashboardData.cs
+++ b/ReportingDashboard/Models/DashboardData.cs
@@ -1,0 +1,46 @@
+namespace ReportingDashboard.Models;
+
+public record DashboardData(
+    ProjectInfo Project,
+    TimelineConfig Timeline,
+    List<MilestoneTrack> Tracks,
+    HeatmapData Heatmap
+);
+
+public record ProjectInfo(
+    string Title,
+    string Subtitle,
+    string BacklogUrl,
+    string CurrentMonth
+);
+
+public record TimelineConfig(
+    List<string> Months,
+    double NowPosition
+);
+
+public record MilestoneTrack(
+    string Id,
+    string Label,
+    string Color,
+    List<Milestone> Milestones
+);
+
+public record Milestone(
+    string Date,
+    string Type,
+    double Position,
+    string? Label
+);
+
+public record HeatmapData(
+    List<string> Months,
+    List<HeatmapCategory> Categories
+);
+
+public record HeatmapCategory(
+    string Name,
+    string CssClass,
+    string Emoji,
+    Dictionary<string, List<string>> Items
+);

--- a/ReportingDashboard/Models/DashboardData.cs
+++ b/ReportingDashboard/Models/DashboardData.cs
@@ -1,46 +1,48 @@
+using System.Text.Json.Serialization;
+
 namespace ReportingDashboard.Models;
 
 public record DashboardData(
-    ProjectInfo Project,
-    TimelineConfig Timeline,
-    List<MilestoneTrack> Tracks,
-    HeatmapData Heatmap
+    [property: JsonPropertyName("project")] ProjectInfo Project,
+    [property: JsonPropertyName("timeline")] TimelineConfig Timeline,
+    [property: JsonPropertyName("tracks")] List<MilestoneTrack> Tracks,
+    [property: JsonPropertyName("heatmap")] HeatmapData Heatmap
 );
 
 public record ProjectInfo(
-    string Title,
-    string Subtitle,
-    string BacklogUrl,
-    string CurrentMonth
+    [property: JsonPropertyName("title")] string Title,
+    [property: JsonPropertyName("subtitle")] string Subtitle,
+    [property: JsonPropertyName("backlogUrl")] string BacklogUrl,
+    [property: JsonPropertyName("currentMonth")] string CurrentMonth
 );
 
 public record TimelineConfig(
-    List<string> Months,
-    double NowPosition
+    [property: JsonPropertyName("months")] List<string> Months,
+    [property: JsonPropertyName("nowPosition")] double NowPosition
 );
 
 public record MilestoneTrack(
-    string Id,
-    string Label,
-    string Color,
-    List<Milestone> Milestones
+    [property: JsonPropertyName("id")] string Id,
+    [property: JsonPropertyName("label")] string Label,
+    [property: JsonPropertyName("color")] string Color,
+    [property: JsonPropertyName("milestones")] List<Milestone> Milestones
 );
 
 public record Milestone(
-    string Date,
-    string Type,
-    double Position,
-    string? Label
+    [property: JsonPropertyName("date")] string Date,
+    [property: JsonPropertyName("type")] string Type,
+    [property: JsonPropertyName("position")] double Position,
+    [property: JsonPropertyName("label")] string? Label
 );
 
 public record HeatmapData(
-    List<string> Months,
-    List<HeatmapCategory> Categories
+    [property: JsonPropertyName("months")] List<string> Months,
+    [property: JsonPropertyName("categories")] List<HeatmapCategory> Categories
 );
 
 public record HeatmapCategory(
-    string Name,
-    string CssClass,
-    string Emoji,
-    Dictionary<string, List<string>> Items
+    [property: JsonPropertyName("name")] string Name,
+    [property: JsonPropertyName("cssClass")] string CssClass,
+    [property: JsonPropertyName("emoji")] string Emoji,
+    [property: JsonPropertyName("items")] Dictionary<string, List<string>> Items
 );

--- a/ReportingDashboard/Program.cs
+++ b/ReportingDashboard/Program.cs
@@ -1,0 +1,15 @@
+using ReportingDashboard.Components;
+using ReportingDashboard.Services;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddRazorComponents();
+builder.Services.AddSingleton<DashboardDataService>();
+
+var app = builder.Build();
+
+app.UseStaticFiles();
+app.UseAntiforgery();
+app.MapRazorComponents<App>();
+
+app.Run();

--- a/ReportingDashboard/Properties/launchSettings.json
+++ b/ReportingDashboard/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:5000",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/ReportingDashboard/ReportingDashboard.csproj
+++ b/ReportingDashboard/ReportingDashboard.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>ReportingDashboard</RootNamespace>
+  </PropertyGroup>
+
+</Project>

--- a/ReportingDashboard/Services/DashboardDataService.cs
+++ b/ReportingDashboard/Services/DashboardDataService.cs
@@ -1,0 +1,78 @@
+using System.Text.Json;
+using ReportingDashboard.Models;
+
+namespace ReportingDashboard.Services;
+
+public class DashboardDataService
+{
+    private readonly string _path;
+    private readonly JsonSerializerOptions _options = new() { PropertyNameCaseInsensitive = true };
+
+    public DashboardDataService(IWebHostEnvironment env)
+    {
+        _path = Path.Combine(env.ContentRootPath, "Data", "data.json");
+    }
+
+    public (DashboardData? Data, string? Error) Load()
+    {
+        try
+        {
+            if (!File.Exists(_path))
+                return (null, $"data.json not found at: {_path}");
+
+            var json = File.ReadAllText(_path);
+            var data = JsonSerializer.Deserialize<DashboardData>(json, _options);
+
+            if (data is null)
+                return (null, "data.json deserialized to null.");
+
+            var error = Validate(data);
+            return (error is null ? data : null, error);
+        }
+        catch (JsonException ex)
+        {
+            return (null, $"Invalid JSON in data.json: {ex.Message}");
+        }
+    }
+
+    private static string? Validate(DashboardData data)
+    {
+        if (string.IsNullOrWhiteSpace(data.Project?.Title))
+            return "Missing required field: project.title";
+        if (string.IsNullOrWhiteSpace(data.Project?.Subtitle))
+            return "Missing required field: project.subtitle";
+        if (string.IsNullOrWhiteSpace(data.Project?.CurrentMonth))
+            return "Missing required field: project.currentMonth";
+        if (data.Timeline?.Months is null || data.Timeline.Months.Count == 0)
+            return "Missing required field: timeline.months";
+        if (data.Timeline.NowPosition < 0.0 || data.Timeline.NowPosition > 1.0)
+            return "timeline.nowPosition must be between 0.0 and 1.0";
+        if (data.Tracks is null)
+            return "Missing required field: tracks";
+        if (data.Heatmap?.Categories is null)
+            return "Missing required field: heatmap.categories";
+
+        var validCssClasses = new HashSet<string> { "ship", "prog", "carry", "block" };
+        var validMilestoneTypes = new HashSet<string> { "checkpoint", "poc", "production" };
+
+        foreach (var category in data.Heatmap.Categories)
+        {
+            if (!validCssClasses.Contains(category.CssClass))
+                return $"Invalid cssClass: {category.CssClass}";
+        }
+
+        foreach (var track in data.Tracks)
+        {
+            if (track.Milestones is null) continue;
+            foreach (var milestone in track.Milestones)
+            {
+                if (!validMilestoneTypes.Contains(milestone.Type))
+                    return $"Invalid milestone type: {milestone.Type}";
+                if (milestone.Position < 0.0 || milestone.Position > 1.0)
+                    return $"Milestone position must be between 0.0 and 1.0";
+            }
+        }
+
+        return null;
+    }
+}

--- a/ReportingDashboard/Services/DashboardDataService.cs
+++ b/ReportingDashboard/Services/DashboardDataService.cs
@@ -8,6 +8,9 @@ public class DashboardDataService
     private readonly string _path;
     private readonly JsonSerializerOptions _options = new() { PropertyNameCaseInsensitive = true };
 
+    private static readonly HashSet<string> ValidCssClasses = new() { "ship", "prog", "carry", "block" };
+    private static readonly HashSet<string> ValidMilestoneTypes = new() { "checkpoint", "poc", "production" };
+
     public DashboardDataService(IWebHostEnvironment env)
     {
         _path = Path.Combine(env.ContentRootPath, "Data", "data.json");
@@ -27,50 +30,90 @@ public class DashboardDataService
                 return (null, "data.json deserialized to null.");
 
             var error = Validate(data);
-            return (error is null ? data : null, error);
+            return error is null ? (data, null) : (null, error);
         }
         catch (JsonException ex)
         {
             return (null, $"Invalid JSON in data.json: {ex.Message}");
         }
+        catch (Exception ex)
+        {
+            return (null, $"Error reading data.json: {ex.Message}");
+        }
     }
 
     private static string? Validate(DashboardData data)
     {
-        if (string.IsNullOrWhiteSpace(data.Project?.Title))
+        // Project validation
+        if (data.Project is null)
+            return "Missing required field: project";
+        if (string.IsNullOrWhiteSpace(data.Project.Title))
             return "Missing required field: project.title";
-        if (string.IsNullOrWhiteSpace(data.Project?.Subtitle))
+        if (string.IsNullOrWhiteSpace(data.Project.Subtitle))
             return "Missing required field: project.subtitle";
-        if (string.IsNullOrWhiteSpace(data.Project?.CurrentMonth))
+        if (string.IsNullOrWhiteSpace(data.Project.CurrentMonth))
             return "Missing required field: project.currentMonth";
-        if (data.Timeline?.Months is null || data.Timeline.Months.Count == 0)
-            return "Missing required field: timeline.months";
+
+        // Timeline validation
+        if (data.Timeline is null)
+            return "Missing required field: timeline";
+        if (data.Timeline.Months is null || data.Timeline.Months.Count == 0)
+            return "Missing required field: timeline.months (must have at least 1 element)";
         if (data.Timeline.NowPosition < 0.0 || data.Timeline.NowPosition > 1.0)
             return "timeline.nowPosition must be between 0.0 and 1.0";
+
+        // Tracks validation
         if (data.Tracks is null)
             return "Missing required field: tracks";
-        if (data.Heatmap?.Categories is null)
-            return "Missing required field: heatmap.categories";
 
-        var validCssClasses = new HashSet<string> { "ship", "prog", "carry", "block" };
-        var validMilestoneTypes = new HashSet<string> { "checkpoint", "poc", "production" };
-
-        foreach (var category in data.Heatmap.Categories)
+        for (var t = 0; t < data.Tracks.Count; t++)
         {
-            if (!validCssClasses.Contains(category.CssClass))
-                return $"Invalid cssClass: {category.CssClass}";
+            var track = data.Tracks[t];
+            if (string.IsNullOrWhiteSpace(track.Id))
+                return $"Missing required field: tracks[{t}].id";
+            if (string.IsNullOrWhiteSpace(track.Label))
+                return $"Missing required field: tracks[{t}].label";
+            if (string.IsNullOrWhiteSpace(track.Color))
+                return $"Missing required field: tracks[{t}].color";
+
+            if (track.Milestones is not null)
+            {
+                for (var m = 0; m < track.Milestones.Count; m++)
+                {
+                    var milestone = track.Milestones[m];
+                    if (string.IsNullOrWhiteSpace(milestone.Type))
+                        return $"Missing required field: tracks[{t}].milestones[{m}].type";
+                    if (!ValidMilestoneTypes.Contains(milestone.Type))
+                        return $"Invalid milestone type: '{milestone.Type}' in tracks[{t}].milestones[{m}]. Must be one of: checkpoint, poc, production";
+                    if (milestone.Position < 0.0 || milestone.Position > 1.0)
+                        return $"tracks[{t}].milestones[{m}].position must be between 0.0 and 1.0";
+                    if (string.IsNullOrWhiteSpace(milestone.Date))
+                        return $"Missing required field: tracks[{t}].milestones[{m}].date";
+                }
+            }
         }
 
-        foreach (var track in data.Tracks)
+        // Heatmap validation
+        if (data.Heatmap is null)
+            return "Missing required field: heatmap";
+        if (data.Heatmap.Categories is null)
+            return "Missing required field: heatmap.categories";
+        if (data.Heatmap.Months is null || data.Heatmap.Months.Count == 0)
+            return "Missing required field: heatmap.months (must have at least 1 element)";
+
+        for (var c = 0; c < data.Heatmap.Categories.Count; c++)
         {
-            if (track.Milestones is null) continue;
-            foreach (var milestone in track.Milestones)
-            {
-                if (!validMilestoneTypes.Contains(milestone.Type))
-                    return $"Invalid milestone type: {milestone.Type}";
-                if (milestone.Position < 0.0 || milestone.Position > 1.0)
-                    return $"Milestone position must be between 0.0 and 1.0";
-            }
+            var category = data.Heatmap.Categories[c];
+            if (string.IsNullOrWhiteSpace(category.Name))
+                return $"Missing required field: heatmap.categories[{c}].name";
+            if (string.IsNullOrWhiteSpace(category.CssClass))
+                return $"Missing required field: heatmap.categories[{c}].cssClass";
+            if (!ValidCssClasses.Contains(category.CssClass))
+                return $"Invalid cssClass: '{category.CssClass}' in heatmap.categories[{c}]. Must be one of: ship, prog, carry, block";
+            if (string.IsNullOrWhiteSpace(category.Emoji))
+                return $"Missing required field: heatmap.categories[{c}].emoji";
+            if (category.Items is null)
+                return $"Missing required field: heatmap.categories[{c}].items";
         }
 
         return null;

--- a/ReportingDashboard/wwwroot/css/app.css
+++ b/ReportingDashboard/wwwroot/css/app.css
@@ -1,0 +1,33 @@
+/* placeholder - full stylesheet will be created in step 4 */
+
+.dashboard-error {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 1920px;
+    height: 1080px;
+    background: #fff;
+}
+
+.dashboard-error-content {
+    text-align: center;
+    max-width: 800px;
+    padding: 40px;
+}
+
+.dashboard-error-content h2 {
+    font-size: 24px;
+    color: #c00;
+    margin-bottom: 16px;
+}
+
+.dashboard-error-content p {
+    font-size: 18px;
+    color: #c00;
+    line-height: 1.6;
+    word-break: break-word;
+}
+
+.components-reconnect-modal {
+    display: none !important;
+}

--- a/ReportingDashboard/wwwroot/css/app.css
+++ b/ReportingDashboard/wwwroot/css/app.css
@@ -1,12 +1,430 @@
-/* placeholder - full stylesheet will be created in step 4 */
+/* ============================================================
+   Executive Reporting Dashboard — Global Stylesheet
+   Ported from OriginalDesignConcept.html
+   All CSS in one file to prevent merge conflicts.
+   ============================================================ */
 
+/* --- CSS Custom Properties (Theme Colors) --- */
+:root {
+    /* Track colors */
+    --track-m1: #0078D4;
+    --track-m2: #00897B;
+    --track-m3: #546E7A;
+
+    /* Milestone marker colors */
+    --color-poc: #F4B400;
+    --color-prod: #34A853;
+    --color-checkpoint: #999;
+    --color-now: #EA4335;
+
+    /* Link color */
+    --color-link: #0078D4;
+
+    /* Borders */
+    --border-light: #E0E0E0;
+    --border-medium: #CCC;
+    --border-heavy: #E8E8E8;
+
+    /* Text colors */
+    --text-primary: #111;
+    --text-secondary: #888;
+    --text-muted: #AAA;
+    --text-label: #666;
+    --text-track-name: #444;
+    --text-item: #333;
+
+    /* Backgrounds */
+    --bg-page: #FFFFFF;
+    --bg-timeline: #FAFAFA;
+    --bg-header-row: #F5F5F5;
+
+    /* Current month highlight */
+    --bg-current-month-hdr: #FFF0D0;
+    --text-current-month-hdr: #C07700;
+
+    /* Shipped (green) */
+    --ship-hdr-bg: #E8F5E9;
+    --ship-hdr-text: #1B7A28;
+    --ship-cell-bg: #F0FBF0;
+    --ship-cell-current-bg: #D8F2DA;
+    --ship-dot: #34A853;
+
+    /* In Progress (blue) */
+    --prog-hdr-bg: #E3F2FD;
+    --prog-hdr-text: #1565C0;
+    --prog-cell-bg: #EEF4FE;
+    --prog-cell-current-bg: #DAE8FB;
+    --prog-dot: #0078D4;
+
+    /* Carryover (amber) */
+    --carry-hdr-bg: #FFF8E1;
+    --carry-hdr-text: #B45309;
+    --carry-cell-bg: #FFFDE7;
+    --carry-cell-current-bg: #FFF0B0;
+    --carry-dot: #F4B400;
+
+    /* Blockers (red) */
+    --block-hdr-bg: #FEF2F2;
+    --block-hdr-text: #991B1B;
+    --block-cell-bg: #FFF5F5;
+    --block-cell-current-bg: #FFE4E4;
+    --block-dot: #EA4335;
+}
+
+/* --- Global Reset --- */
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+/* --- Body --- */
+body {
+    width: 1920px;
+    height: 1080px;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    font-family: 'Segoe UI', Arial, sans-serif;
+    color: var(--text-primary);
+    background: var(--bg-page);
+}
+
+/* --- Links --- */
+a {
+    color: var(--color-link);
+    text-decoration: none;
+}
+
+a:hover {
+    text-decoration: underline;
+}
+
+/* ============================================================
+   Section 1: Header (.hdr)
+   ============================================================ */
+.hdr {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 12px 44px 10px 44px;
+    border-bottom: 1px solid var(--border-light);
+    flex-shrink: 0;
+}
+
+.hdr h1 {
+    font-size: 24px;
+    font-weight: 700;
+    margin: 0;
+    line-height: 1.2;
+}
+
+.hdr h1 a {
+    font-size: 13px;
+    font-weight: 400;
+    margin-left: 10px;
+    color: var(--color-link);
+    text-decoration: none;
+}
+
+.hdr h1 a:hover {
+    text-decoration: underline;
+}
+
+.sub {
+    font-size: 12px;
+    color: var(--text-secondary);
+    margin-top: 2px;
+}
+
+/* Header legend */
+.hdr-legend {
+    display: flex;
+    align-items: center;
+    gap: 22px;
+    font-size: 12px;
+    color: var(--text-label);
+}
+
+.hdr-legend-item {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.legend-diamond {
+    width: 12px;
+    height: 12px;
+    transform: rotate(45deg);
+    display: inline-block;
+    flex-shrink: 0;
+}
+
+.legend-diamond-poc {
+    background: var(--color-poc);
+}
+
+.legend-diamond-prod {
+    background: var(--color-prod);
+}
+
+.legend-circle {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--color-checkpoint);
+    display: inline-block;
+    flex-shrink: 0;
+}
+
+.legend-now-bar {
+    width: 2px;
+    height: 14px;
+    background: var(--color-now);
+    display: inline-block;
+    flex-shrink: 0;
+}
+
+/* ============================================================
+   Section 2: Timeline Area (.tl-area)
+   ============================================================ */
+.tl-area {
+    height: 196px;
+    flex-shrink: 0;
+    background: var(--bg-timeline);
+    border-bottom: 2px solid var(--border-heavy);
+    padding: 6px 44px;
+    display: flex;
+    flex-direction: row;
+}
+
+/* Timeline labels sidebar (left) */
+.tl-labels {
+    width: 230px;
+    flex-shrink: 0;
+    border-right: 1px solid var(--border-light);
+    padding: 16px 12px 16px 0;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-around;
+}
+
+.tl-track-label {
+    display: flex;
+    align-items: baseline;
+    gap: 6px;
+    font-size: 12px;
+    line-height: 1.4;
+}
+
+.tl-track-id {
+    font-weight: 600;
+}
+
+.tl-track-name {
+    font-weight: 400;
+    color: var(--text-track-name);
+}
+
+/* SVG timeline container (right) */
+.tl-svg-box {
+    flex: 1;
+    padding-left: 12px;
+    padding-top: 6px;
+    overflow: visible;
+}
+
+/* ============================================================
+   Section 3: Heatmap (.hm-wrap)
+   ============================================================ */
+.hm-wrap {
+    flex: 1;
+    min-height: 0;
+    padding: 10px 44px;
+    display: flex;
+    flex-direction: column;
+}
+
+.hm-title {
+    font-size: 14px;
+    font-weight: 700;
+    color: var(--text-secondary);
+    letter-spacing: 0.5px;
+    text-transform: uppercase;
+    margin-bottom: 8px;
+}
+
+/* --- Heatmap Grid --- */
+.hm-grid {
+    flex: 1;
+    min-height: 0;
+    display: grid;
+    border: 1px solid var(--border-light);
+}
+
+/* Corner cell ("STATUS") */
+.hm-corner {
+    background: var(--bg-header-row);
+    font-size: 11px;
+    font-weight: 700;
+    text-transform: uppercase;
+    color: #999;
+    display: flex;
+    align-items: center;
+    padding: 0 12px;
+    border-bottom: 2px solid var(--border-medium);
+    border-right: 2px solid var(--border-medium);
+}
+
+/* Month column headers */
+.hm-col-hdr {
+    background: var(--bg-header-row);
+    font-size: 16px;
+    font-weight: 700;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-bottom: 2px solid var(--border-medium);
+    border-right: 1px solid var(--border-light);
+}
+
+/* Current month header highlight */
+.apr-hdr {
+    background: var(--bg-current-month-hdr) !important;
+    color: var(--text-current-month-hdr);
+}
+
+/* --- Row Headers --- */
+.hm-row-hdr {
+    font-size: 11px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.7px;
+    display: flex;
+    align-items: center;
+    padding: 0 12px;
+    border-right: 2px solid var(--border-medium);
+    border-bottom: 1px solid var(--border-light);
+}
+
+/* --- Data Cells --- */
+.hm-cell {
+    padding: 8px 12px;
+    border-right: 1px solid var(--border-light);
+    border-bottom: 1px solid var(--border-light);
+    overflow: hidden;
+}
+
+/* --- Cell Items --- */
+.it {
+    font-size: 12px;
+    color: var(--text-item);
+    line-height: 1.35;
+    padding: 2px 0 2px 12px;
+    position: relative;
+}
+
+.it::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 7px;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+}
+
+/* ============================================================
+   Row Color Variants: Shipped (green)
+   ============================================================ */
+.ship-hdr {
+    background: var(--ship-hdr-bg);
+    color: var(--ship-hdr-text);
+}
+
+.ship-cell {
+    background: var(--ship-cell-bg);
+}
+
+.ship-cell.apr {
+    background: var(--ship-cell-current-bg);
+}
+
+.ship-cell .it::before {
+    background: var(--ship-dot);
+}
+
+/* ============================================================
+   Row Color Variants: In Progress (blue)
+   ============================================================ */
+.prog-hdr {
+    background: var(--prog-hdr-bg);
+    color: var(--prog-hdr-text);
+}
+
+.prog-cell {
+    background: var(--prog-cell-bg);
+}
+
+.prog-cell.apr {
+    background: var(--prog-cell-current-bg);
+}
+
+.prog-cell .it::before {
+    background: var(--prog-dot);
+}
+
+/* ============================================================
+   Row Color Variants: Carryover (amber)
+   ============================================================ */
+.carry-hdr {
+    background: var(--carry-hdr-bg);
+    color: var(--carry-hdr-text);
+}
+
+.carry-cell {
+    background: var(--carry-cell-bg);
+}
+
+.carry-cell.apr {
+    background: var(--carry-cell-current-bg);
+}
+
+.carry-cell .it::before {
+    background: var(--carry-dot);
+}
+
+/* ============================================================
+   Row Color Variants: Blockers (red)
+   ============================================================ */
+.block-hdr {
+    background: var(--block-hdr-bg);
+    color: var(--block-hdr-text);
+}
+
+.block-cell {
+    background: var(--block-cell-bg);
+}
+
+.block-cell.apr {
+    background: var(--block-cell-current-bg);
+}
+
+.block-cell .it::before {
+    background: var(--block-dot);
+}
+
+/* ============================================================
+   Error Display (Dashboard.razor error state)
+   ============================================================ */
 .dashboard-error {
     display: flex;
     align-items: center;
     justify-content: center;
-    width: 1920px;
-    height: 1080px;
-    background: #fff;
+    width: 100%;
+    flex: 1;
+    min-height: 0;
+    background: var(--bg-page);
 }
 
 .dashboard-error-content {
@@ -28,6 +446,13 @@
     word-break: break-word;
 }
 
+/* ============================================================
+   Blazor Safety Net: Hide reconnection modal
+   ============================================================ */
 .components-reconnect-modal {
+    display: none !important;
+}
+
+#components-reconnect-modal {
     display: none !important;
 }

--- a/tests/ReportingDashboard.Tests/Integration/DIContainerTests.cs
+++ b/tests/ReportingDashboard.Tests/Integration/DIContainerTests.cs
@@ -1,0 +1,62 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using ReportingDashboard.Services;
+using Xunit;
+
+namespace ReportingDashboard.Tests.Integration;
+
+[Trait("Category", "Integration")]
+public class DIContainerTests : IDisposable
+{
+    private readonly WebAppFactory _factory;
+
+    public DIContainerTests()
+    {
+        _factory = new WebAppFactory();
+    }
+
+    public void Dispose() => _factory.Dispose();
+
+    [Fact]
+    public void DashboardDataService_IsRegistered()
+    {
+        var service = _factory.Services.GetService<DashboardDataService>();
+        service.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void DashboardDataService_IsSingleton()
+    {
+        var s1 = _factory.Services.GetRequiredService<DashboardDataService>();
+        var s2 = _factory.Services.GetRequiredService<DashboardDataService>();
+        s1.Should().BeSameAs(s2);
+    }
+
+    [Fact]
+    public void IWebHostEnvironment_IsAvailable()
+    {
+        var env = _factory.Services.GetService<IWebHostEnvironment>();
+        env.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void DashboardDataService_ResolvesFromScopedProvider()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var service = scope.ServiceProvider.GetService<DashboardDataService>();
+        service.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void DashboardDataService_SameInstanceAcrossScopes()
+    {
+        using var scope1 = _factory.Services.CreateScope();
+        using var scope2 = _factory.Services.CreateScope();
+
+        var s1 = scope1.ServiceProvider.GetRequiredService<DashboardDataService>();
+        var s2 = scope2.ServiceProvider.GetRequiredService<DashboardDataService>();
+
+        s1.Should().BeSameAs(s2, "singleton should return same instance across scopes");
+    }
+}

--- a/tests/ReportingDashboard.Tests/Integration/DashboardDataServiceIntegrationTests.cs
+++ b/tests/ReportingDashboard.Tests/Integration/DashboardDataServiceIntegrationTests.cs
@@ -1,0 +1,104 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using ReportingDashboard.Services;
+using ReportingDashboard.Tests.Integration.Helpers;
+using Xunit;
+
+namespace ReportingDashboard.Tests.Integration;
+
+[Trait("Category", "Integration")]
+public class DashboardDataServiceIntegrationTests : IDisposable
+{
+    private readonly WebAppFactory _factory;
+
+    public DashboardDataServiceIntegrationTests()
+    {
+        _factory = new WebAppFactory();
+    }
+
+    public void Dispose() => _factory.Dispose();
+
+    private DashboardDataService ResolveService()
+    {
+        // Resolve the service from the real DI container
+        var scope = _factory.Services.CreateScope();
+        return scope.ServiceProvider.GetRequiredService<DashboardDataService>();
+    }
+
+    [Fact]
+    public void Service_IsRegisteredAsSingleton_InDIContainer()
+    {
+        var service1 = _factory.Services.GetRequiredService<DashboardDataService>();
+        var service2 = _factory.Services.GetRequiredService<DashboardDataService>();
+
+        service1.Should().BeSameAs(service2);
+    }
+
+    [Fact]
+    public void Service_ResolvesFromDI_WithWebHostEnvironment()
+    {
+        var service = _factory.Services.GetService<DashboardDataService>();
+        service.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Load_WithValidFile_ThroughDI_ReturnsData()
+    {
+        _factory.WriteDataJson(TestDataHelper.BuildValidJsonString());
+        var service = ResolveService();
+
+        var (data, error) = service.Load();
+
+        error.Should().BeNull();
+        data.Should().NotBeNull();
+        data!.Project.Title.Should().Be("Test Project");
+    }
+
+    [Fact]
+    public void Load_WithMissingFile_ThroughDI_ReturnsFileNotFoundError()
+    {
+        _factory.DeleteDataJson();
+        var service = ResolveService();
+
+        var (data, error) = service.Load();
+
+        data.Should().BeNull();
+        error.Should().Contain("data.json not found at:");
+    }
+
+    [Fact]
+    public void Load_WithMalformedJson_ThroughDI_ReturnsParseError()
+    {
+        _factory.WriteDataJson("{ broken json }");
+        var service = ResolveService();
+
+        var (data, error) = service.Load();
+
+        data.Should().BeNull();
+        error.Should().Contain("Invalid JSON in data.json:");
+    }
+
+    [Fact]
+    public void Load_ReReadsFileOnEachCall_ThroughDI()
+    {
+        _factory.WriteDataJson(TestDataHelper.BuildValidJsonString(title: "Version 1"));
+        var service = ResolveService();
+
+        var (data1, _) = service.Load();
+        data1!.Project.Title.Should().Be("Version 1");
+
+        _factory.WriteDataJson(TestDataHelper.BuildValidJsonString(title: "Version 2"));
+
+        var (data2, _) = service.Load();
+        data2!.Project.Title.Should().Be("Version 2");
+    }
+
+    [Fact]
+    public void IWebHostEnvironment_IsAvailable_InDI()
+    {
+        var env = _factory.Services.GetService<IWebHostEnvironment>();
+        env.Should().NotBeNull();
+        env!.ContentRootPath.Should().NotBeNullOrEmpty();
+    }
+}

--- a/tests/ReportingDashboard.Tests/Integration/DashboardPageIntegrationTests.cs
+++ b/tests/ReportingDashboard.Tests/Integration/DashboardPageIntegrationTests.cs
@@ -1,0 +1,260 @@
+using System.Net;
+using FluentAssertions;
+using ReportingDashboard.Tests.Integration.Helpers;
+using Xunit;
+
+namespace ReportingDashboard.Tests.Integration;
+
+[Trait("Category", "Integration")]
+public class DashboardPageIntegrationTests : IClassFixture<WebAppFactory>, IDisposable
+{
+    private readonly WebAppFactory _factory;
+    private readonly HttpClient _client;
+
+    public DashboardPageIntegrationTests(WebAppFactory factory)
+    {
+        _factory = factory;
+        _client = _factory.CreateClient();
+    }
+
+    public void Dispose() => _client.Dispose();
+
+    [Fact]
+    public async Task GetRoot_ReturnsSuccessStatusCode()
+    {
+        _factory.WriteDataJson(TestDataHelper.BuildValidJsonString());
+
+        var response = await _client.GetAsync("/");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task GetRoot_ReturnsHtmlContentType()
+    {
+        _factory.WriteDataJson(TestDataHelper.BuildValidJsonString());
+
+        var response = await _client.GetAsync("/");
+
+        response.Content.Headers.ContentType!.MediaType.Should().Be("text/html");
+    }
+
+    [Fact]
+    public async Task GetRoot_WithValidData_RendersProjectTitle()
+    {
+        _factory.WriteDataJson(TestDataHelper.BuildValidJsonString(title: "Executive Dashboard Alpha"));
+
+        var response = await _client.GetAsync("/");
+        var html = await response.Content.ReadAsStringAsync();
+
+        html.Should().Contain("Executive Dashboard Alpha");
+    }
+
+    [Fact]
+    public async Task GetRoot_WithValidData_RendersSubtitle()
+    {
+        _factory.WriteDataJson(TestDataHelper.BuildValidJsonString(subtitle: "Cloud Engineering · Platform · Apr 2024"));
+
+        var response = await _client.GetAsync("/");
+        var html = await response.Content.ReadAsStringAsync();
+
+        html.Should().Contain("Cloud Engineering · Platform · Apr 2024");
+    }
+
+    [Fact]
+    public async Task GetRoot_WithValidData_RendersHeaderSection()
+    {
+        _factory.WriteDataJson(TestDataHelper.BuildValidJsonString());
+
+        var response = await _client.GetAsync("/");
+        var html = await response.Content.ReadAsStringAsync();
+
+        html.Should().Contain("class=\"hdr\"");
+    }
+
+    [Fact]
+    public async Task GetRoot_WithValidData_RendersTimelinePlaceholder()
+    {
+        _factory.WriteDataJson(TestDataHelper.BuildValidJsonString());
+
+        var response = await _client.GetAsync("/");
+        var html = await response.Content.ReadAsStringAsync();
+
+        html.Should().Contain("class=\"tl-area\"");
+        html.Should().Contain("Timeline placeholder");
+        html.Should().Contain("1 track(s) configured");
+    }
+
+    [Fact]
+    public async Task GetRoot_WithValidData_RendersHeatmapPlaceholder()
+    {
+        _factory.WriteDataJson(TestDataHelper.BuildValidJsonString());
+
+        var response = await _client.GetAsync("/");
+        var html = await response.Content.ReadAsStringAsync();
+
+        html.Should().Contain("class=\"hm-wrap\"");
+        html.Should().Contain("Heatmap placeholder");
+        html.Should().Contain("4 categories x 6 months");
+    }
+
+    [Fact]
+    public async Task GetRoot_WithMissingDataJson_RendersErrorMessage()
+    {
+        _factory.DeleteDataJson();
+
+        var response = await _client.GetAsync("/");
+        var html = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        html.Should().Contain("Dashboard Error");
+        html.Should().Contain("data.json not found at:");
+    }
+
+    [Fact]
+    public async Task GetRoot_WithMissingDataJson_DoesNotRenderStackTrace()
+    {
+        _factory.DeleteDataJson();
+
+        var response = await _client.GetAsync("/");
+        var html = await response.Content.ReadAsStringAsync();
+
+        html.Should().NotContain("System.");
+        html.Should().NotContain("StackTrace");
+        html.Should().NotContain("at ReportingDashboard");
+    }
+
+    [Fact]
+    public async Task GetRoot_WithMalformedJson_RendersParseError()
+    {
+        _factory.WriteDataJson("{ broken }");
+
+        var response = await _client.GetAsync("/");
+        var html = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        html.Should().Contain("Dashboard Error");
+        html.Should().Contain("Invalid JSON");
+    }
+
+    [Fact]
+    public async Task GetRoot_WithMissingRequiredField_RendersValidationError()
+    {
+        var json = """
+        {
+            "project": { "title": "", "subtitle": "S", "backlogUrl": "", "currentMonth": "Jan" },
+            "timeline": { "months": ["Jan"], "nowPosition": 0.5 },
+            "tracks": [],
+            "heatmap": { "months": ["Jan"], "categories": [] }
+        }
+        """;
+        _factory.WriteDataJson(json);
+
+        var response = await _client.GetAsync("/");
+        var html = await response.Content.ReadAsStringAsync();
+
+        html.Should().Contain("Dashboard Error");
+        html.Should().Contain("project.title");
+    }
+
+    [Fact]
+    public async Task GetRoot_WithInvalidNowPosition_RendersValidationError()
+    {
+        var json = """
+        {
+            "project": { "title": "T", "subtitle": "S", "backlogUrl": "", "currentMonth": "Jan" },
+            "timeline": { "months": ["Jan"], "nowPosition": 1.5 },
+            "tracks": [],
+            "heatmap": { "months": ["Jan"], "categories": [] }
+        }
+        """;
+        _factory.WriteDataJson(json);
+
+        var response = await _client.GetAsync("/");
+        var html = await response.Content.ReadAsStringAsync();
+
+        html.Should().Contain("Dashboard Error");
+        html.Should().Contain("nowPosition");
+    }
+
+    [Fact]
+    public async Task GetRoot_WithValidData_DoesNotRenderErrorSection()
+    {
+        _factory.WriteDataJson(TestDataHelper.BuildValidJsonString());
+
+        var response = await _client.GetAsync("/");
+        var html = await response.Content.ReadAsStringAsync();
+
+        html.Should().NotContain("Dashboard Error");
+        html.Should().NotContain("dashboard-error");
+    }
+
+    [Fact]
+    public async Task GetRoot_RendersWithin1920Container()
+    {
+        _factory.WriteDataJson(TestDataHelper.BuildValidJsonString());
+
+        var response = await _client.GetAsync("/");
+        var html = await response.Content.ReadAsStringAsync();
+
+        html.Should().Contain("width:1920px");
+        html.Should().Contain("height:1080px");
+        html.Should().Contain("overflow:hidden");
+    }
+
+    [Fact]
+    public async Task GetRoot_HasNoRenderModeAttribute()
+    {
+        _factory.WriteDataJson(TestDataHelper.BuildValidJsonString());
+
+        var response = await _client.GetAsync("/");
+        var html = await response.Content.ReadAsStringAsync();
+
+        html.Should().NotContain("rendermode");
+        html.Should().NotContain("blazor-enhanced-nav");
+    }
+
+    [Fact]
+    public async Task GetRoot_HasCorrectDoctype()
+    {
+        _factory.WriteDataJson(TestDataHelper.BuildValidJsonString());
+
+        var response = await _client.GetAsync("/");
+        var html = await response.Content.ReadAsStringAsync();
+
+        html.TrimStart().Should().StartWith("<!DOCTYPE html>");
+    }
+
+    [Fact]
+    public async Task GetRoot_HasCorrectViewportMeta()
+    {
+        _factory.WriteDataJson(TestDataHelper.BuildValidJsonString());
+
+        var response = await _client.GetAsync("/");
+        var html = await response.Content.ReadAsStringAsync();
+
+        html.Should().Contain("width=1920");
+    }
+
+    [Fact]
+    public async Task GetRoot_HasCssLink()
+    {
+        _factory.WriteDataJson(TestDataHelper.BuildValidJsonString());
+
+        var response = await _client.GetAsync("/");
+        var html = await response.Content.ReadAsStringAsync();
+
+        html.Should().Contain("css/app.css");
+    }
+
+    [Fact]
+    public async Task GetRoot_HasCorrectTitle()
+    {
+        _factory.WriteDataJson(TestDataHelper.BuildValidJsonString());
+
+        var response = await _client.GetAsync("/");
+        var html = await response.Content.ReadAsStringAsync();
+
+        html.Should().Contain("<title>Executive Reporting Dashboard</title>");
+    }
+}

--- a/tests/ReportingDashboard.Tests/Integration/ErrorRenderingIntegrationTests.cs
+++ b/tests/ReportingDashboard.Tests/Integration/ErrorRenderingIntegrationTests.cs
@@ -1,0 +1,215 @@
+using System.Net;
+using FluentAssertions;
+using Xunit;
+
+namespace ReportingDashboard.Tests.Integration;
+
+[Trait("Category", "Integration")]
+public class ErrorRenderingIntegrationTests : IDisposable
+{
+    private readonly WebAppFactory _factory;
+    private readonly HttpClient _client;
+
+    public ErrorRenderingIntegrationTests()
+    {
+        _factory = new WebAppFactory();
+        _client = _factory.CreateClient();
+    }
+
+    public void Dispose()
+    {
+        _client.Dispose();
+        _factory.Dispose();
+    }
+
+    [Fact]
+    public async Task MissingFile_RendersErrorDiv_NotBlazorErrorBoundary()
+    {
+        _factory.DeleteDataJson();
+
+        var response = await _client.GetAsync("/");
+        var html = await response.Content.ReadAsStringAsync();
+
+        html.Should().Contain("dashboard-error");
+        html.Should().NotContain("blazor-error-boundary");
+        html.Should().NotContain("blazor-error-ui");
+    }
+
+    [Fact]
+    public async Task MissingFile_ErrorContainsFilePath()
+    {
+        _factory.DeleteDataJson();
+
+        var response = await _client.GetAsync("/");
+        var html = await response.Content.ReadAsStringAsync();
+
+        html.Should().Contain("data.json not found at:");
+        html.Should().Contain("Data");
+    }
+
+    [Fact]
+    public async Task MalformedJson_EmptyObject_RendersValidationError()
+    {
+        _factory.WriteDataJson("{}");
+
+        var response = await _client.GetAsync("/");
+        var html = await response.Content.ReadAsStringAsync();
+
+        html.Should().Contain("Dashboard Error");
+    }
+
+    [Fact]
+    public async Task MalformedJson_ArrayInsteadOfObject_RendersError()
+    {
+        _factory.WriteDataJson("[1,2,3]");
+
+        var response = await _client.GetAsync("/");
+        var html = await response.Content.ReadAsStringAsync();
+
+        html.Should().Contain("Dashboard Error");
+    }
+
+    [Fact]
+    public async Task MalformedJson_TruncatedString_RendersParseError()
+    {
+        _factory.WriteDataJson("{\"project\": {\"title\": \"unterminated");
+
+        var response = await _client.GetAsync("/");
+        var html = await response.Content.ReadAsStringAsync();
+
+        html.Should().Contain("Dashboard Error");
+        html.Should().Contain("Invalid JSON");
+    }
+
+    [Fact]
+    public async Task ValidationError_EmptyTitle_ShowsFieldName()
+    {
+        var json = """
+        {
+            "project": { "title": "", "subtitle": "Sub", "backlogUrl": "", "currentMonth": "Jan" },
+            "timeline": { "months": ["Jan"], "nowPosition": 0.5 },
+            "tracks": [],
+            "heatmap": { "months": ["Jan"], "categories": [] }
+        }
+        """;
+        _factory.WriteDataJson(json);
+
+        var response = await _client.GetAsync("/");
+        var html = await response.Content.ReadAsStringAsync();
+
+        html.Should().Contain("project.title");
+    }
+
+    [Fact]
+    public async Task ValidationError_EmptySubtitle_ShowsFieldName()
+    {
+        var json = """
+        {
+            "project": { "title": "T", "subtitle": "", "backlogUrl": "", "currentMonth": "Jan" },
+            "timeline": { "months": ["Jan"], "nowPosition": 0.5 },
+            "tracks": [],
+            "heatmap": { "months": ["Jan"], "categories": [] }
+        }
+        """;
+        _factory.WriteDataJson(json);
+
+        var response = await _client.GetAsync("/");
+        var html = await response.Content.ReadAsStringAsync();
+
+        html.Should().Contain("project.subtitle");
+    }
+
+    [Fact]
+    public async Task ValidationError_EmptyTimelineMonths_ShowsFieldName()
+    {
+        var json = """
+        {
+            "project": { "title": "T", "subtitle": "S", "backlogUrl": "", "currentMonth": "Jan" },
+            "timeline": { "months": [], "nowPosition": 0.5 },
+            "tracks": [],
+            "heatmap": { "months": ["Jan"], "categories": [] }
+        }
+        """;
+        _factory.WriteDataJson(json);
+
+        var response = await _client.GetAsync("/");
+        var html = await response.Content.ReadAsStringAsync();
+
+        html.Should().Contain("timeline.months");
+    }
+
+    [Fact]
+    public async Task ValidationError_InvalidCssClass_ShowsFieldName()
+    {
+        var json = """
+        {
+            "project": { "title": "T", "subtitle": "S", "backlogUrl": "", "currentMonth": "Jan" },
+            "timeline": { "months": ["Jan"], "nowPosition": 0.5 },
+            "tracks": [],
+            "heatmap": {
+                "months": ["Jan"],
+                "categories": [
+                    { "name": "X", "cssClass": "invalid", "emoji": "✅", "items": {} }
+                ]
+            }
+        }
+        """;
+        _factory.WriteDataJson(json);
+
+        var response = await _client.GetAsync("/");
+        var html = await response.Content.ReadAsStringAsync();
+
+        html.Should().Contain("Invalid cssClass");
+        html.Should().Contain("heatmap.categories[0]");
+    }
+
+    [Fact]
+    public async Task ValidationError_InvalidMilestoneType_ShowsError()
+    {
+        var json = """
+        {
+            "project": { "title": "T", "subtitle": "S", "backlogUrl": "", "currentMonth": "Jan" },
+            "timeline": { "months": ["Jan"], "nowPosition": 0.5 },
+            "tracks": [
+                {
+                    "id": "m1", "label": "L", "color": "#000",
+                    "milestones": [
+                        { "date": "2024-01-01", "type": "invalid", "position": 0.5 }
+                    ]
+                }
+            ],
+            "heatmap": { "months": ["Jan"], "categories": [] }
+        }
+        """;
+        _factory.WriteDataJson(json);
+
+        var response = await _client.GetAsync("/");
+        var html = await response.Content.ReadAsStringAsync();
+
+        html.Should().Contain("Invalid milestone type");
+    }
+
+    [Fact]
+    public async Task ErrorPage_StillReturns200StatusCode()
+    {
+        _factory.DeleteDataJson();
+
+        var response = await _client.GetAsync("/");
+
+        // Blazor renders error within the page, still returns 200
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task ErrorPage_DoesNotRenderDataSections()
+    {
+        _factory.DeleteDataJson();
+
+        var response = await _client.GetAsync("/");
+        var html = await response.Content.ReadAsStringAsync();
+
+        html.Should().NotContain("class=\"hdr\"");
+        html.Should().NotContain("class=\"tl-area\"");
+        html.Should().NotContain("class=\"hm-wrap\"");
+    }
+}

--- a/tests/ReportingDashboard.Tests/Integration/Helpers/TestDataHelper.cs
+++ b/tests/ReportingDashboard.Tests/Integration/Helpers/TestDataHelper.cs
@@ -1,0 +1,89 @@
+using System.Text.Json;
+
+namespace ReportingDashboard.Tests.Integration.Helpers;
+
+public static class TestDataHelper
+{
+    public static string BuildValidJsonString(
+        string title = "Test Project",
+        string subtitle = "Test Org · Test Workstream · Apr 2024",
+        string backlogUrl = "https://dev.azure.com/test",
+        string currentMonth = "Apr",
+        double nowPosition = 0.55)
+    {
+        var data = new
+        {
+            project = new { title, subtitle, backlogUrl, currentMonth },
+            timeline = new
+            {
+                months = new[] { "Jan", "Feb", "Mar", "Apr", "May", "Jun" },
+                nowPosition
+            },
+            tracks = new[]
+            {
+                new
+                {
+                    id = "m1",
+                    label = "M1 - Feature Alpha",
+                    color = "#4285F4",
+                    milestones = new[]
+                    {
+                        new { date = "2024-02-15", type = "checkpoint", position = 0.25, label = (string?)null },
+                        new { date = "2024-04-01", type = "poc", position = 0.55, label = "PoC" },
+                        new { date = "2024-06-01", type = "production", position = 0.92, label = "GA" }
+                    }
+                }
+            },
+            heatmap = new
+            {
+                months = new[] { "Jan", "Feb", "Mar", "Apr", "May", "Jun" },
+                categories = new[]
+                {
+                    new
+                    {
+                        name = "Shipped",
+                        cssClass = "ship",
+                        emoji = "✅",
+                        items = new Dictionary<string, string[]>
+                        {
+                            { "Jan", new[] { "Auth module", "CI pipeline" } },
+                            { "Feb", new[] { "Search API" } }
+                        }
+                    },
+                    new
+                    {
+                        name = "In Progress",
+                        cssClass = "prog",
+                        emoji = "🔄",
+                        items = new Dictionary<string, string[]>
+                        {
+                            { "Apr", new[] { "Dashboard UI", "Data layer" } }
+                        }
+                    },
+                    new
+                    {
+                        name = "Carryover",
+                        cssClass = "carry",
+                        emoji = "📦",
+                        items = new Dictionary<string, string[]>
+                        {
+                            { "Mar", new[] { "Legacy migration" } }
+                        }
+                    },
+                    new
+                    {
+                        name = "Blockers",
+                        cssClass = "block",
+                        emoji = "🚫",
+                        items = new Dictionary<string, string[]>
+                        {
+                            { "Apr", new[] { "Vendor dependency" } }
+                        }
+                    }
+                }
+            }
+        };
+
+        return JsonSerializer.Serialize(data, new JsonSerializerOptions { WriteIndented = true });
+    }
+}

--- a/tests/ReportingDashboard.Tests/Integration/MiddlewarePipelineTests.cs
+++ b/tests/ReportingDashboard.Tests/Integration/MiddlewarePipelineTests.cs
@@ -1,0 +1,126 @@
+using System.Net;
+using FluentAssertions;
+using ReportingDashboard.Tests.Integration.Helpers;
+using Xunit;
+
+namespace ReportingDashboard.Tests.Integration;
+
+[Trait("Category", "Integration")]
+public class MiddlewarePipelineTests : IDisposable
+{
+    private readonly WebAppFactory _factory;
+    private readonly HttpClient _client;
+
+    public MiddlewarePipelineTests()
+    {
+        _factory = new WebAppFactory();
+        _client = _factory.CreateClient();
+    }
+
+    public void Dispose()
+    {
+        _client.Dispose();
+        _factory.Dispose();
+    }
+
+    [Fact]
+    public async Task AntiforgeryMiddleware_IsActive_ResponseContainsToken()
+    {
+        _factory.WriteDataJson(TestDataHelper.BuildValidJsonString());
+
+        var response = await _client.GetAsync("/");
+        var html = await response.Content.ReadAsStringAsync();
+
+        // Antiforgery middleware typically injects a __RequestVerificationToken
+        // or sets antiforgery cookies. We check for cookie presence.
+        response.Headers.TryGetValues("Set-Cookie", out var cookies);
+        // Blazor static SSR with antiforgery should set a cookie
+        // This test verifies the middleware pipeline is wired up
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task UnknownRoute_Returns200_WithNotFoundContent()
+    {
+        _factory.WriteDataJson(TestDataHelper.BuildValidJsonString());
+
+        // Blazor Router handles unknown routes with its NotFound template
+        var response = await _client.GetAsync("/unknown-page-xyz");
+        var html = await response.Content.ReadAsStringAsync();
+
+        // The Router's NotFound renders "Page Not Found"
+        // Note: depending on routing config this may return 200 with the not-found content
+        // or 404. In Blazor static SSR, the Router renders within the page.
+        response.StatusCode.Should().BeOneOf(HttpStatusCode.OK, HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task GetRoot_ResponseIsNotChunkedOrStreaming_CompletesQuickly()
+    {
+        _factory.WriteDataJson(TestDataHelper.BuildValidJsonString());
+
+        var response = await _client.GetAsync("/");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+        html.Length.Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public async Task GetRoot_NoBlazorScriptReference()
+    {
+        _factory.WriteDataJson(TestDataHelper.BuildValidJsonString());
+
+        var response = await _client.GetAsync("/");
+        var html = await response.Content.ReadAsStringAsync();
+
+        // Static SSR should not include blazor.server.js or blazor.web.js interactive scripts
+        html.Should().NotContain("blazor.server.js");
+    }
+
+    [Fact]
+    public async Task MultipleSequentialRequests_AllSucceed()
+    {
+        _factory.WriteDataJson(TestDataHelper.BuildValidJsonString());
+
+        for (var i = 0; i < 5; i++)
+        {
+            var response = await _client.GetAsync("/");
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+        }
+    }
+
+    [Fact]
+    public async Task DataChangesBetweenRequests_ReflectedImmediately()
+    {
+        _factory.WriteDataJson(TestDataHelper.BuildValidJsonString(title: "Request 1 Title"));
+
+        var response1 = await _client.GetAsync("/");
+        var html1 = await response1.Content.ReadAsStringAsync();
+        html1.Should().Contain("Request 1 Title");
+
+        _factory.WriteDataJson(TestDataHelper.BuildValidJsonString(title: "Request 2 Title"));
+
+        var response2 = await _client.GetAsync("/");
+        var html2 = await response2.Content.ReadAsStringAsync();
+        html2.Should().Contain("Request 2 Title");
+        html2.Should().NotContain("Request 1 Title");
+    }
+
+    [Fact]
+    public async Task DataDeletedBetweenRequests_ShowsError()
+    {
+        _factory.WriteDataJson(TestDataHelper.BuildValidJsonString());
+
+        var response1 = await _client.GetAsync("/");
+        var html1 = await response1.Content.ReadAsStringAsync();
+        html1.Should().NotContain("Dashboard Error");
+
+        _factory.DeleteDataJson();
+
+        var response2 = await _client.GetAsync("/");
+        var html2 = await response2.Content.ReadAsStringAsync();
+        html2.Should().Contain("Dashboard Error");
+        html2.Should().Contain("data.json not found");
+    }
+}

--- a/tests/ReportingDashboard.Tests/Integration/StaticFileIntegrationTests.cs
+++ b/tests/ReportingDashboard.Tests/Integration/StaticFileIntegrationTests.cs
@@ -1,0 +1,170 @@
+using System.Net;
+using FluentAssertions;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace ReportingDashboard.Tests.Integration;
+
+[Trait("Category", "Integration")]
+public class StaticFileIntegrationTests : IDisposable
+{
+    private readonly WebApplicationFactory<Program> _factory;
+    private readonly HttpClient _client;
+
+    public StaticFileIntegrationTests()
+    {
+        // Use the real content root so we get the actual wwwroot/css/app.css
+        _factory = new WebApplicationFactory<Program>()
+            .WithWebHostBuilder(builder =>
+            {
+                builder.UseEnvironment("Development");
+            });
+        _client = _factory.CreateClient();
+    }
+
+    public void Dispose()
+    {
+        _client.Dispose();
+        _factory.Dispose();
+    }
+
+    [Fact]
+    public async Task GetAppCss_ReturnsSuccess()
+    {
+        var response = await _client.GetAsync("/css/app.css");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task GetAppCss_ReturnsCssContentType()
+    {
+        var response = await _client.GetAsync("/css/app.css");
+
+        if (response.StatusCode == HttpStatusCode.OK)
+        {
+            response.Content.Headers.ContentType!.MediaType.Should().Be("text/css");
+        }
+    }
+
+    [Fact]
+    public async Task GetAppCss_ContainsRootCustomProperties()
+    {
+        var response = await _client.GetAsync("/css/app.css");
+
+        if (response.StatusCode == HttpStatusCode.OK)
+        {
+            var css = await response.Content.ReadAsStringAsync();
+            css.Should().Contain(":root");
+        }
+    }
+
+    [Fact]
+    public async Task GetAppCss_ContainsHeaderClasses()
+    {
+        var response = await _client.GetAsync("/css/app.css");
+
+        if (response.StatusCode == HttpStatusCode.OK)
+        {
+            var css = await response.Content.ReadAsStringAsync();
+            css.Should().Contain(".hdr");
+            css.Should().Contain(".sub");
+        }
+    }
+
+    [Fact]
+    public async Task GetAppCss_ContainsTimelineClasses()
+    {
+        var response = await _client.GetAsync("/css/app.css");
+
+        if (response.StatusCode == HttpStatusCode.OK)
+        {
+            var css = await response.Content.ReadAsStringAsync();
+            css.Should().Contain(".tl-area");
+            css.Should().Contain(".tl-svg-box");
+        }
+    }
+
+    [Fact]
+    public async Task GetAppCss_ContainsHeatmapClasses()
+    {
+        var response = await _client.GetAsync("/css/app.css");
+
+        if (response.StatusCode == HttpStatusCode.OK)
+        {
+            var css = await response.Content.ReadAsStringAsync();
+            css.Should().Contain(".hm-wrap");
+            css.Should().Contain(".hm-grid");
+            css.Should().Contain(".hm-cell");
+            css.Should().Contain(".hm-row-hdr");
+            css.Should().Contain(".hm-col-hdr");
+            css.Should().Contain(".hm-corner");
+            css.Should().Contain(".hm-title");
+        }
+    }
+
+    [Fact]
+    public async Task GetAppCss_ContainsRowColorVariants()
+    {
+        var response = await _client.GetAsync("/css/app.css");
+
+        if (response.StatusCode == HttpStatusCode.OK)
+        {
+            var css = await response.Content.ReadAsStringAsync();
+            css.Should().Contain(".ship-hdr");
+            css.Should().Contain(".ship-cell");
+            css.Should().Contain(".prog-hdr");
+            css.Should().Contain(".prog-cell");
+            css.Should().Contain(".carry-hdr");
+            css.Should().Contain(".carry-cell");
+            css.Should().Contain(".block-hdr");
+            css.Should().Contain(".block-cell");
+        }
+    }
+
+    [Fact]
+    public async Task GetAppCss_ContainsItemClass()
+    {
+        var response = await _client.GetAsync("/css/app.css");
+
+        if (response.StatusCode == HttpStatusCode.OK)
+        {
+            var css = await response.Content.ReadAsStringAsync();
+            css.Should().Contain(".it");
+        }
+    }
+
+    [Fact]
+    public async Task GetAppCss_ContainsReconnectModalHide()
+    {
+        var response = await _client.GetAsync("/css/app.css");
+
+        if (response.StatusCode == HttpStatusCode.OK)
+        {
+            var css = await response.Content.ReadAsStringAsync();
+            css.Should().Contain(".components-reconnect-modal");
+            css.Should().Contain("display: none !important");
+        }
+    }
+
+    [Fact]
+    public async Task GetAppCss_ContainsCurrentMonthHighlightClass()
+    {
+        var response = await _client.GetAsync("/css/app.css");
+
+        if (response.StatusCode == HttpStatusCode.OK)
+        {
+            var css = await response.Content.ReadAsStringAsync();
+            css.Should().Contain(".apr-hdr");
+        }
+    }
+
+    [Fact]
+    public async Task GetNonExistentStaticFile_Returns404()
+    {
+        var response = await _client.GetAsync("/css/nonexistent.css");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+}

--- a/tests/ReportingDashboard.Tests/Integration/WebAppFactory.cs
+++ b/tests/ReportingDashboard.Tests/Integration/WebAppFactory.cs
@@ -1,0 +1,54 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+
+namespace ReportingDashboard.Tests.Integration;
+
+/// <summary>
+/// Custom WebApplicationFactory that configures a temp Data directory
+/// so tests can control the data.json file independently.
+/// </summary>
+public class WebAppFactory : WebApplicationFactory<Program>
+{
+    private readonly string _tempContentRoot;
+
+    public string DataDir { get; }
+    public string DataJsonPath { get; }
+
+    public WebAppFactory()
+    {
+        _tempContentRoot = Path.Combine(Path.GetTempPath(), $"DashboardIntTest_{Guid.NewGuid():N}");
+        DataDir = Path.Combine(_tempContentRoot, "Data");
+        Directory.CreateDirectory(DataDir);
+        DataJsonPath = Path.Combine(DataDir, "data.json");
+
+        // Copy wwwroot if needed for static files
+        var wwwroot = Path.Combine(_tempContentRoot, "wwwroot", "css");
+        Directory.CreateDirectory(wwwroot);
+    }
+
+    public void WriteDataJson(string content)
+    {
+        File.WriteAllText(DataJsonPath, content);
+    }
+
+    public void DeleteDataJson()
+    {
+        if (File.Exists(DataJsonPath))
+            File.Delete(DataJsonPath);
+    }
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseContentRoot(_tempContentRoot);
+        builder.UseEnvironment("Development");
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        base.Dispose(disposing);
+        if (Directory.Exists(_tempContentRoot))
+        {
+            try { Directory.Delete(_tempContentRoot, recursive: true); } catch { }
+        }
+    }
+}

--- a/tests/ReportingDashboard.Tests/ReportingDashboard.Tests.csproj
+++ b/tests/ReportingDashboard.Tests/ReportingDashboard.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.7.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7" />
+    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\ReportingDashboard\ReportingDashboard.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/ReportingDashboard.Tests/Unit/Models/DashboardDataModelsTests.cs
+++ b/tests/ReportingDashboard.Tests/Unit/Models/DashboardDataModelsTests.cs
@@ -1,0 +1,198 @@
+using System.Text.Json;
+using FluentAssertions;
+using ReportingDashboard.Models;
+using Xunit;
+
+namespace ReportingDashboard.Tests.Unit.Models;
+
+[Trait("Category", "Unit")]
+public class DashboardDataModelsTests
+{
+    private static readonly JsonSerializerOptions Options = new() { PropertyNameCaseInsensitive = true };
+
+    // ---- ProjectInfo ----
+
+    [Fact]
+    public void ProjectInfo_Deserialize_AllFieldsMapped()
+    {
+        var json = """{"title":"P","subtitle":"S","backlogUrl":"http://x","currentMonth":"Apr"}""";
+        var result = JsonSerializer.Deserialize<ProjectInfo>(json, Options);
+
+        result.Should().NotBeNull();
+        result!.Title.Should().Be("P");
+        result.Subtitle.Should().Be("S");
+        result.BacklogUrl.Should().Be("http://x");
+        result.CurrentMonth.Should().Be("Apr");
+    }
+
+    [Fact]
+    public void ProjectInfo_Serialize_UsesJsonPropertyNames()
+    {
+        var info = new ProjectInfo("Title", "Sub", "http://url", "Mar");
+        var json = JsonSerializer.Serialize(info);
+
+        json.Should().Contain("\"title\":");
+        json.Should().Contain("\"subtitle\":");
+        json.Should().Contain("\"backlogUrl\":");
+        json.Should().Contain("\"currentMonth\":");
+    }
+
+    // ---- TimelineConfig ----
+
+    [Fact]
+    public void TimelineConfig_Deserialize_AllFieldsMapped()
+    {
+        var json = """{"months":["Jan","Feb"],"nowPosition":0.42}""";
+        var result = JsonSerializer.Deserialize<TimelineConfig>(json, Options);
+
+        result.Should().NotBeNull();
+        result!.Months.Should().BeEquivalentTo(new[] { "Jan", "Feb" });
+        result.NowPosition.Should().Be(0.42);
+    }
+
+    // ---- MilestoneTrack ----
+
+    [Fact]
+    public void MilestoneTrack_Deserialize_AllFieldsMapped()
+    {
+        var json = """{"id":"m1","label":"Track 1","color":"#FF0000","milestones":[]}""";
+        var result = JsonSerializer.Deserialize<MilestoneTrack>(json, Options);
+
+        result.Should().NotBeNull();
+        result!.Id.Should().Be("m1");
+        result.Label.Should().Be("Track 1");
+        result.Color.Should().Be("#FF0000");
+        result.Milestones.Should().BeEmpty();
+    }
+
+    // ---- Milestone ----
+
+    [Fact]
+    public void Milestone_Deserialize_WithLabel()
+    {
+        var json = """{"date":"2024-03-15","type":"poc","position":0.5,"label":"PoC Ready"}""";
+        var result = JsonSerializer.Deserialize<Milestone>(json, Options);
+
+        result.Should().NotBeNull();
+        result!.Date.Should().Be("2024-03-15");
+        result.Type.Should().Be("poc");
+        result.Position.Should().Be(0.5);
+        result.Label.Should().Be("PoC Ready");
+    }
+
+    [Fact]
+    public void Milestone_Deserialize_WithoutLabel()
+    {
+        var json = """{"date":"2024-03-15","type":"checkpoint","position":0.3}""";
+        var result = JsonSerializer.Deserialize<Milestone>(json, Options);
+
+        result.Should().NotBeNull();
+        result!.Label.Should().BeNull();
+    }
+
+    // ---- HeatmapData ----
+
+    [Fact]
+    public void HeatmapData_Deserialize_AllFieldsMapped()
+    {
+        var json = """{"months":["Jan","Feb","Mar"],"categories":[]}""";
+        var result = JsonSerializer.Deserialize<HeatmapData>(json, Options);
+
+        result.Should().NotBeNull();
+        result!.Months.Should().HaveCount(3);
+        result.Categories.Should().BeEmpty();
+    }
+
+    // ---- HeatmapCategory ----
+
+    [Fact]
+    public void HeatmapCategory_Deserialize_WithItems()
+    {
+        var json = """{"name":"Shipped","cssClass":"ship","emoji":"✅","items":{"Jan":["A","B"],"Feb":["C"]}}""";
+        var result = JsonSerializer.Deserialize<HeatmapCategory>(json, Options);
+
+        result.Should().NotBeNull();
+        result!.Name.Should().Be("Shipped");
+        result.CssClass.Should().Be("ship");
+        result.Emoji.Should().Be("✅");
+        result.Items.Should().HaveCount(2);
+        result.Items["Jan"].Should().BeEquivalentTo(new[] { "A", "B" });
+        result.Items["Feb"].Should().BeEquivalentTo(new[] { "C" });
+    }
+
+    [Fact]
+    public void HeatmapCategory_Deserialize_EmptyItems()
+    {
+        var json = """{"name":"X","cssClass":"ship","emoji":"✅","items":{}}""";
+        var result = JsonSerializer.Deserialize<HeatmapCategory>(json, Options);
+
+        result.Should().NotBeNull();
+        result!.Items.Should().BeEmpty();
+    }
+
+    // ---- Full DashboardData Round-Trip ----
+
+    [Fact]
+    public void DashboardData_RoundTrip_PreservesAllData()
+    {
+        var original = new DashboardData(
+            new ProjectInfo("Title", "Sub", "http://url", "Apr"),
+            new TimelineConfig(new List<string> { "Jan", "Feb" }, 0.5),
+            new List<MilestoneTrack>
+            {
+                new("m1", "Track 1", "#FF0000", new List<Milestone>
+                {
+                    new("2024-03-15", "poc", 0.5, "PoC")
+                })
+            },
+            new HeatmapData(
+                new List<string> { "Jan", "Feb" },
+                new List<HeatmapCategory>
+                {
+                    new("Shipped", "ship", "✅", new Dictionary<string, List<string>>
+                    {
+                        { "Jan", new List<string> { "Item A" } }
+                    })
+                })
+        );
+
+        var json = JsonSerializer.Serialize(original);
+        var deserialized = JsonSerializer.Deserialize<DashboardData>(json, Options);
+
+        deserialized.Should().NotBeNull();
+        deserialized!.Project.Title.Should().Be("Title");
+        deserialized.Timeline.Months.Should().HaveCount(2);
+        deserialized.Tracks.Should().HaveCount(1);
+        deserialized.Tracks[0].Milestones[0].Label.Should().Be("PoC");
+        deserialized.Heatmap.Categories[0].Items["Jan"].Should().Contain("Item A");
+    }
+
+    // ---- Record Equality ----
+
+    [Fact]
+    public void ProjectInfo_RecordEquality_EqualValues()
+    {
+        var a = new ProjectInfo("T", "S", "http://x", "Jan");
+        var b = new ProjectInfo("T", "S", "http://x", "Jan");
+
+        a.Should().Be(b);
+    }
+
+    [Fact]
+    public void ProjectInfo_RecordEquality_DifferentValues()
+    {
+        var a = new ProjectInfo("T1", "S", "http://x", "Jan");
+        var b = new ProjectInfo("T2", "S", "http://x", "Jan");
+
+        a.Should().NotBe(b);
+    }
+
+    [Fact]
+    public void Milestone_RecordEquality_NullLabel()
+    {
+        var a = new Milestone("2024-01-01", "poc", 0.5, null);
+        var b = new Milestone("2024-01-01", "poc", 0.5, null);
+
+        a.Should().Be(b);
+    }
+}

--- a/tests/ReportingDashboard.Tests/Unit/Services/DashboardDataServiceTests.cs
+++ b/tests/ReportingDashboard.Tests/Unit/Services/DashboardDataServiceTests.cs
@@ -1,0 +1,1006 @@
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Hosting;
+using Moq;
+using ReportingDashboard.Models;
+using ReportingDashboard.Services;
+using Xunit;
+
+namespace ReportingDashboard.Tests.Unit.Services;
+
+[Trait("Category", "Unit")]
+public class DashboardDataServiceTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly string _dataDir;
+    private readonly string _dataJsonPath;
+    private readonly Mock<IWebHostEnvironment> _envMock;
+
+    public DashboardDataServiceTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"DashboardTests_{Guid.NewGuid():N}");
+        _dataDir = Path.Combine(_tempDir, "Data");
+        Directory.CreateDirectory(_dataDir);
+        _dataJsonPath = Path.Combine(_dataDir, "data.json");
+
+        _envMock = new Mock<IWebHostEnvironment>();
+        _envMock.Setup(e => e.ContentRootPath).Returns(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    private DashboardDataService CreateService() => new(_envMock.Object);
+
+    private void WriteJson(object data)
+    {
+        var json = JsonSerializer.Serialize(data, new JsonSerializerOptions { WriteIndented = true });
+        File.WriteAllText(_dataJsonPath, json);
+    }
+
+    private void WriteRawJson(string json)
+    {
+        File.WriteAllText(_dataJsonPath, json);
+    }
+
+    private static object BuildValidData(
+        string? title = "Test Project",
+        string? subtitle = "Test Subtitle",
+        string? backlogUrl = "https://example.com",
+        string? currentMonth = "Apr",
+        List<string>? timelineMonths = null,
+        double nowPosition = 0.5,
+        List<object>? tracks = null,
+        List<string>? heatmapMonths = null,
+        List<object>? categories = null)
+    {
+        return new
+        {
+            project = new
+            {
+                title,
+                subtitle,
+                backlogUrl,
+                currentMonth
+            },
+            timeline = new
+            {
+                months = timelineMonths ?? new List<string> { "Jan", "Feb", "Mar" },
+                nowPosition
+            },
+            tracks = tracks ?? new List<object>
+            {
+                new
+                {
+                    id = "m1",
+                    label = "Track 1",
+                    color = "#FF0000",
+                    milestones = new List<object>
+                    {
+                        new { date = "2024-03-15", type = "checkpoint", position = 0.4, label = "CP1" }
+                    }
+                }
+            },
+            heatmap = new
+            {
+                months = heatmapMonths ?? new List<string> { "Jan", "Feb", "Mar" },
+                categories = categories ?? new List<object>
+                {
+                    new
+                    {
+                        name = "Shipped",
+                        cssClass = "ship",
+                        emoji = "✅",
+                        items = new Dictionary<string, List<string>>
+                        {
+                            { "Jan", new List<string> { "Item A" } }
+                        }
+                    }
+                }
+            }
+        };
+    }
+
+    // ---- File Not Found ----
+
+    [Fact]
+    public void Load_FileNotFound_ReturnsError()
+    {
+        if (File.Exists(_dataJsonPath)) File.Delete(_dataJsonPath);
+        var service = CreateService();
+
+        var (data, error) = service.Load();
+
+        data.Should().BeNull();
+        error.Should().Contain("data.json not found at:");
+        error.Should().Contain(_dataJsonPath);
+    }
+
+    // ---- Invalid JSON ----
+
+    [Fact]
+    public void Load_MalformedJson_ReturnsParseError()
+    {
+        WriteRawJson("{ \"bad json }");
+        var service = CreateService();
+
+        var (data, error) = service.Load();
+
+        data.Should().BeNull();
+        error.Should().Contain("Invalid JSON in data.json:");
+    }
+
+    [Fact]
+    public void Load_EmptyFile_ReturnsError()
+    {
+        WriteRawJson("");
+        var service = CreateService();
+
+        var (data, error) = service.Load();
+
+        data.Should().BeNull();
+        error.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public void Load_NullJsonRoot_ReturnsError()
+    {
+        WriteRawJson("null");
+        var service = CreateService();
+
+        var (data, error) = service.Load();
+
+        data.Should().BeNull();
+        error.Should().Contain("deserialized to null");
+    }
+
+    // ---- Valid Data ----
+
+    [Fact]
+    public void Load_ValidData_ReturnsDataWithNoError()
+    {
+        WriteJson(BuildValidData());
+        var service = CreateService();
+
+        var (data, error) = service.Load();
+
+        error.Should().BeNull();
+        data.Should().NotBeNull();
+        data!.Project.Title.Should().Be("Test Project");
+        data.Project.Subtitle.Should().Be("Test Subtitle");
+        data.Timeline.NowPosition.Should().Be(0.5);
+        data.Tracks.Should().HaveCount(1);
+        data.Heatmap.Categories.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void Load_ReReadsFileEachCall_ReflectsChanges()
+    {
+        WriteJson(BuildValidData(title: "First Title"));
+        var service = CreateService();
+
+        var (data1, _) = service.Load();
+        data1!.Project.Title.Should().Be("First Title");
+
+        WriteJson(BuildValidData(title: "Second Title"));
+
+        var (data2, _) = service.Load();
+        data2!.Project.Title.Should().Be("Second Title");
+    }
+
+    // ---- Project Validation ----
+
+    [Fact]
+    public void Load_MissingProjectTitle_ReturnsValidationError()
+    {
+        WriteJson(BuildValidData(title: ""));
+        var service = CreateService();
+
+        var (data, error) = service.Load();
+
+        data.Should().BeNull();
+        error.Should().Be("Missing required field: project.title");
+    }
+
+    [Fact]
+    public void Load_WhitespaceProjectTitle_ReturnsValidationError()
+    {
+        WriteJson(BuildValidData(title: "   "));
+        var service = CreateService();
+
+        var (data, error) = service.Load();
+
+        data.Should().BeNull();
+        error.Should().Be("Missing required field: project.title");
+    }
+
+    [Fact]
+    public void Load_MissingProjectSubtitle_ReturnsValidationError()
+    {
+        WriteJson(BuildValidData(subtitle: ""));
+        var service = CreateService();
+
+        var (data, error) = service.Load();
+
+        data.Should().BeNull();
+        error.Should().Be("Missing required field: project.subtitle");
+    }
+
+    [Fact]
+    public void Load_MissingCurrentMonth_ReturnsValidationError()
+    {
+        WriteJson(BuildValidData(currentMonth: ""));
+        var service = CreateService();
+
+        var (data, error) = service.Load();
+
+        data.Should().BeNull();
+        error.Should().Be("Missing required field: project.currentMonth");
+    }
+
+    // ---- Timeline Validation ----
+
+    [Fact]
+    public void Load_EmptyTimelineMonths_ReturnsValidationError()
+    {
+        WriteJson(BuildValidData(timelineMonths: new List<string>()));
+        var service = CreateService();
+
+        var (data, error) = service.Load();
+
+        data.Should().BeNull();
+        error.Should().Contain("timeline.months");
+        error.Should().Contain("at least 1 element");
+    }
+
+    [Fact]
+    public void Load_NowPositionBelowZero_ReturnsValidationError()
+    {
+        WriteJson(BuildValidData(nowPosition: -0.1));
+        var service = CreateService();
+
+        var (data, error) = service.Load();
+
+        data.Should().BeNull();
+        error.Should().Contain("timeline.nowPosition must be between 0.0 and 1.0");
+    }
+
+    [Fact]
+    public void Load_NowPositionAboveOne_ReturnsValidationError()
+    {
+        WriteJson(BuildValidData(nowPosition: 1.1));
+        var service = CreateService();
+
+        var (data, error) = service.Load();
+
+        data.Should().BeNull();
+        error.Should().Contain("timeline.nowPosition must be between 0.0 and 1.0");
+    }
+
+    [Theory]
+    [InlineData(0.0)]
+    [InlineData(0.5)]
+    [InlineData(1.0)]
+    public void Load_NowPositionAtBoundary_Succeeds(double nowPosition)
+    {
+        WriteJson(BuildValidData(nowPosition: nowPosition));
+        var service = CreateService();
+
+        var (data, error) = service.Load();
+
+        error.Should().BeNull();
+        data.Should().NotBeNull();
+        data!.Timeline.NowPosition.Should().Be(nowPosition);
+    }
+
+    // ---- Tracks Validation ----
+
+    [Fact]
+    public void Load_TrackMissingId_ReturnsValidationError()
+    {
+        var tracks = new List<object>
+        {
+            new { id = "", label = "Track 1", color = "#FF0000", milestones = new List<object>() }
+        };
+        WriteJson(BuildValidData(tracks: tracks));
+        var service = CreateService();
+
+        var (data, error) = service.Load();
+
+        data.Should().BeNull();
+        error.Should().Be("Missing required field: tracks[0].id");
+    }
+
+    [Fact]
+    public void Load_TrackMissingLabel_ReturnsValidationError()
+    {
+        var tracks = new List<object>
+        {
+            new { id = "m1", label = "", color = "#FF0000", milestones = new List<object>() }
+        };
+        WriteJson(BuildValidData(tracks: tracks));
+        var service = CreateService();
+
+        var (data, error) = service.Load();
+
+        data.Should().BeNull();
+        error.Should().Be("Missing required field: tracks[0].label");
+    }
+
+    [Fact]
+    public void Load_TrackMissingColor_ReturnsValidationError()
+    {
+        var tracks = new List<object>
+        {
+            new { id = "m1", label = "Track 1", color = "", milestones = new List<object>() }
+        };
+        WriteJson(BuildValidData(tracks: tracks));
+        var service = CreateService();
+
+        var (data, error) = service.Load();
+
+        data.Should().BeNull();
+        error.Should().Be("Missing required field: tracks[0].color");
+    }
+
+    [Fact]
+    public void Load_EmptyTracksArray_Succeeds()
+    {
+        WriteJson(BuildValidData(tracks: new List<object>()));
+        var service = CreateService();
+
+        var (data, error) = service.Load();
+
+        error.Should().BeNull();
+        data.Should().NotBeNull();
+        data!.Tracks.Should().BeEmpty();
+    }
+
+    // ---- Milestone Validation ----
+
+    [Fact]
+    public void Load_MilestoneInvalidType_ReturnsValidationError()
+    {
+        var tracks = new List<object>
+        {
+            new
+            {
+                id = "m1", label = "Track 1", color = "#FF0000",
+                milestones = new List<object>
+                {
+                    new { date = "2024-03-15", type = "invalid", position = 0.5 }
+                }
+            }
+        };
+        WriteJson(BuildValidData(tracks: tracks));
+        var service = CreateService();
+
+        var (data, error) = service.Load();
+
+        data.Should().BeNull();
+        error.Should().Contain("Invalid milestone type: 'invalid'");
+        error.Should().Contain("tracks[0].milestones[0]");
+    }
+
+    [Theory]
+    [InlineData("checkpoint")]
+    [InlineData("poc")]
+    [InlineData("production")]
+    public void Load_MilestoneValidType_Succeeds(string type)
+    {
+        var tracks = new List<object>
+        {
+            new
+            {
+                id = "m1", label = "Track 1", color = "#FF0000",
+                milestones = new List<object>
+                {
+                    new { date = "2024-03-15", type, position = 0.5 }
+                }
+            }
+        };
+        WriteJson(BuildValidData(tracks: tracks));
+        var service = CreateService();
+
+        var (data, error) = service.Load();
+
+        error.Should().BeNull();
+        data.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Load_MilestonePositionBelowZero_ReturnsValidationError()
+    {
+        var tracks = new List<object>
+        {
+            new
+            {
+                id = "m1", label = "Track 1", color = "#FF0000",
+                milestones = new List<object>
+                {
+                    new { date = "2024-03-15", type = "checkpoint", position = -0.01 }
+                }
+            }
+        };
+        WriteJson(BuildValidData(tracks: tracks));
+        var service = CreateService();
+
+        var (data, error) = service.Load();
+
+        data.Should().BeNull();
+        error.Should().Contain("milestones[0].position must be between 0.0 and 1.0");
+    }
+
+    [Fact]
+    public void Load_MilestonePositionAboveOne_ReturnsValidationError()
+    {
+        var tracks = new List<object>
+        {
+            new
+            {
+                id = "m1", label = "Track 1", color = "#FF0000",
+                milestones = new List<object>
+                {
+                    new { date = "2024-03-15", type = "checkpoint", position = 1.01 }
+                }
+            }
+        };
+        WriteJson(BuildValidData(tracks: tracks));
+        var service = CreateService();
+
+        var (data, error) = service.Load();
+
+        data.Should().BeNull();
+        error.Should().Contain("milestones[0].position must be between 0.0 and 1.0");
+    }
+
+    [Fact]
+    public void Load_MilestoneMissingDate_ReturnsValidationError()
+    {
+        var tracks = new List<object>
+        {
+            new
+            {
+                id = "m1", label = "Track 1", color = "#FF0000",
+                milestones = new List<object>
+                {
+                    new { date = "", type = "checkpoint", position = 0.5 }
+                }
+            }
+        };
+        WriteJson(BuildValidData(tracks: tracks));
+        var service = CreateService();
+
+        var (data, error) = service.Load();
+
+        data.Should().BeNull();
+        error.Should().Contain("tracks[0].milestones[0].date");
+    }
+
+    [Fact]
+    public void Load_MilestoneMissingType_ReturnsValidationError()
+    {
+        var tracks = new List<object>
+        {
+            new
+            {
+                id = "m1", label = "Track 1", color = "#FF0000",
+                milestones = new List<object>
+                {
+                    new { date = "2024-03-15", type = "", position = 0.5 }
+                }
+            }
+        };
+        WriteJson(BuildValidData(tracks: tracks));
+        var service = CreateService();
+
+        var (data, error) = service.Load();
+
+        data.Should().BeNull();
+        error.Should().Contain("tracks[0].milestones[0].type");
+    }
+
+    [Fact]
+    public void Load_MilestoneOptionalLabelNull_Succeeds()
+    {
+        var tracks = new List<object>
+        {
+            new
+            {
+                id = "m1", label = "Track 1", color = "#FF0000",
+                milestones = new List<object>
+                {
+                    new { date = "2024-03-15", type = "checkpoint", position = 0.5 }
+                }
+            }
+        };
+        WriteJson(BuildValidData(tracks: tracks));
+        var service = CreateService();
+
+        var (data, error) = service.Load();
+
+        error.Should().BeNull();
+        data!.Tracks[0].Milestones[0].Label.Should().BeNull();
+    }
+
+    // ---- Heatmap Validation ----
+
+    [Fact]
+    public void Load_HeatmapEmptyMonths_ReturnsValidationError()
+    {
+        WriteJson(BuildValidData(heatmapMonths: new List<string>()));
+        var service = CreateService();
+
+        var (data, error) = service.Load();
+
+        data.Should().BeNull();
+        error.Should().Contain("heatmap.months");
+    }
+
+    [Fact]
+    public void Load_CategoryMissingName_ReturnsValidationError()
+    {
+        var categories = new List<object>
+        {
+            new
+            {
+                name = "",
+                cssClass = "ship",
+                emoji = "✅",
+                items = new Dictionary<string, List<string>>()
+            }
+        };
+        WriteJson(BuildValidData(categories: categories));
+        var service = CreateService();
+
+        var (data, error) = service.Load();
+
+        data.Should().BeNull();
+        error.Should().Be("Missing required field: heatmap.categories[0].name");
+    }
+
+    [Fact]
+    public void Load_CategoryMissingCssClass_ReturnsValidationError()
+    {
+        var categories = new List<object>
+        {
+            new
+            {
+                name = "Shipped",
+                cssClass = "",
+                emoji = "✅",
+                items = new Dictionary<string, List<string>>()
+            }
+        };
+        WriteJson(BuildValidData(categories: categories));
+        var service = CreateService();
+
+        var (data, error) = service.Load();
+
+        data.Should().BeNull();
+        error.Should().Be("Missing required field: heatmap.categories[0].cssClass");
+    }
+
+    [Fact]
+    public void Load_CategoryInvalidCssClass_ReturnsValidationError()
+    {
+        var categories = new List<object>
+        {
+            new
+            {
+                name = "Shipped",
+                cssClass = "invalid",
+                emoji = "✅",
+                items = new Dictionary<string, List<string>>()
+            }
+        };
+        WriteJson(BuildValidData(categories: categories));
+        var service = CreateService();
+
+        var (data, error) = service.Load();
+
+        data.Should().BeNull();
+        error.Should().Contain("Invalid cssClass: 'invalid'");
+        error.Should().Contain("heatmap.categories[0]");
+    }
+
+    [Theory]
+    [InlineData("ship")]
+    [InlineData("prog")]
+    [InlineData("carry")]
+    [InlineData("block")]
+    public void Load_CategoryValidCssClass_Succeeds(string cssClass)
+    {
+        var categories = new List<object>
+        {
+            new
+            {
+                name = "Test",
+                cssClass,
+                emoji = "✅",
+                items = new Dictionary<string, List<string>>()
+            }
+        };
+        WriteJson(BuildValidData(categories: categories));
+        var service = CreateService();
+
+        var (data, error) = service.Load();
+
+        error.Should().BeNull();
+        data.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Load_CategoryMissingEmoji_ReturnsValidationError()
+    {
+        var categories = new List<object>
+        {
+            new
+            {
+                name = "Shipped",
+                cssClass = "ship",
+                emoji = "",
+                items = new Dictionary<string, List<string>>()
+            }
+        };
+        WriteJson(BuildValidData(categories: categories));
+        var service = CreateService();
+
+        var (data, error) = service.Load();
+
+        data.Should().BeNull();
+        error.Should().Be("Missing required field: heatmap.categories[0].emoji");
+    }
+
+    // ---- Multiple Tracks / Categories Indexing ----
+
+    [Fact]
+    public void Load_SecondTrackInvalid_ReportsCorrectIndex()
+    {
+        var tracks = new List<object>
+        {
+            new { id = "m1", label = "Track 1", color = "#FF0000", milestones = new List<object>() },
+            new { id = "", label = "Track 2", color = "#00FF00", milestones = new List<object>() }
+        };
+        WriteJson(BuildValidData(tracks: tracks));
+        var service = CreateService();
+
+        var (data, error) = service.Load();
+
+        data.Should().BeNull();
+        error.Should().Be("Missing required field: tracks[1].id");
+    }
+
+    [Fact]
+    public void Load_SecondCategoryInvalid_ReportsCorrectIndex()
+    {
+        var categories = new List<object>
+        {
+            new
+            {
+                name = "Shipped", cssClass = "ship", emoji = "✅",
+                items = new Dictionary<string, List<string>>()
+            },
+            new
+            {
+                name = "", cssClass = "prog", emoji = "🔄",
+                items = new Dictionary<string, List<string>>()
+            }
+        };
+        WriteJson(BuildValidData(categories: categories));
+        var service = CreateService();
+
+        var (data, error) = service.Load();
+
+        data.Should().BeNull();
+        error.Should().Be("Missing required field: heatmap.categories[1].name");
+    }
+
+    [Fact]
+    public void Load_SecondMilestoneInvalid_ReportsCorrectIndex()
+    {
+        var tracks = new List<object>
+        {
+            new
+            {
+                id = "m1", label = "Track 1", color = "#FF0000",
+                milestones = new List<object>
+                {
+                    new { date = "2024-03-15", type = "checkpoint", position = 0.4 },
+                    new { date = "2024-04-15", type = "badtype", position = 0.6 }
+                }
+            }
+        };
+        WriteJson(BuildValidData(tracks: tracks));
+        var service = CreateService();
+
+        var (data, error) = service.Load();
+
+        data.Should().BeNull();
+        error.Should().Contain("tracks[0].milestones[1]");
+    }
+
+    // ---- Data Integrity / Deserialization ----
+
+    [Fact]
+    public void Load_ValidData_DeserializesAllFieldsCorrectly()
+    {
+        var tracks = new List<object>
+        {
+            new
+            {
+                id = "m1", label = "Track Alpha", color = "#123ABC",
+                milestones = new List<object>
+                {
+                    new { date = "2024-06-01", type = "poc", position = 0.75, label = "PoC Ready" }
+                }
+            }
+        };
+        var categories = new List<object>
+        {
+            new
+            {
+                name = "Blockers", cssClass = "block", emoji = "🚫",
+                items = new Dictionary<string, List<string>>
+                {
+                    { "Feb", new List<string> { "Bug X", "Bug Y" } },
+                    { "Mar", new List<string> { "Dep Z" } }
+                }
+            }
+        };
+        WriteJson(BuildValidData(
+            title: "Alpha Project",
+            subtitle: "Org > Team > Apr 2024",
+            backlogUrl: "https://dev.azure.com/backlog",
+            currentMonth: "Apr",
+            timelineMonths: new List<string> { "Jan", "Feb", "Mar", "Apr", "May", "Jun" },
+            nowPosition: 0.65,
+            tracks: tracks,
+            heatmapMonths: new List<string> { "Jan", "Feb", "Mar", "Apr" },
+            categories: categories
+        ));
+        var service = CreateService();
+
+        var (data, error) = service.Load();
+
+        error.Should().BeNull();
+        data.Should().NotBeNull();
+
+        data!.Project.Title.Should().Be("Alpha Project");
+        data.Project.Subtitle.Should().Be("Org > Team > Apr 2024");
+        data.Project.BacklogUrl.Should().Be("https://dev.azure.com/backlog");
+        data.Project.CurrentMonth.Should().Be("Apr");
+
+        data.Timeline.Months.Should().HaveCount(6);
+        data.Timeline.NowPosition.Should().Be(0.65);
+
+        data.Tracks.Should().HaveCount(1);
+        data.Tracks[0].Id.Should().Be("m1");
+        data.Tracks[0].Label.Should().Be("Track Alpha");
+        data.Tracks[0].Color.Should().Be("#123ABC");
+        data.Tracks[0].Milestones.Should().HaveCount(1);
+        data.Tracks[0].Milestones[0].Date.Should().Be("2024-06-01");
+        data.Tracks[0].Milestones[0].Type.Should().Be("poc");
+        data.Tracks[0].Milestones[0].Position.Should().Be(0.75);
+        data.Tracks[0].Milestones[0].Label.Should().Be("PoC Ready");
+
+        data.Heatmap.Months.Should().HaveCount(4);
+        data.Heatmap.Categories.Should().HaveCount(1);
+        data.Heatmap.Categories[0].Name.Should().Be("Blockers");
+        data.Heatmap.Categories[0].CssClass.Should().Be("block");
+        data.Heatmap.Categories[0].Items.Should().ContainKey("Feb");
+        data.Heatmap.Categories[0].Items["Feb"].Should().BeEquivalentTo(new[] { "Bug X", "Bug Y" });
+        data.Heatmap.Categories[0].Items["Mar"].Should().BeEquivalentTo(new[] { "Dep Z" });
+    }
+
+    [Fact]
+    public void Load_MultipleTracks_AllDeserialized()
+    {
+        var tracks = new List<object>
+        {
+            new { id = "m1", label = "Track 1", color = "#FF0000", milestones = new List<object>() },
+            new { id = "m2", label = "Track 2", color = "#00FF00", milestones = new List<object>() },
+            new { id = "m3", label = "Track 3", color = "#0000FF", milestones = new List<object>() }
+        };
+        WriteJson(BuildValidData(tracks: tracks));
+        var service = CreateService();
+
+        var (data, error) = service.Load();
+
+        error.Should().BeNull();
+        data!.Tracks.Should().HaveCount(3);
+        data.Tracks[2].Id.Should().Be("m3");
+    }
+
+    [Fact]
+    public void Load_MultipleCategories_AllDeserialized()
+    {
+        var categories = new List<object>
+        {
+            new { name = "Shipped", cssClass = "ship", emoji = "✅", items = new Dictionary<string, List<string>>() },
+            new { name = "In Progress", cssClass = "prog", emoji = "🔄", items = new Dictionary<string, List<string>>() },
+            new { name = "Carryover", cssClass = "carry", emoji = "📦", items = new Dictionary<string, List<string>>() },
+            new { name = "Blockers", cssClass = "block", emoji = "🚫", items = new Dictionary<string, List<string>>() }
+        };
+        WriteJson(BuildValidData(categories: categories));
+        var service = CreateService();
+
+        var (data, error) = service.Load();
+
+        error.Should().BeNull();
+        data!.Heatmap.Categories.Should().HaveCount(4);
+    }
+
+    // ---- Never Throws ----
+
+    [Fact]
+    public void Load_NeverThrows_OnMissingFile()
+    {
+        if (File.Exists(_dataJsonPath)) File.Delete(_dataJsonPath);
+        var service = CreateService();
+
+        var act = () => service.Load();
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void Load_NeverThrows_OnMalformedJson()
+    {
+        WriteRawJson("{{{");
+        var service = CreateService();
+
+        var act = () => service.Load();
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void Load_NeverThrows_OnInvalidData()
+    {
+        WriteJson(new { project = new { title = "" } });
+        var service = CreateService();
+
+        var act = () => service.Load();
+
+        act.Should().NotThrow();
+    }
+
+    // ---- Edge Cases ----
+
+    [Fact]
+    public void Load_EmptyJsonObject_ReturnsValidationError()
+    {
+        WriteRawJson("{}");
+        var service = CreateService();
+
+        var (data, error) = service.Load();
+
+        data.Should().BeNull();
+        error.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public void Load_ValidJsonArray_ReturnsError()
+    {
+        WriteRawJson("[1,2,3]");
+        var service = CreateService();
+
+        var (data, error) = service.Load();
+
+        data.Should().BeNull();
+        error.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public void Load_TrackWithNullMilestones_Succeeds()
+    {
+        // When milestones is present but null/omitted, validation should still pass
+        // because the code checks `if (track.Milestones is not null)`
+        WriteRawJson(JsonSerializer.Serialize(new
+        {
+            project = new { title = "T", subtitle = "S", backlogUrl = "", currentMonth = "Jan" },
+            timeline = new { months = new[] { "Jan" }, nowPosition = 0.5 },
+            tracks = new[]
+            {
+                new { id = "m1", label = "Track", color = "#000" }
+                // milestones omitted
+            },
+            heatmap = new
+            {
+                months = new[] { "Jan" },
+                categories = new[]
+                {
+                    new { name = "X", cssClass = "ship", emoji = "✅", items = new Dictionary<string, List<string>>() }
+                }
+            }
+        }));
+        var service = CreateService();
+
+        var (data, error) = service.Load();
+
+        error.Should().BeNull();
+        data.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Load_CategoryWithEmptyItems_Succeeds()
+    {
+        var categories = new List<object>
+        {
+            new
+            {
+                name = "Shipped", cssClass = "ship", emoji = "✅",
+                items = new Dictionary<string, List<string>>()
+            }
+        };
+        WriteJson(BuildValidData(categories: categories));
+        var service = CreateService();
+
+        var (data, error) = service.Load();
+
+        error.Should().BeNull();
+        data!.Heatmap.Categories[0].Items.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Load_MilestonePositionExactlyZero_Succeeds()
+    {
+        var tracks = new List<object>
+        {
+            new
+            {
+                id = "m1", label = "Track 1", color = "#FF0000",
+                milestones = new List<object>
+                {
+                    new { date = "2024-01-01", type = "checkpoint", position = 0.0 }
+                }
+            }
+        };
+        WriteJson(BuildValidData(tracks: tracks));
+        var service = CreateService();
+
+        var (data, error) = service.Load();
+
+        error.Should().BeNull();
+    }
+
+    [Fact]
+    public void Load_MilestonePositionExactlyOne_Succeeds()
+    {
+        var tracks = new List<object>
+        {
+            new
+            {
+                id = "m1", label = "Track 1", color = "#FF0000",
+                milestones = new List<object>
+                {
+                    new { date = "2024-12-31", type = "production", position = 1.0 }
+                }
+            }
+        };
+        WriteJson(BuildValidData(tracks: tracks));
+        var service = CreateService();
+
+        var (data, error) = service.Load();
+
+        error.Should().BeNull();
+    }
+
+    // ---- Constructor / Path ----
+
+    [Fact]
+    public void Constructor_SetsPathFromEnvironment()
+    {
+        var service = CreateService();
+
+        // Verify by checking Load returns file-not-found with expected path
+        if (File.Exists(_dataJsonPath)) File.Delete(_dataJsonPath);
+        var (_, error) = service.Load();
+
+        error.Should().Contain(Path.Combine(_tempDir, "Data", "data.json"));
+    }
+}

--- a/tests/ReportingDashboard.UITests/Infrastructure/PlaywrightFixture.cs
+++ b/tests/ReportingDashboard.UITests/Infrastructure/PlaywrightFixture.cs
@@ -1,0 +1,67 @@
+using Microsoft.Playwright;
+using Xunit;
+
+namespace ReportingDashboard.UITests.Infrastructure;
+
+public class PlaywrightFixture : IAsyncLifetime
+{
+    private IPlaywright? _playwright;
+    private IBrowser? _browser;
+
+    public IBrowser Browser => _browser ?? throw new InvalidOperationException("Browser not initialized. Ensure IAsyncLifetime.InitializeAsync has been called.");
+    public string BaseUrl { get; }
+
+    public PlaywrightFixture()
+    {
+        BaseUrl = Environment.GetEnvironmentVariable("BASE_URL") ?? "http://localhost:5000";
+    }
+
+    public async Task InitializeAsync()
+    {
+        _playwright = await Playwright.CreateAsync();
+
+        var headed = Environment.GetEnvironmentVariable("HEADED") is "1" or "true";
+
+        _browser = await _playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions
+        {
+            Headless = !headed,
+        });
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_browser is not null)
+            await _browser.DisposeAsync();
+        _playwright?.Dispose();
+    }
+
+    public async Task<IPage> NewPageAsync()
+    {
+        var context = await Browser.NewContextAsync(new BrowserNewContextOptions
+        {
+            ViewportSize = new ViewportSize { Width = 1920, Height = 1080 },
+            IgnoreHTTPSErrors = true
+        });
+        return await context.NewPageAsync();
+    }
+
+    public async Task CaptureScreenshotAsync(IPage page, string testName)
+    {
+        var screenshotsDir = Path.Combine(AppContext.BaseDirectory, "screenshots");
+        Directory.CreateDirectory(screenshotsDir);
+
+        var safeName = string.Join("_", testName.Split(Path.GetInvalidFileNameChars()));
+        var path = Path.Combine(screenshotsDir, $"{safeName}_{DateTime.UtcNow:yyyyMMdd_HHmmss}.png");
+
+        await page.ScreenshotAsync(new PageScreenshotOptions
+        {
+            Path = path,
+            FullPage = true
+        });
+    }
+}
+
+[CollectionDefinition("Playwright")]
+public class PlaywrightCollection : ICollectionFixture<PlaywrightFixture>
+{
+}

--- a/tests/ReportingDashboard.UITests/PageObjects/CssInspector.cs
+++ b/tests/ReportingDashboard.UITests/PageObjects/CssInspector.cs
@@ -1,0 +1,33 @@
+using Microsoft.Playwright;
+
+namespace ReportingDashboard.UITests.PageObjects;
+
+public class CssInspector
+{
+    private readonly IPage _page;
+    private readonly string _baseUrl;
+
+    public CssInspector(IPage page, string baseUrl)
+    {
+        _page = page;
+        _baseUrl = baseUrl.TrimEnd('/');
+    }
+
+    public async Task<string> FetchAppCssAsync()
+    {
+        var response = await _page.APIRequest.GetAsync($"{_baseUrl}/css/app.css");
+        return await response.TextAsync();
+    }
+
+    public async Task<bool> CssContainsClassAsync(string className)
+    {
+        var css = await FetchAppCssAsync();
+        return css.Contains(className);
+    }
+
+    public async Task<bool> CssContainsRootCustomPropertiesAsync()
+    {
+        var css = await FetchAppCssAsync();
+        return css.Contains(":root");
+    }
+}

--- a/tests/ReportingDashboard.UITests/PageObjects/DashboardPage.cs
+++ b/tests/ReportingDashboard.UITests/PageObjects/DashboardPage.cs
@@ -1,0 +1,66 @@
+using Microsoft.Playwright;
+
+namespace ReportingDashboard.UITests.PageObjects;
+
+public class DashboardPage
+{
+    private readonly IPage _page;
+    private readonly string _baseUrl;
+
+    public DashboardPage(IPage page, string baseUrl)
+    {
+        _page = page;
+        _baseUrl = baseUrl.TrimEnd('/');
+    }
+
+    // Navigation
+    public async Task NavigateAsync()
+    {
+        await _page.GotoAsync($"{_baseUrl}/", new PageGotoOptions
+        {
+            WaitUntil = WaitUntilState.NetworkIdle,
+            Timeout = 15000
+        });
+    }
+
+    // Container
+    public ILocator MainContainer =>
+        _page.Locator("div[style*='width:1920px'][style*='height:1080px']");
+
+    // Error section
+    public ILocator ErrorSection => _page.Locator(".dashboard-error");
+    public ILocator ErrorContent => _page.Locator(".dashboard-error-content");
+    public ILocator ErrorHeading => _page.Locator(".dashboard-error-content h2");
+    public ILocator ErrorMessage => _page.Locator(".dashboard-error-content p");
+
+    // Header section
+    public ILocator Header => _page.Locator(".hdr");
+    public ILocator HeaderTitle => _page.Locator(".hdr h1");
+    public ILocator HeaderSubtitle => _page.Locator(".hdr .sub");
+
+    // Timeline section
+    public ILocator TimelineArea => _page.Locator(".tl-area");
+
+    // Heatmap section
+    public ILocator HeatmapWrap => _page.Locator(".hm-wrap");
+
+    // General
+    public IPage Page => _page;
+
+    public async Task<string> GetTitleAsync() => await _page.TitleAsync();
+
+    public async Task<string> GetPageHtmlAsync() => await _page.ContentAsync();
+
+    public async Task<bool> HasBlazorReconnectModalAsync()
+    {
+        var modal = _page.Locator(".components-reconnect-modal");
+        var count = await modal.CountAsync();
+        if (count == 0) return false;
+        return await modal.IsVisibleAsync();
+    }
+
+    public async Task<ViewportSize?> GetViewportAsync()
+    {
+        return _page.ViewportSize;
+    }
+}

--- a/tests/ReportingDashboard.UITests/PageObjects/ErrorPage.cs
+++ b/tests/ReportingDashboard.UITests/PageObjects/ErrorPage.cs
@@ -1,0 +1,41 @@
+using Microsoft.Playwright;
+
+namespace ReportingDashboard.UITests.PageObjects;
+
+public class ErrorPage
+{
+    private readonly IPage _page;
+    private readonly string _baseUrl;
+
+    public ErrorPage(IPage page, string baseUrl)
+    {
+        _page = page;
+        _baseUrl = baseUrl.TrimEnd('/');
+    }
+
+    public async Task NavigateToAsync(string path = "/")
+    {
+        await _page.GotoAsync($"{_baseUrl}{path}", new PageGotoOptions
+        {
+            WaitUntil = WaitUntilState.NetworkIdle,
+            Timeout = 15000
+        });
+    }
+
+    public ILocator ErrorContainer => _page.Locator(".dashboard-error");
+    public ILocator ErrorContent => _page.Locator(".dashboard-error-content");
+    public ILocator ErrorHeading => _page.Locator(".dashboard-error-content h2");
+    public ILocator ErrorText => _page.Locator(".dashboard-error-content p");
+
+    public IPage Page => _page;
+
+    public async Task<string> GetErrorTextAsync()
+    {
+        return await ErrorText.TextContentAsync() ?? "";
+    }
+
+    public async Task<bool> IsErrorVisibleAsync()
+    {
+        return await ErrorContainer.CountAsync() > 0 && await ErrorContainer.IsVisibleAsync();
+    }
+}

--- a/tests/ReportingDashboard.UITests/ReportingDashboard.UITests.csproj
+++ b/tests/ReportingDashboard.UITests/ReportingDashboard.UITests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="Microsoft.Playwright" Version="1.41.0" />
+    <PackageReference Include="xunit" Version="2.7.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\ReportingDashboard\ReportingDashboard.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/ReportingDashboard.UITests/Tests/CssCompletenessTests.cs
+++ b/tests/ReportingDashboard.UITests/Tests/CssCompletenessTests.cs
@@ -1,0 +1,259 @@
+using FluentAssertions;
+using Microsoft.Playwright;
+using ReportingDashboard.UITests.Infrastructure;
+using ReportingDashboard.UITests.PageObjects;
+using Xunit;
+
+namespace ReportingDashboard.UITests.Tests;
+
+[Collection("Playwright")]
+[Trait("Category", "UI")]
+public class CssCompletenessTests
+{
+    private readonly PlaywrightFixture _fixture;
+
+    public CssCompletenessTests(PlaywrightFixture fixture) => _fixture = fixture;
+
+    private async Task<string> FetchCssAsync()
+    {
+        var page = await _fixture.NewPageAsync();
+        var inspector = new CssInspector(page, _fixture.BaseUrl);
+        return await inspector.FetchAppCssAsync();
+    }
+
+    [Fact]
+    public async Task AppCss_IsServed_Returns200()
+    {
+        var page = await _fixture.NewPageAsync();
+        var response = await page.APIRequest.GetAsync($"{_fixture.BaseUrl}/css/app.css");
+        response.Status.Should().Be(200);
+    }
+
+    [Fact]
+    public async Task AppCss_ContainsRootCustomProperties()
+    {
+        var css = await FetchCssAsync();
+        css.Should().Contain(":root");
+    }
+
+    [Fact]
+    public async Task AppCss_ContainsGlobalReset()
+    {
+        var css = await FetchCssAsync();
+        css.Should().Contain("box-sizing");
+    }
+
+    // Header classes
+    [Fact]
+    public async Task AppCss_ContainsHdrClass()
+    {
+        var css = await FetchCssAsync();
+        css.Should().Contain(".hdr");
+    }
+
+    [Fact]
+    public async Task AppCss_ContainsSubClass()
+    {
+        var css = await FetchCssAsync();
+        css.Should().Contain(".sub");
+    }
+
+    // Timeline classes
+    [Fact]
+    public async Task AppCss_ContainsTlAreaClass()
+    {
+        var css = await FetchCssAsync();
+        css.Should().Contain(".tl-area");
+    }
+
+    [Fact]
+    public async Task AppCss_ContainsTlSvgBoxClass()
+    {
+        var css = await FetchCssAsync();
+        css.Should().Contain(".tl-svg-box");
+    }
+
+    // Heatmap classes
+    [Fact]
+    public async Task AppCss_ContainsHmWrapClass()
+    {
+        var css = await FetchCssAsync();
+        css.Should().Contain(".hm-wrap");
+    }
+
+    [Fact]
+    public async Task AppCss_ContainsHmTitleClass()
+    {
+        var css = await FetchCssAsync();
+        css.Should().Contain(".hm-title");
+    }
+
+    [Fact]
+    public async Task AppCss_ContainsHmGridClass()
+    {
+        var css = await FetchCssAsync();
+        css.Should().Contain(".hm-grid");
+    }
+
+    [Fact]
+    public async Task AppCss_ContainsHmCornerClass()
+    {
+        var css = await FetchCssAsync();
+        css.Should().Contain(".hm-corner");
+    }
+
+    [Fact]
+    public async Task AppCss_ContainsHmColHdrClass()
+    {
+        var css = await FetchCssAsync();
+        css.Should().Contain(".hm-col-hdr");
+    }
+
+    [Fact]
+    public async Task AppCss_ContainsAprHdrClass()
+    {
+        var css = await FetchCssAsync();
+        css.Should().Contain(".apr-hdr");
+    }
+
+    [Fact]
+    public async Task AppCss_ContainsHmRowHdrClass()
+    {
+        var css = await FetchCssAsync();
+        css.Should().Contain(".hm-row-hdr");
+    }
+
+    [Fact]
+    public async Task AppCss_ContainsHmCellClass()
+    {
+        var css = await FetchCssAsync();
+        css.Should().Contain(".hm-cell");
+    }
+
+    [Fact]
+    public async Task AppCss_ContainsItClass()
+    {
+        var css = await FetchCssAsync();
+        css.Should().Contain(".it");
+    }
+
+    // Row color variants - Shipped (green)
+    [Fact]
+    public async Task AppCss_ContainsShipHdrClass()
+    {
+        var css = await FetchCssAsync();
+        css.Should().Contain(".ship-hdr");
+    }
+
+    [Fact]
+    public async Task AppCss_ContainsShipCellClass()
+    {
+        var css = await FetchCssAsync();
+        css.Should().Contain(".ship-cell");
+    }
+
+    // Row color variants - In Progress (blue)
+    [Fact]
+    public async Task AppCss_ContainsProgHdrClass()
+    {
+        var css = await FetchCssAsync();
+        css.Should().Contain(".prog-hdr");
+    }
+
+    [Fact]
+    public async Task AppCss_ContainsProgCellClass()
+    {
+        var css = await FetchCssAsync();
+        css.Should().Contain(".prog-cell");
+    }
+
+    // Row color variants - Carryover (amber)
+    [Fact]
+    public async Task AppCss_ContainsCarryHdrClass()
+    {
+        var css = await FetchCssAsync();
+        css.Should().Contain(".carry-hdr");
+    }
+
+    [Fact]
+    public async Task AppCss_ContainsCarryCellClass()
+    {
+        var css = await FetchCssAsync();
+        css.Should().Contain(".carry-cell");
+    }
+
+    // Row color variants - Blockers (red)
+    [Fact]
+    public async Task AppCss_ContainsBlockHdrClass()
+    {
+        var css = await FetchCssAsync();
+        css.Should().Contain(".block-hdr");
+    }
+
+    [Fact]
+    public async Task AppCss_ContainsBlockCellClass()
+    {
+        var css = await FetchCssAsync();
+        css.Should().Contain(".block-cell");
+    }
+
+    // Blazor reconnect modal safety net
+    [Fact]
+    public async Task AppCss_ContainsReconnectModalHide()
+    {
+        var css = await FetchCssAsync();
+        css.Should().Contain(".components-reconnect-modal");
+        css.Should().Contain("display: none !important");
+    }
+
+    // Design reference color verification
+    [Fact]
+    public async Task AppCss_ContainsShipGreenColors()
+    {
+        var css = await FetchCssAsync();
+        // From design: .ship-hdr color:#1B7A28, .ship-cell background:#F0FBF0
+        css.Should().Contain("#E8F5E9");
+    }
+
+    [Fact]
+    public async Task AppCss_ContainsProgBlueColors()
+    {
+        var css = await FetchCssAsync();
+        // From design: .prog-hdr background:#E3F2FD
+        css.Should().Contain("#E3F2FD");
+    }
+
+    [Fact]
+    public async Task AppCss_ContainsCarryAmberColors()
+    {
+        var css = await FetchCssAsync();
+        // From design: .carry-hdr background:#FFF8E1
+        css.Should().Contain("#FFF8E1");
+    }
+
+    [Fact]
+    public async Task AppCss_ContainsBlockRedColors()
+    {
+        var css = await FetchCssAsync();
+        // From design: .block-hdr background:#FEF2F2
+        css.Should().Contain("#FEF2F2");
+    }
+
+    [Fact]
+    public async Task AppCss_ContainsAprHighlightColor()
+    {
+        var css = await FetchCssAsync();
+        // From design: .apr-hdr background:#FFF0D0 color:#C07700
+        css.Should().Contain("#FFF0D0");
+        css.Should().Contain("#C07700");
+    }
+
+    [Fact]
+    public async Task AppCss_ContainsDotPseudoElement()
+    {
+        var css = await FetchCssAsync();
+        // .it::before pseudo-element for colored dots
+        css.Should().Contain("::before");
+        css.Should().Contain("border-radius");
+    }
+}

--- a/tests/ReportingDashboard.UITests/Tests/DashboardPageTests.cs
+++ b/tests/ReportingDashboard.UITests/Tests/DashboardPageTests.cs
@@ -1,0 +1,181 @@
+using FluentAssertions;
+using Microsoft.Playwright;
+using ReportingDashboard.UITests.Infrastructure;
+using ReportingDashboard.UITests.PageObjects;
+using Xunit;
+
+namespace ReportingDashboard.UITests.Tests;
+
+[Collection("Playwright")]
+[Trait("Category", "UI")]
+public class DashboardPageTests
+{
+    private readonly PlaywrightFixture _fixture;
+
+    public DashboardPageTests(PlaywrightFixture fixture) => _fixture = fixture;
+
+    [Fact]
+    public async Task HomePage_LoadsSuccessfully_Returns200()
+    {
+        var page = await _fixture.NewPageAsync();
+        var dashboardPage = new DashboardPage(page, _fixture.BaseUrl);
+
+        IResponse? response = null;
+        page.Response += (_, r) =>
+        {
+            if (r.Url.TrimEnd('/') == _fixture.BaseUrl.TrimEnd('/') || r.Url == _fixture.BaseUrl + "/")
+                response = r;
+        };
+
+        await dashboardPage.NavigateAsync();
+
+        response.Should().NotBeNull();
+        response!.Status.Should().Be(200);
+    }
+
+    [Fact]
+    public async Task HomePage_HasCorrectTitle()
+    {
+        var page = await _fixture.NewPageAsync();
+        var dashboardPage = new DashboardPage(page, _fixture.BaseUrl);
+
+        await dashboardPage.NavigateAsync();
+
+        var title = await dashboardPage.GetTitleAsync();
+        title.Should().Contain("Executive Reporting Dashboard");
+    }
+
+    [Fact]
+    public async Task HomePage_Has1920x1080Container()
+    {
+        var page = await _fixture.NewPageAsync();
+        var dashboardPage = new DashboardPage(page, _fixture.BaseUrl);
+
+        await dashboardPage.NavigateAsync();
+
+        var container = dashboardPage.MainContainer;
+        await Assertions.Expect(container).ToBeVisibleAsync();
+
+        var box = await container.BoundingBoxAsync();
+        box.Should().NotBeNull();
+        box!.Width.Should().BeApproximately(1920, 2);
+        box.Height.Should().BeApproximately(1080, 2);
+    }
+
+    [Fact]
+    public async Task HomePage_ContainerHasFlexColumnLayout()
+    {
+        var page = await _fixture.NewPageAsync();
+        var dashboardPage = new DashboardPage(page, _fixture.BaseUrl);
+
+        await dashboardPage.NavigateAsync();
+
+        var container = dashboardPage.MainContainer;
+        var display = await container.EvaluateAsync<string>("el => getComputedStyle(el).display");
+        var direction = await container.EvaluateAsync<string>("el => getComputedStyle(el).flexDirection");
+
+        display.Should().Be("flex");
+        direction.Should().Be("column");
+    }
+
+    [Fact]
+    public async Task HomePage_ContainerHasOverflowHidden()
+    {
+        var page = await _fixture.NewPageAsync();
+        var dashboardPage = new DashboardPage(page, _fixture.BaseUrl);
+
+        await dashboardPage.NavigateAsync();
+
+        var container = dashboardPage.MainContainer;
+        var overflow = await container.EvaluateAsync<string>("el => getComputedStyle(el).overflow");
+
+        overflow.Should().Be("hidden");
+    }
+
+    [Fact]
+    public async Task HomePage_HasCorrectFontFamily()
+    {
+        var page = await _fixture.NewPageAsync();
+        var dashboardPage = new DashboardPage(page, _fixture.BaseUrl);
+
+        await dashboardPage.NavigateAsync();
+
+        var container = dashboardPage.MainContainer;
+        var fontFamily = await container.EvaluateAsync<string>("el => getComputedStyle(el).fontFamily");
+
+        fontFamily.Should().Contain("Segoe UI");
+    }
+
+    [Fact]
+    public async Task HomePage_NoBlazorReconnectModalVisible()
+    {
+        var page = await _fixture.NewPageAsync();
+        var dashboardPage = new DashboardPage(page, _fixture.BaseUrl);
+
+        await dashboardPage.NavigateAsync();
+
+        var hasModal = await dashboardPage.HasBlazorReconnectModalAsync();
+        hasModal.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task HomePage_NoBlazorServerScript()
+    {
+        var page = await _fixture.NewPageAsync();
+        var dashboardPage = new DashboardPage(page, _fixture.BaseUrl);
+
+        await dashboardPage.NavigateAsync();
+
+        var html = await dashboardPage.GetPageHtmlAsync();
+        html.Should().NotContain("blazor.server.js");
+    }
+
+    [Fact]
+    public async Task HomePage_HasViewportMetaWidth1920()
+    {
+        var page = await _fixture.NewPageAsync();
+        var dashboardPage = new DashboardPage(page, _fixture.BaseUrl);
+
+        await dashboardPage.NavigateAsync();
+
+        var viewport = await page.Locator("meta[name='viewport']").GetAttributeAsync("content");
+        viewport.Should().Contain("width=1920");
+    }
+
+    [Fact]
+    public async Task HomePage_HasCssLink()
+    {
+        var page = await _fixture.NewPageAsync();
+        var dashboardPage = new DashboardPage(page, _fixture.BaseUrl);
+
+        await dashboardPage.NavigateAsync();
+
+        var cssLink = page.Locator("link[rel='stylesheet'][href='css/app.css']");
+        var count = await cssLink.CountAsync();
+        count.Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public async Task HomePage_HasDoctype()
+    {
+        var page = await _fixture.NewPageAsync();
+        var dashboardPage = new DashboardPage(page, _fixture.BaseUrl);
+
+        await dashboardPage.NavigateAsync();
+
+        var doctype = await page.EvaluateAsync<string>("() => document.doctype ? new XMLSerializer().serializeToString(document.doctype) : ''");
+        doctype.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task HomePage_HtmlHasLangAttribute()
+    {
+        var page = await _fixture.NewPageAsync();
+        var dashboardPage = new DashboardPage(page, _fixture.BaseUrl);
+
+        await dashboardPage.NavigateAsync();
+
+        var lang = await page.Locator("html").GetAttributeAsync("lang");
+        lang.Should().Be("en");
+    }
+}

--- a/tests/ReportingDashboard.UITests/Tests/DashboardWithValidDataTests.cs
+++ b/tests/ReportingDashboard.UITests/Tests/DashboardWithValidDataTests.cs
@@ -1,0 +1,209 @@
+using FluentAssertions;
+using Microsoft.Playwright;
+using ReportingDashboard.UITests.Infrastructure;
+using ReportingDashboard.UITests.PageObjects;
+using Xunit;
+
+namespace ReportingDashboard.UITests.Tests;
+
+[Collection("Playwright")]
+[Trait("Category", "UI")]
+public class DashboardWithValidDataTests
+{
+    private readonly PlaywrightFixture _fixture;
+
+    public DashboardWithValidDataTests(PlaywrightFixture fixture) => _fixture = fixture;
+
+    [Fact]
+    public async Task ValidData_RendersHeaderSection()
+    {
+        var page = await _fixture.NewPageAsync();
+        var dashboardPage = new DashboardPage(page, _fixture.BaseUrl);
+
+        await dashboardPage.NavigateAsync();
+
+        // If data is valid, header should be visible; if error, skip assertion
+        var errorCount = await dashboardPage.ErrorSection.CountAsync();
+        if (errorCount == 0)
+        {
+            await Assertions.Expect(dashboardPage.Header).ToBeVisibleAsync();
+        }
+    }
+
+    [Fact]
+    public async Task ValidData_HeaderContainsProjectTitle()
+    {
+        var page = await _fixture.NewPageAsync();
+        var dashboardPage = new DashboardPage(page, _fixture.BaseUrl);
+
+        await dashboardPage.NavigateAsync();
+
+        var errorCount = await dashboardPage.ErrorSection.CountAsync();
+        if (errorCount == 0)
+        {
+            var titleText = await dashboardPage.HeaderTitle.TextContentAsync();
+            titleText.Should().NotBeNullOrWhiteSpace();
+        }
+    }
+
+    [Fact]
+    public async Task ValidData_HeaderTitleIs24pxBold()
+    {
+        var page = await _fixture.NewPageAsync();
+        var dashboardPage = new DashboardPage(page, _fixture.BaseUrl);
+
+        await dashboardPage.NavigateAsync();
+
+        var errorCount = await dashboardPage.ErrorSection.CountAsync();
+        if (errorCount == 0)
+        {
+            var fontSize = await dashboardPage.HeaderTitle.EvaluateAsync<string>(
+                "el => getComputedStyle(el).fontSize");
+            var fontWeight = await dashboardPage.HeaderTitle.EvaluateAsync<string>(
+                "el => getComputedStyle(el).fontWeight");
+
+            fontSize.Should().Be("24px");
+            fontWeight.Should().BeOneOf("700", "bold");
+        }
+    }
+
+    [Fact]
+    public async Task ValidData_SubtitleIsVisible()
+    {
+        var page = await _fixture.NewPageAsync();
+        var dashboardPage = new DashboardPage(page, _fixture.BaseUrl);
+
+        await dashboardPage.NavigateAsync();
+
+        var errorCount = await dashboardPage.ErrorSection.CountAsync();
+        if (errorCount == 0)
+        {
+            await Assertions.Expect(dashboardPage.HeaderSubtitle).ToBeVisibleAsync();
+        }
+    }
+
+    [Fact]
+    public async Task ValidData_HeaderHasBottomBorder()
+    {
+        var page = await _fixture.NewPageAsync();
+        var dashboardPage = new DashboardPage(page, _fixture.BaseUrl);
+
+        await dashboardPage.NavigateAsync();
+
+        var errorCount = await dashboardPage.ErrorSection.CountAsync();
+        if (errorCount == 0)
+        {
+            var borderBottom = await dashboardPage.Header.EvaluateAsync<string>(
+                "el => getComputedStyle(el).borderBottomStyle");
+            borderBottom.Should().Be("solid");
+        }
+    }
+
+    [Fact]
+    public async Task ValidData_TimelineAreaIsVisible()
+    {
+        var page = await _fixture.NewPageAsync();
+        var dashboardPage = new DashboardPage(page, _fixture.BaseUrl);
+
+        await dashboardPage.NavigateAsync();
+
+        var errorCount = await dashboardPage.ErrorSection.CountAsync();
+        if (errorCount == 0)
+        {
+            await Assertions.Expect(dashboardPage.TimelineArea).ToBeVisibleAsync();
+        }
+    }
+
+    [Fact]
+    public async Task ValidData_TimelineContainsPlaceholderText()
+    {
+        var page = await _fixture.NewPageAsync();
+        var dashboardPage = new DashboardPage(page, _fixture.BaseUrl);
+
+        await dashboardPage.NavigateAsync();
+
+        var errorCount = await dashboardPage.ErrorSection.CountAsync();
+        if (errorCount == 0)
+        {
+            var text = await dashboardPage.TimelineArea.TextContentAsync();
+            text.Should().Contain("Timeline placeholder");
+            text.Should().Contain("track(s) configured");
+        }
+    }
+
+    [Fact]
+    public async Task ValidData_HeatmapAreaIsVisible()
+    {
+        var page = await _fixture.NewPageAsync();
+        var dashboardPage = new DashboardPage(page, _fixture.BaseUrl);
+
+        await dashboardPage.NavigateAsync();
+
+        var errorCount = await dashboardPage.ErrorSection.CountAsync();
+        if (errorCount == 0)
+        {
+            await Assertions.Expect(dashboardPage.HeatmapWrap).ToBeVisibleAsync();
+        }
+    }
+
+    [Fact]
+    public async Task ValidData_HeatmapContainsPlaceholderText()
+    {
+        var page = await _fixture.NewPageAsync();
+        var dashboardPage = new DashboardPage(page, _fixture.BaseUrl);
+
+        await dashboardPage.NavigateAsync();
+
+        var errorCount = await dashboardPage.ErrorSection.CountAsync();
+        if (errorCount == 0)
+        {
+            var text = await dashboardPage.HeatmapWrap.TextContentAsync();
+            text.Should().Contain("Heatmap placeholder");
+            text.Should().Contain("categories x");
+            text.Should().Contain("months");
+        }
+    }
+
+    [Fact]
+    public async Task ValidData_ThreeSectionsRenderedInOrder()
+    {
+        var page = await _fixture.NewPageAsync();
+        var dashboardPage = new DashboardPage(page, _fixture.BaseUrl);
+
+        await dashboardPage.NavigateAsync();
+
+        var errorCount = await dashboardPage.ErrorSection.CountAsync();
+        if (errorCount == 0)
+        {
+            var headerBox = await dashboardPage.Header.BoundingBoxAsync();
+            var timelineBox = await dashboardPage.TimelineArea.BoundingBoxAsync();
+            var heatmapBox = await dashboardPage.HeatmapWrap.BoundingBoxAsync();
+
+            headerBox.Should().NotBeNull();
+            timelineBox.Should().NotBeNull();
+            heatmapBox.Should().NotBeNull();
+
+            // Header above timeline
+            headerBox!.Y.Should().BeLessThan(timelineBox!.Y);
+            // Timeline above heatmap
+            timelineBox.Y.Should().BeLessThan(heatmapBox!.Y);
+        }
+    }
+
+    [Fact]
+    public async Task ValidData_NoErrorSectionRendered()
+    {
+        var page = await _fixture.NewPageAsync();
+        var dashboardPage = new DashboardPage(page, _fixture.BaseUrl);
+
+        await dashboardPage.NavigateAsync();
+
+        // If we get data loaded, error should not be present
+        var headerCount = await dashboardPage.Header.CountAsync();
+        if (headerCount > 0)
+        {
+            var errorCount = await dashboardPage.ErrorSection.CountAsync();
+            errorCount.Should().Be(0);
+        }
+    }
+}

--- a/tests/ReportingDashboard.UITests/Tests/ErrorDisplayTests.cs
+++ b/tests/ReportingDashboard.UITests/Tests/ErrorDisplayTests.cs
@@ -1,0 +1,148 @@
+using FluentAssertions;
+using Microsoft.Playwright;
+using ReportingDashboard.UITests.Infrastructure;
+using ReportingDashboard.UITests.PageObjects;
+using Xunit;
+
+namespace ReportingDashboard.UITests.Tests;
+
+[Collection("Playwright")]
+[Trait("Category", "UI")]
+public class ErrorDisplayTests
+{
+    private readonly PlaywrightFixture _fixture;
+
+    public ErrorDisplayTests(PlaywrightFixture fixture) => _fixture = fixture;
+
+    [Fact]
+    public async Task ErrorState_ErrorSectionHasCenteredLayout()
+    {
+        var page = await _fixture.NewPageAsync();
+        var errorPage = new ErrorPage(page, _fixture.BaseUrl);
+
+        await errorPage.NavigateToAsync("/");
+
+        if (await errorPage.IsErrorVisibleAsync())
+        {
+            var display = await errorPage.ErrorContainer.EvaluateAsync<string>(
+                "el => getComputedStyle(el).display");
+            var justifyContent = await errorPage.ErrorContainer.EvaluateAsync<string>(
+                "el => getComputedStyle(el).justifyContent");
+            var alignItems = await errorPage.ErrorContainer.EvaluateAsync<string>(
+                "el => getComputedStyle(el).alignItems");
+
+            display.Should().Be("flex");
+            justifyContent.Should().Be("center");
+            alignItems.Should().Be("center");
+        }
+    }
+
+    [Fact]
+    public async Task ErrorState_ErrorContainsHeading()
+    {
+        var page = await _fixture.NewPageAsync();
+        var errorPage = new ErrorPage(page, _fixture.BaseUrl);
+
+        await errorPage.NavigateToAsync("/");
+
+        if (await errorPage.IsErrorVisibleAsync())
+        {
+            await Assertions.Expect(errorPage.ErrorHeading).ToBeVisibleAsync();
+            var heading = await errorPage.ErrorHeading.TextContentAsync();
+            heading.Should().Contain("Dashboard Error");
+        }
+    }
+
+    [Fact]
+    public async Task ErrorState_ErrorContainsDescriptiveMessage()
+    {
+        var page = await _fixture.NewPageAsync();
+        var errorPage = new ErrorPage(page, _fixture.BaseUrl);
+
+        await errorPage.NavigateToAsync("/");
+
+        if (await errorPage.IsErrorVisibleAsync())
+        {
+            var message = await errorPage.GetErrorTextAsync();
+            message.Should().NotBeNullOrWhiteSpace();
+            // Should contain either file-not-found, parse error, or validation error
+            var hasDescriptiveMessage = message.Contains("data.json") ||
+                                        message.Contains("Invalid JSON") ||
+                                        message.Contains("Missing required field") ||
+                                        message.Contains("deserialized to null");
+            hasDescriptiveMessage.Should().BeTrue("Error message should be descriptive, not a raw exception");
+        }
+    }
+
+    [Fact]
+    public async Task ErrorState_NoStackTraceVisible()
+    {
+        var page = await _fixture.NewPageAsync();
+        var errorPage = new ErrorPage(page, _fixture.BaseUrl);
+
+        await errorPage.NavigateToAsync("/");
+
+        if (await errorPage.IsErrorVisibleAsync())
+        {
+            var html = await page.ContentAsync();
+            html.Should().NotContain("System.Exception");
+            html.Should().NotContain("StackTrace");
+            html.Should().NotContain("at ReportingDashboard.");
+            html.Should().NotContain("NullReferenceException");
+        }
+    }
+
+    [Fact]
+    public async Task ErrorState_NoDataSectionsRendered()
+    {
+        var page = await _fixture.NewPageAsync();
+        var errorPage = new ErrorPage(page, _fixture.BaseUrl);
+
+        await errorPage.NavigateToAsync("/");
+
+        if (await errorPage.IsErrorVisibleAsync())
+        {
+            var hdrCount = await page.Locator(".hdr").CountAsync();
+            var tlCount = await page.Locator(".tl-area").CountAsync();
+            var hmCount = await page.Locator(".hm-wrap").CountAsync();
+
+            hdrCount.Should().Be(0);
+            tlCount.Should().Be(0);
+            hmCount.Should().Be(0);
+        }
+    }
+
+    [Fact]
+    public async Task ErrorState_NoBlazorErrorBoundary()
+    {
+        var page = await _fixture.NewPageAsync();
+        var errorPage = new ErrorPage(page, _fixture.BaseUrl);
+
+        await errorPage.NavigateToAsync("/");
+
+        var html = await page.ContentAsync();
+        html.Should().NotContain("blazor-error-boundary");
+        html.Should().NotContain("blazor-error-ui");
+    }
+
+    [Fact]
+    public async Task ErrorState_PageStillReturns200()
+    {
+        var page = await _fixture.NewPageAsync();
+        IResponse? mainResponse = null;
+
+        page.Response += (_, r) =>
+        {
+            if (r.Url.TrimEnd('/') == _fixture.BaseUrl.TrimEnd('/') || r.Url == _fixture.BaseUrl + "/")
+                mainResponse = r;
+        };
+
+        var errorPage = new ErrorPage(page, _fixture.BaseUrl);
+        await errorPage.NavigateToAsync("/");
+
+        if (mainResponse is not null)
+        {
+            mainResponse.Status.Should().Be(200);
+        }
+    }
+}

--- a/tests/ReportingDashboard.UITests/Tests/LayoutStructureTests.cs
+++ b/tests/ReportingDashboard.UITests/Tests/LayoutStructureTests.cs
@@ -1,0 +1,105 @@
+using FluentAssertions;
+using Microsoft.Playwright;
+using ReportingDashboard.UITests.Infrastructure;
+using ReportingDashboard.UITests.PageObjects;
+using Xunit;
+
+namespace ReportingDashboard.UITests.Tests;
+
+[Collection("Playwright")]
+[Trait("Category", "UI")]
+public class LayoutStructureTests
+{
+    private readonly PlaywrightFixture _fixture;
+
+    public LayoutStructureTests(PlaywrightFixture fixture) => _fixture = fixture;
+
+    [Fact]
+    public async Task MainLayout_ContainerIsDirectChildOfBody()
+    {
+        var page = await _fixture.NewPageAsync();
+        var dashboardPage = new DashboardPage(page, _fixture.BaseUrl);
+
+        await dashboardPage.NavigateAsync();
+
+        // The 1920x1080 container should be rendered
+        var container = dashboardPage.MainContainer;
+        var count = await container.CountAsync();
+        count.Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public async Task MainLayout_NoNavigationElements()
+    {
+        var page = await _fixture.NewPageAsync();
+        var dashboardPage = new DashboardPage(page, _fixture.BaseUrl);
+
+        await dashboardPage.NavigateAsync();
+
+        var navCount = await page.Locator("nav").CountAsync();
+        var sidebarCount = await page.Locator("[class*='sidebar']").CountAsync();
+        var footerCount = await page.Locator("footer").CountAsync();
+
+        navCount.Should().Be(0);
+        sidebarCount.Should().Be(0);
+        footerCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task MainLayout_WhiteBackground()
+    {
+        var page = await _fixture.NewPageAsync();
+        var dashboardPage = new DashboardPage(page, _fixture.BaseUrl);
+
+        await dashboardPage.NavigateAsync();
+
+        var container = dashboardPage.MainContainer;
+        var bg = await container.EvaluateAsync<string>("el => getComputedStyle(el).backgroundColor");
+
+        // #fff = rgb(255, 255, 255)
+        bg.Should().Contain("255");
+    }
+
+    [Fact]
+    public async Task MainLayout_TextColorIsDark()
+    {
+        var page = await _fixture.NewPageAsync();
+        var dashboardPage = new DashboardPage(page, _fixture.BaseUrl);
+
+        await dashboardPage.NavigateAsync();
+
+        var container = dashboardPage.MainContainer;
+        var color = await container.EvaluateAsync<string>("el => getComputedStyle(el).color");
+
+        // #111 = rgb(17, 17, 17)
+        color.Should().Contain("17");
+    }
+
+    [Fact]
+    public async Task Page_NoHorizontalScrollbar()
+    {
+        var page = await _fixture.NewPageAsync();
+        var dashboardPage = new DashboardPage(page, _fixture.BaseUrl);
+
+        await dashboardPage.NavigateAsync();
+
+        var hasHorizontalScroll = await page.EvaluateAsync<bool>(
+            "() => document.documentElement.scrollWidth > document.documentElement.clientWidth");
+
+        // With viewport at 1920, the 1920px container should not cause scrollbars
+        // Note: this may vary if viewport is smaller, which is why we set it in the fixture
+        hasHorizontalScroll.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Page_CharsetIsUtf8()
+    {
+        var page = await _fixture.NewPageAsync();
+        var dashboardPage = new DashboardPage(page, _fixture.BaseUrl);
+
+        await dashboardPage.NavigateAsync();
+
+        var charset = await page.EvaluateAsync<string>("() => document.characterSet");
+        charset.Should().Be("UTF-8");
+    }
+}

--- a/tests/ReportingDashboard.UITests/Tests/NotFoundPageTests.cs
+++ b/tests/ReportingDashboard.UITests/Tests/NotFoundPageTests.cs
@@ -1,0 +1,67 @@
+using FluentAssertions;
+using Microsoft.Playwright;
+using ReportingDashboard.UITests.Infrastructure;
+using ReportingDashboard.UITests.PageObjects;
+using Xunit;
+
+namespace ReportingDashboard.UITests.Tests;
+
+[Collection("Playwright")]
+[Trait("Category", "UI")]
+public class NotFoundPageTests
+{
+    private readonly PlaywrightFixture _fixture;
+
+    public NotFoundPageTests(PlaywrightFixture fixture) => _fixture = fixture;
+
+    [Fact]
+    public async Task UnknownRoute_RendersPageNotFound()
+    {
+        var page = await _fixture.NewPageAsync();
+
+        await page.GotoAsync($"{_fixture.BaseUrl}/this-page-does-not-exist", new PageGotoOptions
+        {
+            WaitUntil = WaitUntilState.NetworkIdle,
+            Timeout = 15000
+        });
+
+        var html = await page.ContentAsync();
+
+        // The Blazor Router should show the NotFound template
+        // which renders "Page Not Found"
+        html.Should().Contain("Page Not Found");
+    }
+
+    [Fact]
+    public async Task UnknownRoute_UsesMainLayout()
+    {
+        var page = await _fixture.NewPageAsync();
+
+        await page.GotoAsync($"{_fixture.BaseUrl}/nonexistent-route", new PageGotoOptions
+        {
+            WaitUntil = WaitUntilState.NetworkIdle,
+            Timeout = 15000
+        });
+
+        // Main layout container should still be present
+        var container = page.Locator("div[style*='width:1920px'][style*='height:1080px']");
+        var count = await container.CountAsync();
+        count.Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public async Task UnknownRoute_ShowsErrorStyling()
+    {
+        var page = await _fixture.NewPageAsync();
+
+        await page.GotoAsync($"{_fixture.BaseUrl}/xyz-missing", new PageGotoOptions
+        {
+            WaitUntil = WaitUntilState.NetworkIdle,
+            Timeout = 15000
+        });
+
+        var errorDiv = page.Locator(".dashboard-error");
+        var count = await errorDiv.CountAsync();
+        count.Should().BeGreaterThan(0);
+    }
+}

--- a/tests/ReportingDashboard.UITests/Tests/ScreenshotTests.cs
+++ b/tests/ReportingDashboard.UITests/Tests/ScreenshotTests.cs
@@ -1,0 +1,63 @@
+using FluentAssertions;
+using Microsoft.Playwright;
+using ReportingDashboard.UITests.Infrastructure;
+using ReportingDashboard.UITests.PageObjects;
+using Xunit;
+
+namespace ReportingDashboard.UITests.Tests;
+
+[Collection("Playwright")]
+[Trait("Category", "UI")]
+public class ScreenshotTests
+{
+    private readonly PlaywrightFixture _fixture;
+
+    public ScreenshotTests(PlaywrightFixture fixture) => _fixture = fixture;
+
+    [Fact]
+    public async Task Dashboard_CanCaptureScreenshot()
+    {
+        var page = await _fixture.NewPageAsync();
+        var dashboardPage = new DashboardPage(page, _fixture.BaseUrl);
+
+        await dashboardPage.NavigateAsync();
+
+        // Verify we can take a screenshot without error
+        var screenshotsDir = Path.Combine(AppContext.BaseDirectory, "screenshots");
+        Directory.CreateDirectory(screenshotsDir);
+        var path = Path.Combine(screenshotsDir, $"dashboard_test_{DateTime.UtcNow:yyyyMMdd_HHmmss}.png");
+
+        await page.ScreenshotAsync(new PageScreenshotOptions
+        {
+            Path = path,
+            FullPage = false, // 1920x1080 viewport only
+            Type = ScreenshotType.Png
+        });
+
+        File.Exists(path).Should().BeTrue();
+        new FileInfo(path).Length.Should().BeGreaterThan(0);
+
+        // Clean up
+        File.Delete(path);
+    }
+
+    [Fact]
+    public async Task Dashboard_ScreenshotFixtureHelper_Works()
+    {
+        var page = await _fixture.NewPageAsync();
+        var dashboardPage = new DashboardPage(page, _fixture.BaseUrl);
+
+        await dashboardPage.NavigateAsync();
+
+        // Use the fixture helper
+        await _fixture.CaptureScreenshotAsync(page, nameof(Dashboard_ScreenshotFixtureHelper_Works));
+
+        var screenshotsDir = Path.Combine(AppContext.BaseDirectory, "screenshots");
+        var files = Directory.GetFiles(screenshotsDir, $"{nameof(Dashboard_ScreenshotFixtureHelper_Works)}*.png");
+        files.Should().NotBeEmpty();
+
+        // Clean up
+        foreach (var file in files)
+            File.Delete(file);
+    }
+}


### PR DESCRIPTION
## Task Assignment
**Assigned To:** PrincipalEngineer
**Complexity:** High
**Branch:** `agent/principalengineer/t1-project-foundation-scaffolding`

## Requirements
Closes #733

# PR: Project Foundation & Scaffolding for Executive Reporting Dashboard

## Summary

This PR establishes the complete project skeleton for the Executive Reporting Dashboard — a single-page Blazor Server (.NET 8) application that renders a pixel-perfect 1920×1080 dashboard from a `data.json` file. It creates the solution structure, all shared C# record models, the `DashboardDataService` with load/validate logic, the Blazor component shell (App, MainLayout, Dashboard page orchestrator), the complete `app.css` stylesheet ported from `OriginalDesignConcept.html`, and project configuration bound to `http://localhost:5000` with no HTTPS. After this PR merges, parallel engineers can implement individual UI components (Header, Timeline, Heatmap) against well-defined interfaces, models, and CSS classes.

**Key design decisions:**
- **Static SSR only** — no `@rendermode` attribute, no SignalR circuit, no reconnection UI risk.
- **Data reload on every request** — `DashboardDataService` re-reads `data.json` on each call to `Load()` so PMs can edit JSON and refresh the browser instantly without restarting.
- **Single global `app.css`** — all CSS in one file prevents merge conflicts when parallel engineers add components. CSS class names match `OriginalDesignConcept.html` exactly.
- **Dashboard.razor as orchestrator** — it injects the data service, handles error display, and will distribute data to child components via `[Parameter]` (child components are stubbed as HTML comments for parallel tasks).

## Acceptance Criteria

- [ ] `.gitignore` includes `bin/`, `obj/`, `.vs/`, `publish/`, `*.user` patterns for .NET projects
- [ ] `dotnet build` succeeds with zero errors and zero warnings from the `ReportingDashboard/` directory
- [ ] `dotnet run` starts Kestrel and serves at `http://localhost:5000` (HTTP only, no HTTPS)
- [ ] `.csproj` targets `net8.0` and contains zero `<PackageReference>` elements
- [ ] `Models/DashboardData.cs` defines all 8 record types: `DashboardData`, `ProjectInfo`, `TimelineConfig`, `MilestoneTrack`, `Milestone`, `HeatmapData`, `HeatmapCategory`, plus uses `System.Text.Json.Serialization` attributes where needed
- [ ] `Services/DashboardDataService.cs` reads `Data/data.json` on each call to `Load()`, returns `(DashboardData? Data, string? Error)` tuple, handles file-not-found, invalid JSON (`JsonException`), and missing required field validation without throwing
- [ ] Navigating to `http://localhost:5000/` renders a page within a 1920×1080 fixed container (`width:1920px; height:1080px; overflow:hidden`) with flexbox column layout
- [ ] When `Data/data.json` is missing, the page renders a centered error message (not a blank page, not a Blazor error boundary, not a stack trace)
- [ ] When `Data/data.json` contains invalid JSON, the page renders the parse error in user-friendly text
- [ ] When `Data/data.json` is missing required fields (e.g., `project.title`), the page renders which field is missing
- [ ] `app.css` contains all CSS classes from `OriginalDesignConcept.html`: `.hdr`, `.sub`, `.tl-area`, `.tl-svg-box`, `.hm-wrap`, `.hm-title`, `.hm-grid`, `.hm-corner`, `.hm-col-hdr`, `.apr-hdr`, `.hm-row-hdr`, `.hm-cell`, `.it`, and all row-color variants (`.ship-hdr`, `.ship-cell`, `.prog-hdr`, `.prog-cell`, `.carry-hdr`, `.carry-cell`, `.block-hdr`, `.block-cell`)
- [ ] `app.css` defines CSS custom properties in `:root` for all theme colors
- [ ] `App.razor` renders the HTML shell with `<head>` containing the CSS link and no `@rendermode` attribute (Static SSR)
- [ ] `MainLayout.razor` inherits `LayoutComponentBase`, renders only `@Body` with no nav/sidebar/footer, inside the 1920×1080 container
- [ ] `Dashboard.razor` has `@page "/"`, injects `DashboardDataService`, calls `Load()`, conditionally renders error or placeholder content for the three sections (header, timeline, heatmap)
- [ ] No Blazor reconnection UI or framework chrome is visible when the page renders
- [ ] CSS includes a safety-net rule to hide `.components-reconnect-modal`

## Implementation Steps

### Step 1: Solution scaffolding, .gitignore, and project configuration

Update `.gitignore` with .NET patterns (`bin/`, `obj/`, `.vs/`, `*.user`, `publish/`). Create the solution file `ReportingDashboard.sln` and the project `ReportingDashboard/ReportingDashboard.csproj` targeting `net8.0` with the `Microsoft.NET.Sdk.Web` SDK and no `<PackageReference>` elements. Create `Properties/launchSettings.json` with a single `http` profile bound to `http://localhost:5000` (no HTTPS profile). Create `Program.cs` with minimal Blazor Server setup: `AddRazorComponents()`, `UseStaticFiles()`, `UseAntiforgery()`, `MapRazorComponents<App>()`. Register `DashboardDataService` as singleton. Create empty `Data/` directory with a `.gitkeep` file. Verify `dotnet build` passes.

**Files:** `.gitignore` (modify), `ReportingDashboard.sln` (create), `ReportingDashboard/ReportingDashboard.csproj` (create), `ReportingDashboard/Program.cs` (create), `ReportingDashboard/Properties/launchSettings.json` (create), `ReportingDashboard/Data/.gitkeep` (create)

### Step 2: Data models and DashboardDataService

Create `Models/DashboardData.cs` with all 8 record types in the `ReportingDashboard.Models` namespace: `DashboardData` (root with `Project`, `Timeline`, `Tracks`, `Heatmap` properties), `ProjectInfo` (`Title`, `Subtitle`, `BacklogUrl`, `CurrentMonth`), `TimelineConfig` (`Months` list, `NowPosition` double), `MilestoneTrack` (`Id`, `Label`, `Color`, `Milestones` list), `Milestone` (`Date`, `Type`, `Position`, optional `Label`), `HeatmapData` (`Months` list, `Categories` list), `HeatmapCategory` (`Name`, `CssClass`, `Emoji`, `Items` as `Dictionary<string, List<string>>`). Use `System.Text.Json.Serialization` attributes as needed for case mapping. Create `Services/DashboardDataService.cs` in the `ReportingDashboard.Services` namespace implementing the `Load()` method that returns `(DashboardData? Data, string? Error)`. The service reads `Data/data.json` from `ContentRootPath` on every call (not cached). It handles: file not found → descriptive error string; `JsonException` → parse error message; successful deserialization → validate required fields (`project.title` non-empty, `timeline.months` non-null with ≥1 element, `timeline.nowPosition` between 0.0–1.0, `tracks` non-null, `heatmap.categories` non-null, `heatmap.categories[].cssClass` one of ship/prog/carry/block, `milestone.type` one of checkpoint/poc/production, `milestone.position` between 0.0–1.0). Validation errors return the specific field name. The service never throws.

**Files:** `ReportingDashboard/Models/DashboardData.cs` (create), `ReportingDashboard/Services/DashboardDataService.cs` (create)

### Step 3: Blazor component shell (App, Layout, Imports, Dashboard orchestrator)

Create `Components/App.razor` as the HTML document shell: `<!DOCTYPE html>`, `<html>`, `<head>` with charset, viewport meta (`width=1920`), title, and `<link>` to `css/app.css`. `<body>` contains `<Routes />` and no `@rendermode` attribute (defaults to Static SSR). Create `Components/_Imports.razor` with global usings: `@using System.Net.Http`, `@using Microsoft.AspNetCore.Components.Forms`, `@using Microsoft.AspNetCore.Components.Routing`, `@using Microsoft.AspNetCore.Components.Web`, `@using ReportingDashboard.Models`, `@using ReportingDashboard.Services`, `@using ReportingDashboard.Components`. Create `Components/Layout/MainLayout.razor` inheriting `LayoutComponentBase` — renders a single `<div>` with inline style `width:1920px;height:1080px;overflow:hidden;display:flex;flex-direction:column;background:#fff;font-family:'Segoe UI',Arial,sans-serif;color:#111;` containing only `@Body`. No nav, no sidebar, no footer. Create `Components/Pages/Dashboard.razor` with `@page "/"` and `@inject DashboardDataService DataService`. In `OnInitialized`, call `DataService.Load()` to get `(data, error)`. If error is non-null, render a centered error `<div>` (flex center, 1920×1080, 18px red text, white background, no stack trace). If data loads successfully, render HTML comment placeholders for the three child components: `<!-- DashboardHeader will render here -->`, `<!-- TimelineSection will render here -->`, `<!-- HeatmapSection will render here -->`. Also add a `Routes.razor` component with `<Router>` pointing to the app assembly.

**Files:** `ReportingDashboard/Components/App.razor` (create), `ReportingDashboard/Components/_Imports.razor` (create), `ReportingDashboard/Components/Layout/MainLayout.razor` (create), `ReportingDashboard/Components/Pages/Dashboard.razor` (create), `ReportingDashboard/Components/Routes.razor` (create)

### Step 4: Complete app.css stylesheet ported from OriginalDesignConcept.html

Create `wwwroot/css/app.css` with the full stylesheet. Start with `:root` CSS custom properties defining all theme colors (track colors, heatmap row colors, status dot colors, backgrounds, borders, text colors). Then port every CSS rule from the `<style>` block in `OriginalDesignConcept.html` verbatim, organized by section: global reset (`* { margin:0; padding:0; box-sizing:border-box; }`), body constraints (1920×1080, overflow hidden, flex column), link styling, `.hdr` header styles (flexbox row, padding, border-bottom), `.sub` subtitle, `.tl-area` timeline container (196px height, `#FAFAFA` bg, border-bottom), `.tl-svg-box`, `.hm-wrap` heatmap wrapper (flex:1, min-height:0), `.hm-title`, `.hm-grid` (CSS Grid), `.hm-corner`, `.hm-col-hdr`, `.apr-hdr` (current month highlight `#FFF0D0`/`#C07700`), `.hm-row-hdr`, `.hm-cell`, `.it` item with `::before` dot pseudo-element. Then all four row-color variant groups: `.ship-hdr`/`.ship-cell` (greens), `.prog-hdr`/`.prog-cell` (blues), `.carry-hdr`/`.carry-cell` (ambers), `.block-hdr`/`.block-cell` (reds), each with base and `.apr` (current month) backgrounds, and `::before` dot colors. Add `.components-reconnect-modal { display: none !important; }` as a safety net against Blazor reconnection UI. Add error display styles for the centered error message in Dashboard.razor.

**Files:** `ReportingDashboard/wwwroot/css/app.css` (create)

### Step 5: Verify end-to-end build and error rendering

Run `dotnet build` to confirm zero errors. Run `dotnet run` and verify: (1) navigating to `http://localhost:5000` shows the centered error message "data.json not found at: {path}" since no `data.json` exists yet; (2) creating a `Data/data.json` with `{ "invalid }` and refreshing shows a JSON parse error message; (3) creating a valid but incomplete `Data/data.json` (e.g., `{"project":{}}`) shows "Missing required field: project.title"; (4) no Blazor reconnection banner or framework chrome appears; (5) the page renders within a 1920×1080 container with no scrollbars. Fix any issues found. This step produces no new files — only verification and potential bug fixes to files from previous steps.

**Files:** No new files (verification and fixes only)

## Testing

Since unit tests are out of scope per the PM spec, validation is manual:

1. **Build verification**: `dotnet build` succeeds with zero errors and zero warnings.
2. **Startup verification**: `dotnet run` starts without exceptions and binds to `http://localhost:5000`.
3. **Missing data.json**: Delete `Data/data.json`, navigate to `/` — verify centered error message appears with the file path, no blank page, no stack trace, no Blazor error boundary.
4. **Malformed JSON**: Place `{ "bad json }` in `Data/data.json`, refresh — verify parse error message with line/position details renders in the browser.
5. **Missing required fields**: Place `{"project":{"title":""}}` in `Data/data.json`, refresh — verify "Missing required field: project.title" message.
6. **Valid but minimal JSON**: Place a complete minimal `data.json` with all required fields — verify page renders the 1920×1080 container with placeholder comments (no errors).
7. **No HTTPS**: Verify `https://localhost:5001` does NOT respond (no HTTPS profile configured).
8. **No Blazor chrome**: Verify no blue reconnection banner, no error boundary UI, no interactive Blazor elements appear.
9. **CSS completeness**: Inspect the served `app.css` and verify all class names from `OriginalDesignConcept.html` are present.
10. **Zero dependencies**: Inspect `ReportingDashboard.csproj` and confirm no `<PackageReference>` elements exist.

## References
- Architecture: Architecture.md
- PM Spec: 

## Status
- [ ] Implementation
- [ ] Tests Written
- [ ] Ready for Review