### PR TITLE
PrincipalEngineer: Project Foundation & Scaffolding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,26 +1,29 @@
 ## .NET
 bin/
 obj/
-publish/
-
-## User-specific files
-*.rsuser
-*.suo
 *.user
+*.suo
 *.userosscache
 *.sln.docstates
 
-## Build results
+## Visual Studio
+.vs/
+*.rsuser
 [Dd]ebug/
 [Rr]elease/
 x64/
 x86/
-build/
+[Bb]uild/
 bld/
+[Ll]og/
+[Ll]ogs/
 
-## Visual Studio
-.vs/
-*.csproj.user
+## NuGet
+**/[Pp]ackages/*
+!**/[Pp]ackages/build/
+*.nupkg
+**/packages/*
+!**/packages/build/
 
 ## Rider
 .idea/
@@ -30,3 +33,6 @@ Thumbs.db
 ehthumbs.db
 Desktop.ini
 .DS_Store
+
+## Project-specific
+*.db

--- a/ReportingDashboard.Models/DashboardData.cs
+++ b/ReportingDashboard.Models/DashboardData.cs
@@ -1,0 +1,7 @@
+namespace ReportingDashboard.Models;
+
+public record DashboardData(
+    ProjectHeader Header,
+    TimelineConfig Timeline,
+    HeatmapData Heatmap
+);

--- a/ReportingDashboard.Models/HeatmapData.cs
+++ b/ReportingDashboard.Models/HeatmapData.cs
@@ -1,0 +1,7 @@
+namespace ReportingDashboard.Models;
+
+public record HeatmapData(
+    List<string> Columns,
+    int HighlightColumnIndex,
+    List<StatusRow> Rows
+);

--- a/ReportingDashboard.Models/Milestone.cs
+++ b/ReportingDashboard.Models/Milestone.cs
@@ -1,0 +1,9 @@
+namespace ReportingDashboard.Models;
+
+public record Milestone(
+    string TrackId,
+    DateTime Date,
+    string Label,
+    string Type,
+    string? Description
+);

--- a/ReportingDashboard.Models/MonthCell.cs
+++ b/ReportingDashboard.Models/MonthCell.cs
@@ -1,0 +1,5 @@
+namespace ReportingDashboard.Models;
+
+public record MonthCell(
+    List<string> Items
+);

--- a/ReportingDashboard.Models/ProjectHeader.cs
+++ b/ReportingDashboard.Models/ProjectHeader.cs
@@ -1,0 +1,8 @@
+namespace ReportingDashboard.Models;
+
+public record ProjectHeader(
+    string Title,
+    string Subtitle,
+    string BacklogUrl,
+    string CurrentMonth
+);

--- a/ReportingDashboard.Models/ReportingDashboard.Models.csproj
+++ b/ReportingDashboard.Models/ReportingDashboard.Models.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+</Project>

--- a/ReportingDashboard.Models/StatusRow.cs
+++ b/ReportingDashboard.Models/StatusRow.cs
@@ -1,0 +1,7 @@
+namespace ReportingDashboard.Models;
+
+public record StatusRow(
+    string Category,
+    string ColorTheme,
+    List<MonthCell> Cells
+);

--- a/ReportingDashboard.Models/TimelineConfig.cs
+++ b/ReportingDashboard.Models/TimelineConfig.cs
@@ -1,0 +1,9 @@
+namespace ReportingDashboard.Models;
+
+public record TimelineConfig(
+    DateTime StartDate,
+    DateTime EndDate,
+    DateTime NowDate,
+    List<Track> Tracks,
+    List<Milestone> Milestones
+);

--- a/ReportingDashboard.Models/Track.cs
+++ b/ReportingDashboard.Models/Track.cs
@@ -1,0 +1,8 @@
+namespace ReportingDashboard.Models;
+
+public record Track(
+    string Id,
+    string Label,
+    string Description,
+    string Color
+);

--- a/ReportingDashboard.Models/data.json
+++ b/ReportingDashboard.Models/data.json
@@ -1,0 +1,26 @@
+{
+  "project": {
+    "name": "Sample Project",
+    "lead": "Project Lead",
+    "status": "On Track",
+    "lastUpdated": "2026-01-01",
+    "summary": "Sample project dashboard for preview."
+  },
+  "title": "Executive Reporting Dashboard",
+  "subtitle": "Project Status Overview",
+  "backlogLink": "",
+  "currentMonth": "January",
+  "months": ["January", "February", "March"],
+  "milestones": [
+    { "title": "Phase 1", "targetDate": "2026-02-01", "status": "Completed" },
+    { "title": "Phase 2", "targetDate": "2026-04-01", "status": "In Progress" }
+  ],
+  "shipped": [
+    { "title": "Foundation", "description": "Project scaffolding", "category": "Infrastructure", "percentComplete": 100 }
+  ],
+  "inProgress": [
+    { "title": "Dashboard UI", "description": "Building components", "category": "Frontend", "percentComplete": 60 }
+  ],
+  "timeline": { "startMonth": "Jan 2026", "endMonth": "Jun 2026", "tracks": [] },
+  "heatmap": { "months": ["Jan", "Feb", "Mar"], "categories": [], "items": [] }
+}

--- a/ReportingDashboard.Models/wwwroot/data.json
+++ b/ReportingDashboard.Models/wwwroot/data.json
@@ -1,0 +1,26 @@
+{
+  "project": {
+    "name": "Sample Project",
+    "lead": "Project Lead",
+    "status": "On Track",
+    "lastUpdated": "2026-01-01",
+    "summary": "Sample project dashboard for preview."
+  },
+  "title": "Executive Reporting Dashboard",
+  "subtitle": "Project Status Overview",
+  "backlogLink": "",
+  "currentMonth": "January",
+  "months": ["January", "February", "March"],
+  "milestones": [
+    { "title": "Phase 1", "targetDate": "2026-02-01", "status": "Completed" },
+    { "title": "Phase 2", "targetDate": "2026-04-01", "status": "In Progress" }
+  ],
+  "shipped": [
+    { "title": "Foundation", "description": "Project scaffolding", "category": "Infrastructure", "percentComplete": 100 }
+  ],
+  "inProgress": [
+    { "title": "Dashboard UI", "description": "Building components", "category": "Frontend", "percentComplete": 60 }
+  ],
+  "timeline": { "startMonth": "Jan 2026", "endMonth": "Jun 2026", "tracks": [] },
+  "heatmap": { "months": ["Jan", "Feb", "Mar"], "categories": [], "items": [] }
+}

--- a/ReportingDashboard.Models/wwwroot/data/data.json
+++ b/ReportingDashboard.Models/wwwroot/data/data.json
@@ -1,0 +1,26 @@
+{
+  "project": {
+    "name": "Sample Project",
+    "lead": "Project Lead",
+    "status": "On Track",
+    "lastUpdated": "2026-01-01",
+    "summary": "Sample project dashboard for preview."
+  },
+  "title": "Executive Reporting Dashboard",
+  "subtitle": "Project Status Overview",
+  "backlogLink": "",
+  "currentMonth": "January",
+  "months": ["January", "February", "March"],
+  "milestones": [
+    { "title": "Phase 1", "targetDate": "2026-02-01", "status": "Completed" },
+    { "title": "Phase 2", "targetDate": "2026-04-01", "status": "In Progress" }
+  ],
+  "shipped": [
+    { "title": "Foundation", "description": "Project scaffolding", "category": "Infrastructure", "percentComplete": 100 }
+  ],
+  "inProgress": [
+    { "title": "Dashboard UI", "description": "Building components", "category": "Frontend", "percentComplete": 60 }
+  ],
+  "timeline": { "startMonth": "Jan 2026", "endMonth": "Jun 2026", "tracks": [] },
+  "heatmap": { "months": ["Jan", "Feb", "Mar"], "categories": [], "items": [] }
+}

--- a/ReportingDashboard.Web/App.razor
+++ b/ReportingDashboard.Web/App.razor
@@ -1,0 +1,30 @@
+@using Microsoft.AspNetCore.Components.Routing
+@using Microsoft.AspNetCore.Components.Web
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=1920" />
+    <title>Executive Reporting Dashboard</title>
+    <base href="/" />
+    <link href="css/app.css" rel="stylesheet" />
+    <link href="ReportingDashboard.Web.styles.css" rel="stylesheet" />
+</head>
+<body>
+    @Body
+
+    <div id="blazor-error-ui">
+        An unhandled error has occurred.
+        <a href="" class="reload">Reload</a>
+        <a class="dismiss">🗙</a>
+    </div>
+
+    <script src="_framework/blazor.server.js"></script>
+</body>
+</html>
+
+@code {
+    [Parameter]
+    public RenderFragment? Body { get; set; }
+}

--- a/ReportingDashboard.Web/MainLayout.razor
+++ b/ReportingDashboard.Web/MainLayout.razor
@@ -1,0 +1,3 @@
+@inherits LayoutComponentBase
+
+@Body

--- a/ReportingDashboard.Web/MainLayout.razor.css
+++ b/ReportingDashboard.Web/MainLayout.razor.css
@@ -1,0 +1,1 @@
+/* Minimal layout - no nav, no sidebar, no chrome */

--- a/ReportingDashboard.Web/Pages/Dashboard.razor
+++ b/ReportingDashboard.Web/Pages/Dashboard.razor
@@ -1,0 +1,53 @@
+@page "/"
+@using ReportingDashboard.Web.Services
+@using ReportingDashboard.Models
+@inject IDataService DataService
+@implements IDisposable
+
+@if (_data is null)
+{
+    <div style="padding: 60px; font-family: 'Segoe UI', Arial, sans-serif;">
+        <h1 style="color: #EA4335;">Dashboard Configuration Error</h1>
+        <p style="font-size: 16px; color: #333; margin-top: 16px;">@_error</p>
+        <p style="font-size: 13px; color: #888; margin-top: 12px;">
+            Edit data.json and refresh this page.
+        </p>
+    </div>
+}
+else
+{
+    @* Child components will be added in subsequent tasks *@
+    <div class="dashboard-placeholder" style="padding: 60px; font-family: 'Segoe UI', Arial, sans-serif;">
+        <h1>@_data.Header.Title</h1>
+        <p style="color: #888; margin-top: 4px;">@_data.Header.Subtitle</p>
+        <p style="color: #34A853; margin-top: 12px;">✓ data.json loaded successfully. Components will render here.</p>
+    </div>
+}
+
+@code {
+    private DashboardData? _data;
+    private string? _error;
+
+    protected override void OnInitialized()
+    {
+        LoadData();
+        DataService.OnDataChanged += HandleDataChanged;
+    }
+
+    private void LoadData()
+    {
+        _data = DataService.GetData();
+        _error = DataService.GetError();
+    }
+
+    private async void HandleDataChanged()
+    {
+        LoadData();
+        await InvokeAsync(StateHasChanged);
+    }
+
+    public void Dispose()
+    {
+        DataService.OnDataChanged -= HandleDataChanged;
+    }
+}

--- a/ReportingDashboard.Web/Program.cs
+++ b/ReportingDashboard.Web/Program.cs
@@ -1,0 +1,27 @@
+using ReportingDashboard.Web.Services;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddRazorPages();
+builder.Services.AddServerSideBlazor();
+builder.Services.AddSingleton<IDataService>(sp =>
+{
+    var env = sp.GetRequiredService<IWebHostEnvironment>();
+    return new DataService(env.ContentRootPath);
+});
+
+var app = builder.Build();
+
+if (!app.Environment.IsDevelopment())
+{
+    app.UseHsts();
+}
+
+app.UseHttpsRedirection();
+app.UseStaticFiles();
+app.UseRouting();
+
+app.MapBlazorHub();
+app.MapFallbackToPage("/_Host");
+
+app.Run();

--- a/ReportingDashboard.Web/ReportingDashboard.Web.csproj
+++ b/ReportingDashboard.Web/ReportingDashboard.Web.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ReportingDashboard.Models\ReportingDashboard.Models.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="data.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/ReportingDashboard.Web/Services/DataService.cs
+++ b/ReportingDashboard.Web/Services/DataService.cs
@@ -1,0 +1,121 @@
+using System.Text.Json;
+using ReportingDashboard.Models;
+
+namespace ReportingDashboard.Web.Services;
+
+public sealed class DataService : IDataService, IDisposable
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    private readonly string _filePath;
+    private readonly FileSystemWatcher? _watcher;
+    private readonly Timer _debounceTimer;
+
+    private volatile DashboardData? _data;
+    private volatile string? _error;
+
+    public event Action? OnDataChanged;
+
+    public DataService(string contentRootPath)
+    {
+        _filePath = Path.Combine(contentRootPath, "data.json");
+        _debounceTimer = new Timer(OnDebounceElapsed, null, Timeout.Infinite, Timeout.Infinite);
+
+        LoadData();
+
+        try
+        {
+            var directory = Path.GetDirectoryName(_filePath);
+            if (directory is not null)
+            {
+                _watcher = new FileSystemWatcher(directory, "data.json")
+                {
+                    NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.Size | NotifyFilters.CreationTime,
+                    EnableRaisingEvents = true
+                };
+                _watcher.Changed += OnFileChanged;
+                _watcher.Created += OnFileChanged;
+            }
+        }
+        catch
+        {
+            // FileSystemWatcher is a nice-to-have; don't fail startup if it can't be created
+        }
+    }
+
+    public DashboardData? GetData() => _data;
+    public string? GetError() => _error;
+
+    private void LoadData()
+    {
+        try
+        {
+            if (!File.Exists(_filePath))
+            {
+                _data = null;
+                _error = $"data.json not found at {_filePath}. Create this file with your dashboard data.";
+                return;
+            }
+
+            var json = File.ReadAllText(_filePath);
+            _data = JsonSerializer.Deserialize<DashboardData>(json, JsonOptions);
+
+            if (_data is null)
+            {
+                _error = "Failed to parse data.json: deserialization returned null.";
+            }
+            else
+            {
+                _error = null;
+            }
+        }
+        catch (JsonException ex)
+        {
+            _data = null;
+            _error = $"Failed to parse data.json: {ex.Message}";
+        }
+        catch (IOException ex)
+        {
+            // Retry once after a brief delay for file-in-use scenarios
+            try
+            {
+                Thread.Sleep(100);
+                var json = File.ReadAllText(_filePath);
+                _data = JsonSerializer.Deserialize<DashboardData>(json, JsonOptions);
+                _error = _data is null ? "Failed to parse data.json: deserialization returned null." : null;
+            }
+            catch (Exception retryEx)
+            {
+                _data = null;
+                _error = $"Failed to read data.json: {retryEx.Message}";
+            }
+        }
+        catch (Exception ex)
+        {
+            _data = null;
+            _error = $"Failed to load data.json: {ex.Message}";
+        }
+    }
+
+    private void OnFileChanged(object sender, FileSystemEventArgs e)
+    {
+        // Debounce: reset timer to 300ms from now
+        _debounceTimer.Change(300, Timeout.Infinite);
+    }
+
+    private void OnDebounceElapsed(object? state)
+    {
+        LoadData();
+        OnDataChanged?.Invoke();
+    }
+
+    public void Dispose()
+    {
+        _watcher?.Dispose();
+        _debounceTimer.Dispose();
+    }
+}

--- a/ReportingDashboard.Web/Services/IDataService.cs
+++ b/ReportingDashboard.Web/Services/IDataService.cs
@@ -1,0 +1,10 @@
+using ReportingDashboard.Models;
+
+namespace ReportingDashboard.Web.Services;
+
+public interface IDataService
+{
+    DashboardData? GetData();
+    string? GetError();
+    event Action? OnDataChanged;
+}

--- a/ReportingDashboard.Web/_Imports.razor
+++ b/ReportingDashboard.Web/_Imports.razor
@@ -1,0 +1,8 @@
+@using System.Net.Http
+@using Microsoft.AspNetCore.Components.Forms
+@using Microsoft.AspNetCore.Components.Routing
+@using Microsoft.AspNetCore.Components.Web
+@using Microsoft.JSInterop
+@using ReportingDashboard.Web
+@using ReportingDashboard.Web.Services
+@using ReportingDashboard.Models

--- a/ReportingDashboard.Web/data.json
+++ b/ReportingDashboard.Web/data.json
@@ -1,26 +1,165 @@
 {
-  "project": {
-    "name": "Sample Project",
-    "lead": "Project Lead",
-    "status": "On Track",
-    "lastUpdated": "2026-01-01",
-    "summary": "Sample project dashboard for preview."
+  "header": {
+    "title": "Project Phoenix Release Roadmap",
+    "subtitle": "Platform Engineering · Phoenix Workstream · April 2026",
+    "backlogUrl": "https://dev.azure.com/contoso/ProjectPhoenix/_backlogs",
+    "currentMonth": "April 2026"
   },
-  "title": "Executive Reporting Dashboard",
-  "subtitle": "Project Status Overview",
-  "backlogLink": "",
-  "currentMonth": "January",
-  "months": ["January", "February", "March"],
-  "milestones": [
-    { "title": "Phase 1", "targetDate": "2026-02-01", "status": "Completed" },
-    { "title": "Phase 2", "targetDate": "2026-04-01", "status": "In Progress" }
-  ],
-  "shipped": [
-    { "title": "Foundation", "description": "Project scaffolding", "category": "Infrastructure", "percentComplete": 100 }
-  ],
-  "inProgress": [
-    { "title": "Dashboard UI", "description": "Building components", "category": "Frontend", "percentComplete": 60 }
-  ],
-  "timeline": { "startMonth": "Jan 2026", "endMonth": "Jun 2026", "tracks": [] },
-  "heatmap": { "months": ["Jan", "Feb", "Mar"], "categories": [], "items": [] }
+  "timeline": {
+    "startDate": "2026-01-01",
+    "endDate": "2026-06-30",
+    "nowDate": "2026-04-15",
+    "tracks": [
+      {
+        "id": "m1",
+        "label": "M1",
+        "description": "Core API & Auth",
+        "color": "#0078D4"
+      },
+      {
+        "id": "m2",
+        "label": "M2",
+        "description": "Data Pipeline",
+        "color": "#00897B"
+      },
+      {
+        "id": "m3",
+        "label": "M3",
+        "description": "UI & Dashboard",
+        "color": "#546E7A"
+      }
+    ],
+    "milestones": [
+      {
+        "trackId": "m1",
+        "date": "2026-01-15",
+        "label": "Jan 15",
+        "type": "checkpoint-minor",
+        "description": "API spec review"
+      },
+      {
+        "trackId": "m1",
+        "date": "2026-02-20",
+        "label": "Feb 20 PoC",
+        "type": "poc",
+        "description": "Auth PoC complete"
+      },
+      {
+        "trackId": "m1",
+        "date": "2026-03-26",
+        "label": "Mar 26",
+        "type": "checkpoint",
+        "description": "API v1 code-complete"
+      },
+      {
+        "trackId": "m1",
+        "date": "2026-05-15",
+        "label": "May 15 GA",
+        "type": "production",
+        "description": "Core API production release"
+      },
+      {
+        "trackId": "m2",
+        "date": "2026-02-01",
+        "label": "Feb 1",
+        "type": "checkpoint-minor",
+        "description": "Pipeline design approved"
+      },
+      {
+        "trackId": "m2",
+        "date": "2026-03-10",
+        "label": "Mar 10 PoC",
+        "type": "poc",
+        "description": "ETL pipeline PoC"
+      },
+      {
+        "trackId": "m2",
+        "date": "2026-04-20",
+        "label": "Apr 20",
+        "type": "checkpoint",
+        "description": "Pipeline integration tests"
+      },
+      {
+        "trackId": "m2",
+        "date": "2026-06-01",
+        "label": "Jun 1 GA",
+        "type": "production",
+        "description": "Data pipeline production release"
+      },
+      {
+        "trackId": "m3",
+        "date": "2026-03-01",
+        "label": "Mar 1",
+        "type": "checkpoint-minor",
+        "description": "Wireframes approved"
+      },
+      {
+        "trackId": "m3",
+        "date": "2026-04-10",
+        "label": "Apr 10 PoC",
+        "type": "poc",
+        "description": "Dashboard PoC demo"
+      },
+      {
+        "trackId": "m3",
+        "date": "2026-05-20",
+        "label": "May 20",
+        "type": "checkpoint",
+        "description": "UI feature-complete"
+      },
+      {
+        "trackId": "m3",
+        "date": "2026-06-25",
+        "label": "Jun 25 GA",
+        "type": "production",
+        "description": "Dashboard production release"
+      }
+    ]
+  },
+  "heatmap": {
+    "columns": ["January", "February", "March", "April"],
+    "highlightColumnIndex": 3,
+    "rows": [
+      {
+        "category": "Shipped",
+        "colorTheme": "shipped",
+        "cells": [
+          { "items": ["Project kickoff", "Dev environment setup"] },
+          { "items": ["Auth PoC delivered", "API spec finalized"] },
+          { "items": ["ETL pipeline PoC", "CI/CD pipeline live"] },
+          { "items": ["Dashboard PoC demo", "Monitoring alerts configured"] }
+        ]
+      },
+      {
+        "category": "In Progress",
+        "colorTheme": "progress",
+        "cells": [
+          { "items": ["API spec drafting"] },
+          { "items": ["Core API scaffolding", "Pipeline design"] },
+          { "items": ["API v1 development", "Dashboard wireframes"] },
+          { "items": ["Pipeline integration tests", "UI component build-out"] }
+        ]
+      },
+      {
+        "category": "Carryover",
+        "colorTheme": "carryover",
+        "cells": [
+          { "items": [] },
+          { "items": [] },
+          { "items": ["SSO integration (from Feb)"] },
+          { "items": ["Load testing setup (from Mar)"] }
+        ]
+      },
+      {
+        "category": "Blockers",
+        "colorTheme": "blockers",
+        "cells": [
+          { "items": [] },
+          { "items": [] },
+          { "items": ["Vendor API access pending"] },
+          { "items": ["Vendor API access pending", "Capacity approval for staging"] }
+        ]
+      }
+    ]
+  }
 }

--- a/ReportingDashboard.Web/data.json
+++ b/ReportingDashboard.Web/data.json
@@ -1,0 +1,26 @@
+{
+  "project": {
+    "name": "Sample Project",
+    "lead": "Project Lead",
+    "status": "On Track",
+    "lastUpdated": "2026-01-01",
+    "summary": "Sample project dashboard for preview."
+  },
+  "title": "Executive Reporting Dashboard",
+  "subtitle": "Project Status Overview",
+  "backlogLink": "",
+  "currentMonth": "January",
+  "months": ["January", "February", "March"],
+  "milestones": [
+    { "title": "Phase 1", "targetDate": "2026-02-01", "status": "Completed" },
+    { "title": "Phase 2", "targetDate": "2026-04-01", "status": "In Progress" }
+  ],
+  "shipped": [
+    { "title": "Foundation", "description": "Project scaffolding", "category": "Infrastructure", "percentComplete": 100 }
+  ],
+  "inProgress": [
+    { "title": "Dashboard UI", "description": "Building components", "category": "Frontend", "percentComplete": 60 }
+  ],
+  "timeline": { "startMonth": "Jan 2026", "endMonth": "Jun 2026", "tracks": [] },
+  "heatmap": { "months": ["Jan", "Feb", "Mar"], "categories": [], "items": [] }
+}

--- a/ReportingDashboard.Web/wwwroot/css/app.css
+++ b/ReportingDashboard.Web/wwwroot/css/app.css
@@ -1,0 +1,38 @@
+*, *::before, *::after {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+:root {
+    --font-primary: 'Segoe UI', Arial, sans-serif;
+    --color-text: #111;
+    --color-link: #0078D4;
+    --color-border: #E0E0E0;
+    --color-border-heavy: #CCC;
+    --color-subtitle: #888;
+    --color-now: #EA4335;
+    --color-poc: #F4B400;
+    --color-production: #34A853;
+    --color-checkpoint: #999;
+}
+
+html, body {
+    width: 1920px;
+    height: 1080px;
+    overflow: hidden;
+    background: #FFFFFF;
+    font-family: var(--font-primary);
+    color: var(--color-text);
+    display: flex;
+    flex-direction: column;
+}
+
+a {
+    color: var(--color-link);
+    text-decoration: none;
+}
+
+#blazor-error-ui {
+    display: none !important;
+}

--- a/ReportingDashboard.Web/wwwroot/data.json
+++ b/ReportingDashboard.Web/wwwroot/data.json
@@ -1,0 +1,26 @@
+{
+  "project": {
+    "name": "Sample Project",
+    "lead": "Project Lead",
+    "status": "On Track",
+    "lastUpdated": "2026-01-01",
+    "summary": "Sample project dashboard for preview."
+  },
+  "title": "Executive Reporting Dashboard",
+  "subtitle": "Project Status Overview",
+  "backlogLink": "",
+  "currentMonth": "January",
+  "months": ["January", "February", "March"],
+  "milestones": [
+    { "title": "Phase 1", "targetDate": "2026-02-01", "status": "Completed" },
+    { "title": "Phase 2", "targetDate": "2026-04-01", "status": "In Progress" }
+  ],
+  "shipped": [
+    { "title": "Foundation", "description": "Project scaffolding", "category": "Infrastructure", "percentComplete": 100 }
+  ],
+  "inProgress": [
+    { "title": "Dashboard UI", "description": "Building components", "category": "Frontend", "percentComplete": 60 }
+  ],
+  "timeline": { "startMonth": "Jan 2026", "endMonth": "Jun 2026", "tracks": [] },
+  "heatmap": { "months": ["Jan", "Feb", "Mar"], "categories": [], "items": [] }
+}

--- a/ReportingDashboard.Web/wwwroot/data/data.json
+++ b/ReportingDashboard.Web/wwwroot/data/data.json
@@ -1,0 +1,26 @@
+{
+  "project": {
+    "name": "Sample Project",
+    "lead": "Project Lead",
+    "status": "On Track",
+    "lastUpdated": "2026-01-01",
+    "summary": "Sample project dashboard for preview."
+  },
+  "title": "Executive Reporting Dashboard",
+  "subtitle": "Project Status Overview",
+  "backlogLink": "",
+  "currentMonth": "January",
+  "months": ["January", "February", "March"],
+  "milestones": [
+    { "title": "Phase 1", "targetDate": "2026-02-01", "status": "Completed" },
+    { "title": "Phase 2", "targetDate": "2026-04-01", "status": "In Progress" }
+  ],
+  "shipped": [
+    { "title": "Foundation", "description": "Project scaffolding", "category": "Infrastructure", "percentComplete": 100 }
+  ],
+  "inProgress": [
+    { "title": "Dashboard UI", "description": "Building components", "category": "Frontend", "percentComplete": 60 }
+  ],
+  "timeline": { "startMonth": "Jan 2026", "endMonth": "Jun 2026", "tracks": [] },
+  "heatmap": { "months": ["Jan", "Feb", "Mar"], "categories": [], "items": [] }
+}

--- a/ReportingDashboard.sln
+++ b/ReportingDashboard.sln
@@ -1,0 +1,24 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ReportingDashboard.Web", "ReportingDashboard.Web\ReportingDashboard.Web.csproj", "{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ReportingDashboard.Models", "ReportingDashboard.Models\ReportingDashboard.Models.csproj", "{B2C3D4E5-F6A7-8901-BCDE-F12345678901}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B2C3D4E5-F6A7-8901-BCDE-F12345678901}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B2C3D4E5-F6A7-8901-BCDE-F12345678901}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B2C3D4E5-F6A7-8901-BCDE-F12345678901}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B2C3D4E5-F6A7-8901-BCDE-F12345678901}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/ReportingDashboard.sln
+++ b/ReportingDashboard.sln
@@ -1,3 +1,4 @@
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31903.59
@@ -6,19 +7,76 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ReportingDashboard.Web", "R
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ReportingDashboard.Models", "ReportingDashboard.Models\ReportingDashboard.Models.csproj", "{B2C3D4E5-F6A7-8901-BCDE-F12345678901}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{0AB3BF05-4346-4AA6-1389-037BE0695223}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ReportingDashboard.Tests", "tests\ReportingDashboard.Tests\ReportingDashboard.Tests.csproj", "{F5CE7A4C-9D99-4AB5-94BE-13A4302C4BF4}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ReportingDashboard.UITests", "tests\ReportingDashboard.UITests\ReportingDashboard.UITests.csproj", "{D1A63C2F-25ED-4611-B25C-67DF7D790E02}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Debug|x64.Build.0 = Debug|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Debug|x86.Build.0 = Debug|Any CPU
 		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|x64.ActiveCfg = Release|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|x64.Build.0 = Release|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|x86.ActiveCfg = Release|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|x86.Build.0 = Release|Any CPU
 		{B2C3D4E5-F6A7-8901-BCDE-F12345678901}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{B2C3D4E5-F6A7-8901-BCDE-F12345678901}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B2C3D4E5-F6A7-8901-BCDE-F12345678901}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B2C3D4E5-F6A7-8901-BCDE-F12345678901}.Debug|x64.Build.0 = Debug|Any CPU
+		{B2C3D4E5-F6A7-8901-BCDE-F12345678901}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B2C3D4E5-F6A7-8901-BCDE-F12345678901}.Debug|x86.Build.0 = Debug|Any CPU
 		{B2C3D4E5-F6A7-8901-BCDE-F12345678901}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B2C3D4E5-F6A7-8901-BCDE-F12345678901}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B2C3D4E5-F6A7-8901-BCDE-F12345678901}.Release|x64.ActiveCfg = Release|Any CPU
+		{B2C3D4E5-F6A7-8901-BCDE-F12345678901}.Release|x64.Build.0 = Release|Any CPU
+		{B2C3D4E5-F6A7-8901-BCDE-F12345678901}.Release|x86.ActiveCfg = Release|Any CPU
+		{B2C3D4E5-F6A7-8901-BCDE-F12345678901}.Release|x86.Build.0 = Release|Any CPU
+		{F5CE7A4C-9D99-4AB5-94BE-13A4302C4BF4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F5CE7A4C-9D99-4AB5-94BE-13A4302C4BF4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F5CE7A4C-9D99-4AB5-94BE-13A4302C4BF4}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F5CE7A4C-9D99-4AB5-94BE-13A4302C4BF4}.Debug|x64.Build.0 = Debug|Any CPU
+		{F5CE7A4C-9D99-4AB5-94BE-13A4302C4BF4}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F5CE7A4C-9D99-4AB5-94BE-13A4302C4BF4}.Debug|x86.Build.0 = Debug|Any CPU
+		{F5CE7A4C-9D99-4AB5-94BE-13A4302C4BF4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F5CE7A4C-9D99-4AB5-94BE-13A4302C4BF4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F5CE7A4C-9D99-4AB5-94BE-13A4302C4BF4}.Release|x64.ActiveCfg = Release|Any CPU
+		{F5CE7A4C-9D99-4AB5-94BE-13A4302C4BF4}.Release|x64.Build.0 = Release|Any CPU
+		{F5CE7A4C-9D99-4AB5-94BE-13A4302C4BF4}.Release|x86.ActiveCfg = Release|Any CPU
+		{F5CE7A4C-9D99-4AB5-94BE-13A4302C4BF4}.Release|x86.Build.0 = Release|Any CPU
+		{D1A63C2F-25ED-4611-B25C-67DF7D790E02}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D1A63C2F-25ED-4611-B25C-67DF7D790E02}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D1A63C2F-25ED-4611-B25C-67DF7D790E02}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D1A63C2F-25ED-4611-B25C-67DF7D790E02}.Debug|x64.Build.0 = Debug|Any CPU
+		{D1A63C2F-25ED-4611-B25C-67DF7D790E02}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D1A63C2F-25ED-4611-B25C-67DF7D790E02}.Debug|x86.Build.0 = Debug|Any CPU
+		{D1A63C2F-25ED-4611-B25C-67DF7D790E02}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D1A63C2F-25ED-4611-B25C-67DF7D790E02}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D1A63C2F-25ED-4611-B25C-67DF7D790E02}.Release|x64.ActiveCfg = Release|Any CPU
+		{D1A63C2F-25ED-4611-B25C-67DF7D790E02}.Release|x64.Build.0 = Release|Any CPU
+		{D1A63C2F-25ED-4611-B25C-67DF7D790E02}.Release|x86.ActiveCfg = Release|Any CPU
+		{D1A63C2F-25ED-4611-B25C-67DF7D790E02}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{F5CE7A4C-9D99-4AB5-94BE-13A4302C4BF4} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
+		{D1A63C2F-25ED-4611-B25C-67DF7D790E02} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 	EndGlobalSection
 EndGlobal

--- a/tests/ReportingDashboard.Tests/ReportingDashboard.Tests.csproj
+++ b/tests/ReportingDashboard.Tests/ReportingDashboard.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="bunit" Version="1.28.9" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="xunit" Version="2.7.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\ReportingDashboard.Web\ReportingDashboard.Web.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/ReportingDashboard.Tests/Unit/DashboardComponentTests.cs
+++ b/tests/ReportingDashboard.Tests/Unit/DashboardComponentTests.cs
@@ -12,11 +12,24 @@ namespace ReportingDashboard.Tests.Unit;
 public class DashboardComponentTests : TestContext
 {
     private static DashboardData CreateTestData() => new(
-        Header: new ProjectHeader("Test Dashboard", "Org • Stream • April 2026", "https://example.com", "April 2026"),
+        Header: new ProjectHeader(
+            "Project Phoenix",
+            "Trusted Platform \u2022 Privacy Automation \u2022 April 2026",
+            "https://dev.azure.com/org/project/_backlogs",
+            "April 2026"),
         Timeline: new TimelineConfig(
             new DateTime(2026, 1, 1), new DateTime(2026, 12, 31), new DateTime(2026, 4, 15),
-            new List<Track> { new("m1", "M1", "Core API", "#0078D4") },
-            new List<Milestone> { new("m1", new DateTime(2026, 3, 26), "PoC", "poc", null) }
+            new List<Track>
+            {
+                new("m1", "M1", "Core API & Auth", "#0078D4"),
+                new("m2", "M2", "PDS & Data Inventory", "#00897B"),
+                new("m3", "M3", "Auto Review DFD", "#546E7A")
+            },
+            new List<Milestone>
+            {
+                new("m1", new DateTime(2026, 3, 26), "PoC", "poc", null),
+                new("m2", new DateTime(2026, 5, 15), "Production Release", "production", "Full rollout")
+            }
         ),
         Heatmap: new HeatmapData(
             new List<string> { "Jan", "Feb", "Mar", "Apr" }, 3,
@@ -24,10 +37,17 @@ public class DashboardComponentTests : TestContext
             {
                 new("Shipped", "green", new List<MonthCell>
                 {
-                    new(new List<string> { "Item A" }),
-                    new(new List<string>()),
+                    new(new List<string> { "Foundation scaffolding" }),
+                    new(new List<string> { "Auth module" }),
                     new(new List<string>()),
                     new(new List<string>())
+                }),
+                new("In Progress", "blue", new List<MonthCell>
+                {
+                    new(new List<string>()),
+                    new(new List<string> { "Dashboard UI" }),
+                    new(new List<string>()),
+                    new(new List<string> { "Heatmap grid" })
                 })
             }
         )
@@ -38,7 +58,7 @@ public class DashboardComponentTests : TestContext
     {
         var mockService = new Mock<IDataService>();
         mockService.Setup(s => s.GetData()).Returns((DashboardData?)null);
-        mockService.Setup(s => s.GetError()).Returns("data.json not found at /test/data.json.");
+        mockService.Setup(s => s.GetError()).Returns("data.json not found at /test/data.json. Create this file with your dashboard data.");
 
         Services.AddSingleton(mockService.Object);
 
@@ -61,8 +81,8 @@ public class DashboardComponentTests : TestContext
 
         var cut = RenderComponent<ReportingDashboard.Web.Pages.Dashboard>();
 
-        cut.Find("h1").TextContent.Should().Be("Test Dashboard");
-        cut.Markup.Should().Contain("Org • Stream • April 2026");
+        cut.Find("h1").TextContent.Should().Be("Project Phoenix");
+        cut.Markup.Should().Contain("Trusted Platform");
         cut.Markup.Should().Contain("data.json loaded successfully");
     }
 

--- a/tests/ReportingDashboard.Tests/Unit/DashboardComponentTests.cs
+++ b/tests/ReportingDashboard.Tests/Unit/DashboardComponentTests.cs
@@ -1,0 +1,123 @@
+using Bunit;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using ReportingDashboard.Models;
+using ReportingDashboard.Web.Services;
+using Xunit;
+
+namespace ReportingDashboard.Tests.Unit;
+
+[Trait("Category", "Unit")]
+public class DashboardComponentTests : TestContext
+{
+    private static DashboardData CreateTestData() => new(
+        Header: new ProjectHeader("Test Dashboard", "Org • Stream • April 2026", "https://example.com", "April 2026"),
+        Timeline: new TimelineConfig(
+            new DateTime(2026, 1, 1), new DateTime(2026, 12, 31), new DateTime(2026, 4, 15),
+            new List<Track> { new("m1", "M1", "Core API", "#0078D4") },
+            new List<Milestone> { new("m1", new DateTime(2026, 3, 26), "PoC", "poc", null) }
+        ),
+        Heatmap: new HeatmapData(
+            new List<string> { "Jan", "Feb", "Mar", "Apr" }, 3,
+            new List<StatusRow>
+            {
+                new("Shipped", "green", new List<MonthCell>
+                {
+                    new(new List<string> { "Item A" }),
+                    new(new List<string>()),
+                    new(new List<string>()),
+                    new(new List<string>())
+                })
+            }
+        )
+    );
+
+    [Fact]
+    public void WhenDataIsNull_RendersErrorPanel()
+    {
+        var mockService = new Mock<IDataService>();
+        mockService.Setup(s => s.GetData()).Returns((DashboardData?)null);
+        mockService.Setup(s => s.GetError()).Returns("data.json not found at /test/data.json.");
+
+        Services.AddSingleton(mockService.Object);
+
+        var cut = RenderComponent<ReportingDashboard.Web.Pages.Dashboard>();
+
+        cut.Find("h1").TextContent.Should().Be("Dashboard Configuration Error");
+        cut.Markup.Should().Contain("data.json not found");
+        cut.Markup.Should().Contain("Edit data.json and refresh this page.");
+    }
+
+    [Fact]
+    public void WhenDataIsValid_RendersPlaceholderWithTitle()
+    {
+        var data = CreateTestData();
+        var mockService = new Mock<IDataService>();
+        mockService.Setup(s => s.GetData()).Returns(data);
+        mockService.Setup(s => s.GetError()).Returns((string?)null);
+
+        Services.AddSingleton(mockService.Object);
+
+        var cut = RenderComponent<ReportingDashboard.Web.Pages.Dashboard>();
+
+        cut.Find("h1").TextContent.Should().Be("Test Dashboard");
+        cut.Markup.Should().Contain("Org • Stream • April 2026");
+        cut.Markup.Should().Contain("data.json loaded successfully");
+    }
+
+    [Fact]
+    public void ErrorPanel_HasRedHeading()
+    {
+        var mockService = new Mock<IDataService>();
+        mockService.Setup(s => s.GetData()).Returns((DashboardData?)null);
+        mockService.Setup(s => s.GetError()).Returns("Some error");
+
+        Services.AddSingleton(mockService.Object);
+
+        var cut = RenderComponent<ReportingDashboard.Web.Pages.Dashboard>();
+
+        var h1 = cut.Find("h1");
+        h1.GetAttribute("style").Should().Contain("color: #EA4335");
+    }
+
+    [Fact]
+    public void WhenDataIsValid_HasDashboardPlaceholderClass()
+    {
+        var data = CreateTestData();
+        var mockService = new Mock<IDataService>();
+        mockService.Setup(s => s.GetData()).Returns(data);
+        mockService.Setup(s => s.GetError()).Returns((string?)null);
+
+        Services.AddSingleton(mockService.Object);
+
+        var cut = RenderComponent<ReportingDashboard.Web.Pages.Dashboard>();
+
+        cut.Find(".dashboard-placeholder").Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Dispose_UnsubscribesFromOnDataChanged()
+    {
+        int subscribeCount = 0;
+        int unsubscribeCount = 0;
+
+        var mockService = new Mock<IDataService>();
+        mockService.Setup(s => s.GetData()).Returns((DashboardData?)null);
+        mockService.Setup(s => s.GetError()).Returns("error");
+        mockService.SetupAdd(s => s.OnDataChanged += It.IsAny<Action>())
+            .Callback<Action>(_ => subscribeCount++);
+        mockService.SetupRemove(s => s.OnDataChanged -= It.IsAny<Action>())
+            .Callback<Action>(_ => unsubscribeCount++);
+
+        Services.AddSingleton(mockService.Object);
+
+        var cut = RenderComponent<ReportingDashboard.Web.Pages.Dashboard>();
+
+        subscribeCount.Should().Be(1, "component should subscribe to OnDataChanged in OnInitialized");
+
+        DisposeComponents();
+
+        unsubscribeCount.Should().Be(1, "component should unsubscribe from OnDataChanged on Dispose");
+    }
+}

--- a/tests/ReportingDashboard.Tests/Unit/DataServiceTests.cs
+++ b/tests/ReportingDashboard.Tests/Unit/DataServiceTests.cs
@@ -26,9 +26,9 @@ public class DataServiceTests : IDisposable
     {
         header = new
         {
-            title = "Test Project",
-            subtitle = "Test Org • Test Workstream • April 2026",
-            backlogUrl = "https://example.com",
+            title = "Project Phoenix",
+            subtitle = "Trusted Platform \u2022 Privacy Automation Workstream \u2022 April 2026",
+            backlogUrl = "https://dev.azure.com/org/project/_backlogs",
             currentMonth = "April 2026"
         },
         timeline = new
@@ -38,11 +38,14 @@ public class DataServiceTests : IDisposable
             nowDate = "2026-04-15",
             tracks = new[]
             {
-                new { id = "m1", label = "M1", description = "Core API", color = "#0078D4" }
+                new { id = "m1", label = "M1", description = "Core API & Auth", color = "#0078D4" },
+                new { id = "m2", label = "M2", description = "PDS & Data Inventory", color = "#00897B" },
+                new { id = "m3", label = "M3", description = "Auto Review DFD", color = "#546E7A" }
             },
             milestones = new[]
             {
-                new { trackId = "m1", date = "2026-03-26", label = "PoC", type = "poc", description = (string?)null }
+                new { trackId = "m1", date = "2026-03-26", label = "PoC", type = "poc", description = (string?)null },
+                new { trackId = "m2", date = "2026-05-15", label = "Production Release", type = "production", description = "Full rollout" }
             }
         },
         heatmap = new
@@ -57,15 +60,43 @@ public class DataServiceTests : IDisposable
                     colorTheme = "green",
                     cells = new[]
                     {
-                        new { items = new[] { "Item A" } },
-                        new { items = new[] { "Item B" } },
-                        new { items = Array.Empty<string>() },
+                        new { items = new[] { "Foundation scaffolding" } },
+                        new { items = new[] { "Auth module" } },
+                        new { items = new[] { "API endpoints" } },
                         new { items = Array.Empty<string>() }
+                    }
+                },
+                new
+                {
+                    category = "In Progress",
+                    colorTheme = "blue",
+                    cells = new[]
+                    {
+                        new { items = Array.Empty<string>() },
+                        new { items = new[] { "Dashboard UI" } },
+                        new { items = new[] { "Timeline component" } },
+                        new { items = new[] { "Heatmap grid" } }
                     }
                 }
             }
         }
     });
+
+    /// <summary>
+    /// Builds JSON using the WRONG flat schema (matching the buggy shipped data.json)
+    /// to verify it does NOT deserialize into a valid DashboardData.
+    /// </summary>
+    private static string BuildIncorrectSchemaJson() => @"{
+        ""title"": ""Executive Reporting Dashboard"",
+        ""subtitle"": ""Project Status Overview"",
+        ""backlogLink"": """",
+        ""currentMonth"": ""January"",
+        ""months"": [""January"", ""February""],
+        ""milestones"": [{ ""title"": ""Phase 1"", ""targetDate"": ""2026-02-01"", ""status"": ""Completed"" }],
+        ""shipped"": [{ ""title"": ""Foundation"", ""description"": ""Scaffolding"" }],
+        ""timeline"": { ""startMonth"": ""Jan 2026"", ""endMonth"": ""Jun 2026"", ""tracks"": [] },
+        ""heatmap"": { ""months"": [""Jan""], ""categories"": [], ""items"": [] }
+    }";
 
     [Fact]
     public void ValidJson_LoadsDataSuccessfully()
@@ -75,14 +106,76 @@ public class DataServiceTests : IDisposable
         using var service = new DataService(_tempDir);
 
         service.GetData().Should().NotBeNull();
-        service.GetData()!.Header.Title.Should().Be("Test Project");
+        service.GetData()!.Header.Title.Should().Be("Project Phoenix");
         service.GetError().Should().BeNull();
+    }
+
+    [Fact]
+    public void ValidJson_DeserializesAllSubObjects()
+    {
+        File.WriteAllText(Path.Combine(_tempDir, "data.json"), BuildValidJson());
+
+        using var service = new DataService(_tempDir);
+        var data = service.GetData();
+
+        data.Should().NotBeNull();
+
+        // Header uses backlogUrl (not backlogLink)
+        data!.Header.Should().NotBeNull();
+        data.Header.Title.Should().Be("Project Phoenix");
+        data.Header.BacklogUrl.Should().Be("https://dev.azure.com/org/project/_backlogs");
+        data.Header.CurrentMonth.Should().Be("April 2026");
+
+        // Timeline has proper structure with tracks and milestones
+        data.Timeline.Should().NotBeNull();
+        data.Timeline.Tracks.Should().HaveCount(3);
+        data.Timeline.Tracks[0].Id.Should().Be("m1");
+        data.Timeline.Milestones.Should().HaveCount(2);
+        data.Timeline.Milestones[0].TrackId.Should().Be("m1");
+        data.Timeline.Milestones[0].Label.Should().Be("PoC");
+        data.Timeline.Milestones[0].Type.Should().Be("poc");
+        data.Timeline.StartDate.Should().Be(new DateTime(2026, 1, 1));
+        data.Timeline.NowDate.Should().Be(new DateTime(2026, 4, 15));
+
+        // Heatmap uses columns/highlightColumnIndex/rows (not months/categories/items)
+        data.Heatmap.Should().NotBeNull();
+        data.Heatmap.Columns.Should().BeEquivalentTo(new[] { "Jan", "Feb", "Mar", "Apr" });
+        data.Heatmap.HighlightColumnIndex.Should().Be(3);
+        data.Heatmap.Rows.Should().HaveCount(2);
+        data.Heatmap.Rows[0].Category.Should().Be("Shipped");
+        data.Heatmap.Rows[0].Cells.Should().HaveCount(4);
+        data.Heatmap.Rows[0].Cells[0].Items.Should().Contain("Foundation scaffolding");
+    }
+
+    [Fact]
+    public void IncorrectSchema_ProducesNullSubObjects()
+    {
+        // This test documents the bug: if data.json uses the wrong flat schema,
+        // deserialization succeeds but produces null/default sub-objects
+        File.WriteAllText(Path.Combine(_tempDir, "data.json"), BuildIncorrectSchemaJson());
+
+        using var service = new DataService(_tempDir);
+        var data = service.GetData();
+
+        // The incorrect schema will either fail to deserialize (returning null with error)
+        // or produce an object with null Header (since "header" key is missing)
+        if (data is not null)
+        {
+            // If it somehow deserializes, Header should be null because
+            // the flat schema has no "header" object
+            data.Header.Should().BeNull(
+                "a flat schema with 'title'/'backlogLink' at root level does not map to the nested 'header.title'/'header.backlogUrl' structure");
+        }
+        else
+        {
+            service.GetError().Should().NotBeNullOrEmpty(
+                "deserialization of incompatible schema should produce an error");
+        }
     }
 
     [Fact]
     public void MissingFile_ReturnsNullDataWithError()
     {
-        // No data.json created in _tempDir
         using var service = new DataService(_tempDir);
 
         service.GetData().Should().BeNull();
@@ -127,5 +220,20 @@ public class DataServiceTests : IDisposable
 
         var fired = eventFired.Wait(TimeSpan.FromSeconds(3));
         fired.Should().BeTrue("OnDataChanged should fire after file modification");
+    }
+
+    [Fact]
+    public void DataJsonInWrongLocation_IsNotLoaded()
+    {
+        // data.json must only be in the content root, not in subdirectories
+        var subDir = Path.Combine(_tempDir, "wwwroot");
+        Directory.CreateDirectory(subDir);
+        File.WriteAllText(Path.Combine(subDir, "data.json"), BuildValidJson());
+        // No data.json at _tempDir root
+
+        using var service = new DataService(_tempDir);
+
+        service.GetData().Should().BeNull("DataService should only read data.json from content root path");
+        service.GetError().Should().Contain("data.json not found");
     }
 }

--- a/tests/ReportingDashboard.Tests/Unit/DataServiceTests.cs
+++ b/tests/ReportingDashboard.Tests/Unit/DataServiceTests.cs
@@ -1,0 +1,131 @@
+using System.Text.Json;
+using FluentAssertions;
+using ReportingDashboard.Models;
+using ReportingDashboard.Web.Services;
+using Xunit;
+
+namespace ReportingDashboard.Tests.Unit;
+
+[Trait("Category", "Unit")]
+public class DataServiceTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public DataServiceTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"DataServiceTests_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempDir, true); } catch { }
+    }
+
+    private static string BuildValidJson() => JsonSerializer.Serialize(new
+    {
+        header = new
+        {
+            title = "Test Project",
+            subtitle = "Test Org • Test Workstream • April 2026",
+            backlogUrl = "https://example.com",
+            currentMonth = "April 2026"
+        },
+        timeline = new
+        {
+            startDate = "2026-01-01",
+            endDate = "2026-12-31",
+            nowDate = "2026-04-15",
+            tracks = new[]
+            {
+                new { id = "m1", label = "M1", description = "Core API", color = "#0078D4" }
+            },
+            milestones = new[]
+            {
+                new { trackId = "m1", date = "2026-03-26", label = "PoC", type = "poc", description = (string?)null }
+            }
+        },
+        heatmap = new
+        {
+            columns = new[] { "Jan", "Feb", "Mar", "Apr" },
+            highlightColumnIndex = 3,
+            rows = new[]
+            {
+                new
+                {
+                    category = "Shipped",
+                    colorTheme = "green",
+                    cells = new[]
+                    {
+                        new { items = new[] { "Item A" } },
+                        new { items = new[] { "Item B" } },
+                        new { items = Array.Empty<string>() },
+                        new { items = Array.Empty<string>() }
+                    }
+                }
+            }
+        }
+    });
+
+    [Fact]
+    public void ValidJson_LoadsDataSuccessfully()
+    {
+        File.WriteAllText(Path.Combine(_tempDir, "data.json"), BuildValidJson());
+
+        using var service = new DataService(_tempDir);
+
+        service.GetData().Should().NotBeNull();
+        service.GetData()!.Header.Title.Should().Be("Test Project");
+        service.GetError().Should().BeNull();
+    }
+
+    [Fact]
+    public void MissingFile_ReturnsNullDataWithError()
+    {
+        // No data.json created in _tempDir
+        using var service = new DataService(_tempDir);
+
+        service.GetData().Should().BeNull();
+        service.GetError().Should().Contain("data.json not found");
+        service.GetError().Should().Contain(_tempDir);
+    }
+
+    [Fact]
+    public void MalformedJson_ReturnsNullDataWithParseError()
+    {
+        File.WriteAllText(Path.Combine(_tempDir, "data.json"), "{ invalid json !!! }");
+
+        using var service = new DataService(_tempDir);
+
+        service.GetData().Should().BeNull();
+        service.GetError().Should().Contain("Failed to parse data.json");
+    }
+
+    [Fact]
+    public void Dispose_DoesNotThrow()
+    {
+        File.WriteAllText(Path.Combine(_tempDir, "data.json"), BuildValidJson());
+
+        var service = new DataService(_tempDir);
+        var act = () => service.Dispose();
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void OnDataChanged_FiresAfterFileChange()
+    {
+        File.WriteAllText(Path.Combine(_tempDir, "data.json"), BuildValidJson());
+        using var service = new DataService(_tempDir);
+
+        var eventFired = new ManualResetEventSlim(false);
+        service.OnDataChanged += () => eventFired.Set();
+
+        // Modify the file to trigger watcher
+        Thread.Sleep(50);
+        File.WriteAllText(Path.Combine(_tempDir, "data.json"), BuildValidJson());
+
+        var fired = eventFired.Wait(TimeSpan.FromSeconds(3));
+        fired.Should().BeTrue("OnDataChanged should fire after file modification");
+    }
+}

--- a/tests/ReportingDashboard.UITests/DashboardPageTests.cs
+++ b/tests/ReportingDashboard.UITests/DashboardPageTests.cs
@@ -9,7 +9,7 @@ namespace ReportingDashboard.UITests;
 public class DashboardPageTests : IAsyncLifetime
 {
     private readonly PlaywrightFixture _fixture;
-    private IPage _page = null!;
+    private IPage? _page;
 
     public DashboardPageTests(PlaywrightFixture fixture)
     {
@@ -18,42 +18,57 @@ public class DashboardPageTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        _page = await _fixture.Browser.NewPageAsync();
-        _page.SetDefaultTimeout(60000);
+        if (_fixture.IsAvailable)
+        {
+            _page = await _fixture.Browser!.NewPageAsync();
+            _page.SetDefaultTimeout(60000);
+        }
     }
 
     public async Task DisposeAsync()
     {
-        await _page.CloseAsync();
+        if (_page is not null)
+        {
+            await _page.CloseAsync();
+        }
     }
 
-    [Fact]
+    private void SkipIfBrowserUnavailable()
+    {
+        Skip.If(!_fixture.IsAvailable, "Playwright browsers not installed. Run: pwsh bin/Debug/net8.0/playwright.ps1 install");
+    }
+
+    [SkippableFact]
     public async Task HomePage_Loads_WithoutErrors()
     {
-        var response = await _page.GotoAsync(_fixture.BaseUrl);
+        SkipIfBrowserUnavailable();
+
+        var response = await _page!.GotoAsync(_fixture.BaseUrl);
         await _page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
         response!.Status.Should().Be(200);
     }
 
-    [Fact]
+    [SkippableFact]
     public async Task HomePage_ShowsEitherDataOrError()
     {
-        await _page.GotoAsync(_fixture.BaseUrl);
+        SkipIfBrowserUnavailable();
+
+        await _page!.GotoAsync(_fixture.BaseUrl);
         await _page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
-        // The page should render either the error panel or the placeholder
         var h1 = await _page.Locator("h1").First.TextContentAsync();
         h1.Should().NotBeNullOrEmpty("page should display either project title or error heading");
     }
 
-    [Fact]
+    [SkippableFact]
     public async Task ErrorPanel_ShowsConfigurationError_WhenDataMissing()
     {
-        await _page.GotoAsync(_fixture.BaseUrl);
+        SkipIfBrowserUnavailable();
+
+        await _page!.GotoAsync(_fixture.BaseUrl);
         await _page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
-        // If error panel is present, verify its content
         var errorHeading = _page.GetByText("Dashboard Configuration Error");
         if (await errorHeading.CountAsync() > 0)
         {
@@ -64,13 +79,14 @@ public class DashboardPageTests : IAsyncLifetime
         }
     }
 
-    [Fact]
+    [SkippableFact]
     public async Task SuccessState_ShowsProjectTitle_WhenDataValid()
     {
-        await _page.GotoAsync(_fixture.BaseUrl);
+        SkipIfBrowserUnavailable();
+
+        await _page!.GotoAsync(_fixture.BaseUrl);
         await _page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
-        // If data loaded successfully, the placeholder div should exist
         var placeholder = _page.Locator(".dashboard-placeholder");
         if (await placeholder.CountAsync() > 0)
         {
@@ -82,10 +98,12 @@ public class DashboardPageTests : IAsyncLifetime
         }
     }
 
-    [Fact]
+    [SkippableFact]
     public async Task Viewport_IsFixedDimensions()
     {
-        await _page.SetViewportSizeAsync(1920, 1080);
+        SkipIfBrowserUnavailable();
+
+        await _page!.SetViewportSizeAsync(1920, 1080);
         await _page.GotoAsync(_fixture.BaseUrl);
         await _page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 

--- a/tests/ReportingDashboard.UITests/DashboardPageTests.cs
+++ b/tests/ReportingDashboard.UITests/DashboardPageTests.cs
@@ -9,7 +9,7 @@ namespace ReportingDashboard.UITests;
 public class DashboardPageTests : IAsyncLifetime
 {
     private readonly PlaywrightFixture _fixture;
-    private IPage? _page;
+    private IPage _page = null!;
 
     public DashboardPageTests(PlaywrightFixture fixture)
     {
@@ -18,55 +18,38 @@ public class DashboardPageTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        if (_fixture.IsAvailable)
-        {
-            _page = await _fixture.Browser!.NewPageAsync();
-            _page.SetDefaultTimeout(60000);
-        }
+        _page = await _fixture.Browser.NewPageAsync();
+        _page.SetDefaultTimeout(60000);
     }
 
     public async Task DisposeAsync()
     {
-        if (_page is not null)
-        {
-            await _page.CloseAsync();
-        }
+        await _page.CloseAsync();
     }
 
-    private void SkipIfBrowserUnavailable()
-    {
-        Skip.If(!_fixture.IsAvailable, "Playwright browsers not installed. Run: pwsh bin/Debug/net8.0/playwright.ps1 install");
-    }
-
-    [SkippableFact]
+    [Fact]
     public async Task HomePage_Loads_WithoutErrors()
     {
-        SkipIfBrowserUnavailable();
-
-        var response = await _page!.GotoAsync(_fixture.BaseUrl);
+        var response = await _page.GotoAsync(_fixture.BaseUrl);
         await _page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
         response!.Status.Should().Be(200);
     }
 
-    [SkippableFact]
+    [Fact]
     public async Task HomePage_ShowsEitherDataOrError()
     {
-        SkipIfBrowserUnavailable();
-
-        await _page!.GotoAsync(_fixture.BaseUrl);
+        await _page.GotoAsync(_fixture.BaseUrl);
         await _page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
         var h1 = await _page.Locator("h1").First.TextContentAsync();
         h1.Should().NotBeNullOrEmpty("page should display either project title or error heading");
     }
 
-    [SkippableFact]
+    [Fact]
     public async Task ErrorPanel_ShowsConfigurationError_WhenDataMissing()
     {
-        SkipIfBrowserUnavailable();
-
-        await _page!.GotoAsync(_fixture.BaseUrl);
+        await _page.GotoAsync(_fixture.BaseUrl);
         await _page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
         var errorHeading = _page.GetByText("Dashboard Configuration Error");
@@ -79,12 +62,10 @@ public class DashboardPageTests : IAsyncLifetime
         }
     }
 
-    [SkippableFact]
+    [Fact]
     public async Task SuccessState_ShowsProjectTitle_WhenDataValid()
     {
-        SkipIfBrowserUnavailable();
-
-        await _page!.GotoAsync(_fixture.BaseUrl);
+        await _page.GotoAsync(_fixture.BaseUrl);
         await _page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
         var placeholder = _page.Locator(".dashboard-placeholder");
@@ -98,12 +79,10 @@ public class DashboardPageTests : IAsyncLifetime
         }
     }
 
-    [SkippableFact]
+    [Fact]
     public async Task Viewport_IsFixedDimensions()
     {
-        SkipIfBrowserUnavailable();
-
-        await _page!.SetViewportSizeAsync(1920, 1080);
+        await _page.SetViewportSizeAsync(1920, 1080);
         await _page.GotoAsync(_fixture.BaseUrl);
         await _page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 

--- a/tests/ReportingDashboard.UITests/DashboardPageTests.cs
+++ b/tests/ReportingDashboard.UITests/DashboardPageTests.cs
@@ -1,0 +1,95 @@
+using FluentAssertions;
+using Microsoft.Playwright;
+using Xunit;
+
+namespace ReportingDashboard.UITests;
+
+[Collection("Playwright")]
+[Trait("Category", "UI")]
+public class DashboardPageTests : IAsyncLifetime
+{
+    private readonly PlaywrightFixture _fixture;
+    private IPage _page = null!;
+
+    public DashboardPageTests(PlaywrightFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async Task InitializeAsync()
+    {
+        _page = await _fixture.Browser.NewPageAsync();
+        _page.SetDefaultTimeout(60000);
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _page.CloseAsync();
+    }
+
+    [Fact]
+    public async Task HomePage_Loads_WithoutErrors()
+    {
+        var response = await _page.GotoAsync(_fixture.BaseUrl);
+        await _page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        response!.Status.Should().Be(200);
+    }
+
+    [Fact]
+    public async Task HomePage_ShowsEitherDataOrError()
+    {
+        await _page.GotoAsync(_fixture.BaseUrl);
+        await _page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        // The page should render either the error panel or the placeholder
+        var h1 = await _page.Locator("h1").First.TextContentAsync();
+        h1.Should().NotBeNullOrEmpty("page should display either project title or error heading");
+    }
+
+    [Fact]
+    public async Task ErrorPanel_ShowsConfigurationError_WhenDataMissing()
+    {
+        await _page.GotoAsync(_fixture.BaseUrl);
+        await _page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        // If error panel is present, verify its content
+        var errorHeading = _page.GetByText("Dashboard Configuration Error");
+        if (await errorHeading.CountAsync() > 0)
+        {
+            (await errorHeading.IsVisibleAsync()).Should().BeTrue();
+
+            var editHint = _page.GetByText("Edit data.json and refresh this page.");
+            (await editHint.IsVisibleAsync()).Should().BeTrue();
+        }
+    }
+
+    [Fact]
+    public async Task SuccessState_ShowsProjectTitle_WhenDataValid()
+    {
+        await _page.GotoAsync(_fixture.BaseUrl);
+        await _page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        // If data loaded successfully, the placeholder div should exist
+        var placeholder = _page.Locator(".dashboard-placeholder");
+        if (await placeholder.CountAsync() > 0)
+        {
+            var title = await placeholder.Locator("h1").TextContentAsync();
+            title.Should().NotBeNullOrEmpty("project title should be rendered from data.json");
+
+            var successText = _page.GetByText("data.json loaded successfully");
+            (await successText.IsVisibleAsync()).Should().BeTrue();
+        }
+    }
+
+    [Fact]
+    public async Task Viewport_IsFixedDimensions()
+    {
+        await _page.SetViewportSizeAsync(1920, 1080);
+        await _page.GotoAsync(_fixture.BaseUrl);
+        await _page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        var bodyWidth = await _page.EvaluateAsync<int>("() => document.body.offsetWidth");
+        bodyWidth.Should().Be(1920, "body should be fixed at 1920px width per app.css");
+    }
+}

--- a/tests/ReportingDashboard.UITests/PlaywrightFixture.cs
+++ b/tests/ReportingDashboard.UITests/PlaywrightFixture.cs
@@ -1,0 +1,30 @@
+using Microsoft.Playwright;
+using Xunit;
+
+namespace ReportingDashboard.UITests;
+
+public class PlaywrightFixture : IAsyncLifetime
+{
+    public IPlaywright Playwright { get; private set; } = null!;
+    public IBrowser Browser { get; private set; } = null!;
+    public string BaseUrl { get; private set; } = null!;
+
+    public async Task InitializeAsync()
+    {
+        BaseUrl = Environment.GetEnvironmentVariable("BASE_URL") ?? "http://localhost:5000";
+        Playwright = await Microsoft.Playwright.Playwright.CreateAsync();
+        Browser = await Playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions
+        {
+            Headless = true
+        });
+    }
+
+    public async Task DisposeAsync()
+    {
+        await Browser.DisposeAsync();
+        Playwright.Dispose();
+    }
+}
+
+[CollectionDefinition("Playwright")]
+public class PlaywrightCollection : ICollectionFixture<PlaywrightFixture> { }

--- a/tests/ReportingDashboard.UITests/PlaywrightFixture.cs
+++ b/tests/ReportingDashboard.UITests/PlaywrightFixture.cs
@@ -5,24 +5,35 @@ namespace ReportingDashboard.UITests;
 
 public class PlaywrightFixture : IAsyncLifetime
 {
-    public IPlaywright Playwright { get; private set; } = null!;
-    public IBrowser Browser { get; private set; } = null!;
+    public IPlaywright? Playwright { get; private set; }
+    public IBrowser? Browser { get; private set; }
     public string BaseUrl { get; private set; } = null!;
+    public bool IsAvailable => Browser is not null;
 
     public async Task InitializeAsync()
     {
         BaseUrl = Environment.GetEnvironmentVariable("BASE_URL") ?? "http://localhost:5000";
-        Playwright = await Microsoft.Playwright.Playwright.CreateAsync();
-        Browser = await Playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions
+        try
         {
-            Headless = true
-        });
+            Playwright = await Microsoft.Playwright.Playwright.CreateAsync();
+            Browser = await Playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions
+            {
+                Headless = true
+            });
+        }
+        catch
+        {
+            // Playwright browsers not installed — tests will be skipped
+        }
     }
 
     public async Task DisposeAsync()
     {
-        await Browser.DisposeAsync();
-        Playwright.Dispose();
+        if (Browser is not null)
+        {
+            await Browser.DisposeAsync();
+        }
+        Playwright?.Dispose();
     }
 }
 

--- a/tests/ReportingDashboard.UITests/PlaywrightFixture.cs
+++ b/tests/ReportingDashboard.UITests/PlaywrightFixture.cs
@@ -5,35 +5,24 @@ namespace ReportingDashboard.UITests;
 
 public class PlaywrightFixture : IAsyncLifetime
 {
-    public IPlaywright? Playwright { get; private set; }
-    public IBrowser? Browser { get; private set; }
+    public IPlaywright Playwright { get; private set; } = null!;
+    public IBrowser Browser { get; private set; } = null!;
     public string BaseUrl { get; private set; } = null!;
-    public bool IsAvailable => Browser is not null;
 
     public async Task InitializeAsync()
     {
         BaseUrl = Environment.GetEnvironmentVariable("BASE_URL") ?? "http://localhost:5000";
-        try
+        Playwright = await Microsoft.Playwright.Playwright.CreateAsync();
+        Browser = await Playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions
         {
-            Playwright = await Microsoft.Playwright.Playwright.CreateAsync();
-            Browser = await Playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions
-            {
-                Headless = true
-            });
-        }
-        catch
-        {
-            // Playwright browsers not installed — tests will be skipped
-        }
+            Headless = true
+        });
     }
 
     public async Task DisposeAsync()
     {
-        if (Browser is not null)
-        {
-            await Browser.DisposeAsync();
-        }
-        Playwright?.Dispose();
+        await Browser.DisposeAsync();
+        Playwright.Dispose();
     }
 }
 

--- a/tests/ReportingDashboard.UITests/ReportingDashboard.UITests.csproj
+++ b/tests/ReportingDashboard.UITests/ReportingDashboard.UITests.csproj
@@ -9,7 +9,6 @@
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="Microsoft.Playwright" Version="1.42.0" />
-    <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
     <PackageReference Include="xunit" Version="2.7.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7" />
   </ItemGroup>

--- a/tests/ReportingDashboard.UITests/ReportingDashboard.UITests.csproj
+++ b/tests/ReportingDashboard.UITests/ReportingDashboard.UITests.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="Microsoft.Playwright" Version="1.42.0" />
+    <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
     <PackageReference Include="xunit" Version="2.7.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7" />
   </ItemGroup>

--- a/tests/ReportingDashboard.UITests/ReportingDashboard.UITests.csproj
+++ b/tests/ReportingDashboard.UITests/ReportingDashboard.UITests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="Microsoft.Playwright" Version="1.42.0" />
+    <PackageReference Include="xunit" Version="2.7.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Task Assignment
**Assigned To:** PrincipalEngineer
**Complexity:** High
**Branch:** `agent/principalengineer/t1-project-foundation-scaffolding`

## Requirements
Closes #1338

# PR: Project Foundation & Scaffolding for Executive Reporting Dashboard

**Issue:** #1338 | **Parent:** #1330 | **Task ID:** T1

## Summary

Implements the complete project foundation for the Executive Reporting Dashboard — a single-page, screenshot-ready Blazor Server application (.NET 8) that renders project milestones and monthly execution status at exactly 1920×1080 pixels. This PR establishes the solution structure, all shared data models, the JSON data service with FileSystemWatcher and error handling, the Blazor infrastructure (routing, layout, imports), the root Dashboard page with error panel and child component composition slots, and the global CSS reset with fixed viewport and custom properties. No UI components (header, timeline, heatmap) are rendered yet — those are subsequent PRs. After this PR, `dotnet build` succeeds with zero errors/warnings, and navigating to `/` displays either the error panel (if `data.json` is missing/malformed) or placeholder text confirming data loaded successfully.

## Acceptance Criteria

- [ ] `dotnet build` at the solution root completes with **zero errors and zero warnings**
- [ ] Solution contains exactly two projects: `ReportingDashboard.Web` (Blazor Server, net8.0) and `ReportingDashboard.Models` (class library, net8.0)
- [ ] All 8 model records exist in `ReportingDashboard.Models`: `DashboardData`, `ProjectHeader`, `TimelineConfig`, `Track`, `Milestone`, `HeatmapData`, `StatusRow`, `MonthCell`
- [ ] `IDataService` interface exposes `GetData()`, `GetError()`, and `OnDataChanged` event
- [ ] `DataService` loads `data.json` from `IWebHostEnvironment.ContentRootPath`, deserializes with `System.Text.Json` (camelCase, case-insensitive), and caches the result
- [ ] `DataService` catches `FileNotFoundException` and `JsonException`, storing a human-readable error message retrievable via `GetError()`
- [ ] `FileSystemWatcher` monitors `data.json` for changes with 300ms debounce; fires `OnDataChanged` on successful reload
- [ ] `DataService` is registered as a singleton in DI; `Program.cs` contains no authentication, no database, no extra NuGet packages
- [ ] Navigating to `/` with a missing `data.json` renders an error panel: red heading "Dashboard Configuration Error", the error message, and "Edit data.json and refresh this page"
- [ ] Navigating to `/` with a valid `data.json` renders placeholder text confirming data loaded (child component slots present but not yet populated)
- [ ] `MainLayout.razor` contains no navigation, no sidebar, no Bootstrap references — just `@Body`
- [ ] `App.razor` configures the Blazor router with `MainLayout` as the default layout
- [ ] `_Imports.razor` includes global usings for `Microsoft.AspNetCore.Components`, `Microsoft.AspNetCore.Components.Web`, project namespaces
- [ ] `wwwroot/css/app.css` sets `html, body` to `width: 1920px; height: 1080px; overflow: hidden`, uses `'Segoe UI', Arial, sans-serif`, includes CSS custom properties for the color palette, and hides `#blazor-error-ui`
- [ ] `MainLayout.razor.css` removes all default template styling
- [ ] `.gitignore` covers `bin/`, `obj/`, `*.user`, `.vs/`
- [ ] `data.json` is configured with `<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>` in the `.csproj`
- [ ] `Dashboard.razor` subscribes to `IDataService.OnDataChanged` and calls `StateHasChanged` for live reload

## Implementation Steps

### Step 1: Solution scaffolding, .gitignore, and project files

Create the folder structure and project configuration files. This step produces a buildable (but empty) solution.

- Create `.gitignore` at repo root with entries for `bin/`, `obj/`, `*.user`, `.vs/`, `*.suo`, `appsettings.*.json` (keep `appsettings.json`)
- Create `ReportingDashboard.sln` at repo root referencing both projects
- Create `ReportingDashboard.Web/ReportingDashboard.Web.csproj` — `Microsoft.NET.Sdk.Web`, `net8.0`, `<RootNamespace>ReportingDashboard.Web</RootNamespace>`, project reference to `ReportingDashboard.Models`, `data.json` CopyToOutputDirectory PreserveNewest
- Create `ReportingDashboard.Models/ReportingDashboard.Models.csproj` — `Microsoft.NET.Sdk`, `net8.0`
- Create empty placeholder `ReportingDashboard.Web/Program.cs` with minimal `WebApplication.CreateBuilder(args)` → `app.Run()`
- Verify: `dotnet build ReportingDashboard.sln` succeeds

### Step 2: Data models in ReportingDashboard.Models

Create all 8 C# record types that define the `data.json` contract. One file per record, all in the `ReportingDashboard.Models` namespace.

- `DashboardData.cs` — top-level record: `ProjectHeader Header`, `TimelineConfig Timeline`, `HeatmapData Heatmap`
- `ProjectHeader.cs` — `string Title`, `string Subtitle`, `string BacklogUrl`, `string CurrentMonth`
- `TimelineConfig.cs` — `DateTime StartDate`, `DateTime EndDate`, `DateTime NowDate`, `List<Track> Tracks`, `List<Milestone> Milestones`
- `Track.cs` — `string Id`, `string Label`, `string Description`, `string Color`
- `Milestone.cs` — `string TrackId`, `DateTime Date`, `string Label`, `string Type`, `string? Description`
- `HeatmapData.cs` — `List<string> Columns`, `int HighlightColumnIndex`, `List<StatusRow> Rows`
- `StatusRow.cs` — `string Category`, `string ColorTheme`, `List<MonthCell> Cells`
- `MonthCell.cs` — `List<string> Items`
- Verify: `dotnet build ReportingDashboard.Models` succeeds

### Step 3: DataService with FileSystemWatcher and error handling

Implement the data access layer that reads, caches, watches, and error-handles `data.json`.

- Create `ReportingDashboard.Web/Services/IDataService.cs` — interface with `DashboardData? GetData()`, `string? GetError()`, `event Action? OnDataChanged`
- Create `ReportingDashboard.Web/Services/DataService.cs` — singleton implementation:
  - Constructor accepts `IWebHostEnvironment`, resolves `data.json` path via `ContentRootPath`
  - `LoadData()` reads file, deserializes with `JsonSerializerOptions { PropertyNameCaseInsensitive = true, PropertyNamingPolicy = JsonNamingPolicy.CamelCase }`
  - Catches `FileNotFoundException` → error message with absolute path
  - Catches `JsonException` → error message with parse details
  - Catches `IOException` on file-in-use → single retry after 100ms
  - `FileSystemWatcher` on `data.json` with `NotifyFilter = LastWrite`, 300ms `System.Threading.Timer` debounce
  - `volatile` fields for `_data` and `_error`; `OnDataChanged` event fired after successful reload
- Verify: `dotnet build ReportingDashboard.Web` succeeds

### Step 4: Blazor infrastructure — App.razor, MainLayout, _Imports, Program.cs with DI

Wire up the Blazor Server application shell with minimal layout and service registration.

- Create `ReportingDashboard.Web/App.razor` — `<Router>` with `Found`/`NotFound` templates, `DefaultLayout="typeof(MainLayout)"`; include `<link>` to `css/app.css` and the Blazor Server script `_framework/blazor.server.js` in `<head>`/`<body>`
- Create `ReportingDashboard.Web/_Imports.razor` — `@using Microsoft.AspNetCore.Components`, `@using Microsoft.AspNetCore.Components.Web`, `@using Microsoft.AspNetCore.Components.Routing`, `@using ReportingDashboard.Models`, `@using ReportingDashboard.Web.Services`
- Create `ReportingDashboard.Web/MainLayout.razor` — `@inherits LayoutComponentBase`, renders only `@Body` (no nav, no sidebar)
- Create `ReportingDashboard.Web/MainLayout.razor.css` — empty or minimal reset (no Bootstrap classes)
- Update `ReportingDashboard.Web/Program.cs`:
  - `builder.Services.AddRazorPages(); builder.Services.AddServerSideBlazor();`
  - `builder.Services.AddSingleton<IDataService, DataService>();`
  - `app.MapBlazorHub(); app.MapFallbackToPage("/_Host");` or `app.MapRazorPages();` depending on Blazor Server hosting model
  - No authentication, no database, no extra middleware
- Verify: `dotnet run --project ReportingDashboard.Web` starts Kestrel without errors

### Step 5: Dashboard.razor page, global CSS, and sample data.json

Create the root page that composes the dashboard (with placeholder slots for child components) and the global stylesheet.

- Create `ReportingDashboard.Web/wwwroot/css/app.css`:
  - CSS reset (`*, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }`)
  - `:root` CSS custom properties for the full color palette (--color-text, --color-link, --color-border, --color-now, --color-poc, --color-production, --color-checkpoint, etc.)
  - `html, body { width: 1920px; height: 1080px; overflow: hidden; background: #FFF; font-family: 'Segoe UI', Arial, sans-serif; color: #111; display: flex; flex-direction: column; }`
  - `#blazor-error-ui { display: none !important; }`
  - `a { color: var(--color-link); text-decoration: none; }`
- Create `ReportingDashboard.Web/Pages/Dashboard.razor`:
  - `@page "/"`
  - `@inject IDataService DataService`
  - `@implements IDisposable`
  - `OnInitialized`: subscribe to `DataService.OnDataChanged` → `InvokeAsync(StateHasChanged)`
  - `Dispose`: unsubscribe from event
  - Render logic: if `DataService.GetData()` is null, render error panel with `DataService.GetError()`; otherwise render placeholder `<!-- DashboardHeader slot -->`, `<!-- TimelineSection slot -->`, `<!-- HeatmapGrid slot -->` comments confirming data loaded
- Create `ReportingDashboard.Web/data.json` — sample "Project Phoenix" data with 3 tracks, ~10 milestones, 4 heatmap months, 4 status rows with realistic items
- Verify: `dotnet build` succeeds with zero warnings; `dotnet run` → navigate to `/` → error panel or data-loaded confirmation renders correctly

## Testing

Since automated UI testing is out of scope (per spec), verification is manual and build-based:

| What to Test | How to Verify |
|---|---|
| **Build health** | `dotnet build ReportingDashboard.sln` — zero errors, zero warnings |
| **Missing data.json** | Delete/rename `data.json`, run app, navigate to `/` — red error panel displays with file path and "data.json not found" message |
| **Malformed data.json** | Replace `data.json` content with `{ invalid }`, navigate to `/` — error panel shows JSON parse error details, not a blank page or unhandled exception |
| **Valid data.json** | Restore valid `data.json`, navigate to `/` — page loads without errors, placeholder text confirms data was deserialized |
| **FileSystemWatcher live reload** | With app running, edit `data.json` (e.g., change title) — dashboard updates within ~1 second without manual browser refresh |
| **Model completeness** | All 8 records compile and are referenced by `DataService` deserialization — verified implicitly by successful build and data load |
| **No default template artifacts** | No Bootstrap CSS, no `NavMenu`, no `Counter`, no `FetchData`, no sidebar visible at `/` |
| **CSS viewport** | Open browser DevTools, verify `<body>` computed style is `1920×1080`, `overflow: hidden`, no scrollbars |
| **Blazor error UI suppressed** | Inspect DOM — `#blazor-error-ui` element has `display: none !important` |

**Optional unit tests** (if added later): `DataService.LoadData()` with valid JSON returns non-null `DashboardData`; `DataService` with missing file returns null data and descriptive error string; `DataService` with invalid JSON returns null data and parse error string.

## References
- Architecture: Architecture.md
- PM Spec: 

## Status
- [ ] Implementation
- [ ] Tests Written
- [ ] Ready for Review