### PR TITLE
SoftwareEngineer: Heatmap Grid Component [W2]

### DIFF
--- a/ReportingDashboard.sln
+++ b/ReportingDashboard.sln
@@ -1,0 +1,6 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ReportingDashboard.Tests", "tests\ReportingDashboard.Tests\ReportingDashboard.Tests.csproj", "{D88719C8-7501-40D0-B66F-881C8D2A520B}"
+EndProject
+Global
+EndGlobal

--- a/ReportingDashboard/Components/Shared/HeatmapCell.razor
+++ b/ReportingDashboard/Components/Shared/HeatmapCell.razor
@@ -1,0 +1,45 @@
+@namespace ReportingDashboard.Components.Shared
+
+<div class="hm-cell @CellCssClass" style="@(IsLastColumn ? "border-right:none;" : "")">
+    @if (Items == null || Items.Count == 0)
+    {
+        <div class="it" style="color:#AAA;">—</div>
+    }
+    else
+    {
+        @foreach (var item in Items)
+        {
+            <div class="it">@item</div>
+        }
+    }
+</div>
+
+@code {
+    [Parameter]
+    public List<string>? Items { get; set; }
+
+    [Parameter, EditorRequired]
+    public string ColorScheme { get; set; } = "green";
+
+    [Parameter]
+    public bool IsCurrentMonth { get; set; }
+
+    [Parameter]
+    public bool IsLastColumn { get; set; }
+
+    private string CellCssClass
+    {
+        get
+        {
+            var prefix = ColorScheme switch
+            {
+                "green" => "ship",
+                "blue" => "prog",
+                "amber" => "carry",
+                "red" => "block",
+                _ => "ship"
+            };
+            return $"{prefix}-cell{(IsCurrentMonth ? " current-month" : "")}";
+        }
+    }
+}

--- a/tests/ReportingDashboard.Tests/ReportingDashboard.Tests.csproj
+++ b/tests/ReportingDashboard.Tests/ReportingDashboard.Tests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="bunit" Version="1.28.9" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.7.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\ReportingDashboard\ReportingDashboard.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/ReportingDashboard.Tests/Unit/HeatmapComponentTests.cs
+++ b/tests/ReportingDashboard.Tests/Unit/HeatmapComponentTests.cs
@@ -1,0 +1,266 @@
+using Bunit;
+using Xunit;
+using ReportingDashboard.Models;
+using ReportingDashboard.Components.Shared;
+
+namespace ReportingDashboard.Tests.Unit;
+
+public class HeatmapComponentTests : TestContext
+{
+    private static List<HeatmapCategory> CreateSampleCategories()
+    {
+        return new List<HeatmapCategory>
+        {
+            new()
+            {
+                Name = "Shipped",
+                ColorScheme = "green",
+                Rows = new Dictionary<string, List<string>>
+                {
+                    ["Jan 2026"] = new() { "Item A", "Item B" },
+                    ["Feb 2026"] = new() { "Item C" }
+                }
+            },
+            new()
+            {
+                Name = "In Progress",
+                ColorScheme = "blue",
+                Rows = new Dictionary<string, List<string>>
+                {
+                    ["Jan 2026"] = new() { "Task 1" },
+                    ["Feb 2026"] = new() { "Task 2", "Task 3" }
+                }
+            },
+            new()
+            {
+                Name = "Carryover",
+                ColorScheme = "amber",
+                Rows = new Dictionary<string, List<string>>
+                {
+                    ["Jan 2026"] = new(),
+                    ["Feb 2026"] = new() { "Carried item" }
+                }
+            },
+            new()
+            {
+                Name = "Blockers",
+                ColorScheme = "red",
+                Rows = new Dictionary<string, List<string>>
+                {
+                    ["Jan 2026"] = new(),
+                    ["Feb 2026"] = new()
+                }
+            }
+        };
+    }
+
+    private static List<string> CreateSampleMonths() => new() { "Jan 2026", "Feb 2026" };
+
+    [Fact]
+    public void HeatmapGrid_RendersAllFourCategoryRows()
+    {
+        var cut = RenderComponent<HeatmapGrid>(parameters => parameters
+            .Add(p => p.Categories, CreateSampleCategories())
+            .Add(p => p.Months, CreateSampleMonths())
+            .Add(p => p.CurrentMonthIndex, 1));
+
+        var rowHeaders = cut.FindAll(".hm-row-hdr");
+        Assert.Equal(4, rowHeaders.Count);
+    }
+
+    [Fact]
+    public void HeatmapGrid_RendersCorrectCssClassesForRows()
+    {
+        var cut = RenderComponent<HeatmapGrid>(parameters => parameters
+            .Add(p => p.Categories, CreateSampleCategories())
+            .Add(p => p.Months, CreateSampleMonths())
+            .Add(p => p.CurrentMonthIndex, 1));
+
+        var rowHeaders = cut.FindAll(".hm-row-hdr");
+        Assert.Contains("ship-hdr", rowHeaders[0].ClassList);
+        Assert.Contains("prog-hdr", rowHeaders[1].ClassList);
+        Assert.Contains("carry-hdr", rowHeaders[2].ClassList);
+        Assert.Contains("block-hdr", rowHeaders[3].ClassList);
+    }
+
+    [Fact]
+    public void HeatmapGrid_GridColumnCountMatchesMonthsLength()
+    {
+        var months = CreateSampleMonths();
+        var cut = RenderComponent<HeatmapGrid>(parameters => parameters
+            .Add(p => p.Categories, CreateSampleCategories())
+            .Add(p => p.Months, months)
+            .Add(p => p.CurrentMonthIndex, 1));
+
+        var colHeaders = cut.FindAll(".hm-col-hdr");
+        Assert.Equal(months.Count, colHeaders.Count);
+    }
+
+    [Fact]
+    public void HeatmapGrid_CurrentMonthHeaderHasCurrentMonthClass()
+    {
+        var cut = RenderComponent<HeatmapGrid>(parameters => parameters
+            .Add(p => p.Categories, CreateSampleCategories())
+            .Add(p => p.Months, CreateSampleMonths())
+            .Add(p => p.CurrentMonthIndex, 1));
+
+        var colHeaders = cut.FindAll(".hm-col-hdr");
+        Assert.DoesNotContain("current-month", colHeaders[0].ClassList);
+        Assert.Contains("current-month", colHeaders[1].ClassList);
+    }
+
+    [Fact]
+    public void HeatmapGrid_RendersHeatmapTitle()
+    {
+        var cut = RenderComponent<HeatmapGrid>(parameters => parameters
+            .Add(p => p.Categories, CreateSampleCategories())
+            .Add(p => p.Months, CreateSampleMonths())
+            .Add(p => p.CurrentMonthIndex, 0));
+
+        var title = cut.Find(".hm-title");
+        Assert.Contains("Monthly Execution Heatmap", title.TextContent);
+    }
+
+    [Fact]
+    public void HeatmapGrid_RendersCornerCell()
+    {
+        var cut = RenderComponent<HeatmapGrid>(parameters => parameters
+            .Add(p => p.Categories, CreateSampleCategories())
+            .Add(p => p.Months, CreateSampleMonths())
+            .Add(p => p.CurrentMonthIndex, 0));
+
+        var corner = cut.Find(".hm-corner");
+        Assert.Equal("Status", corner.TextContent);
+    }
+
+    [Fact]
+    public void HeatmapGrid_RendersEmojiPrefixes()
+    {
+        var cut = RenderComponent<HeatmapGrid>(parameters => parameters
+            .Add(p => p.Categories, CreateSampleCategories())
+            .Add(p => p.Months, CreateSampleMonths())
+            .Add(p => p.CurrentMonthIndex, 0));
+
+        var rowHeaders = cut.FindAll(".hm-row-hdr");
+        Assert.Contains("✓", rowHeaders[0].TextContent);
+        Assert.Contains("●", rowHeaders[1].TextContent);
+        Assert.Contains("↩", rowHeaders[2].TextContent);
+        Assert.Contains("⚠", rowHeaders[3].TextContent);
+    }
+
+    [Fact]
+    public void HeatmapCell_RendersPopulatedItems()
+    {
+        var items = new List<string> { "Item A", "Item B" };
+        var cut = RenderComponent<HeatmapCell>(parameters => parameters
+            .Add(p => p.Items, items)
+            .Add(p => p.ColorScheme, "green")
+            .Add(p => p.IsCurrentMonth, false));
+
+        var itemElements = cut.FindAll(".it");
+        Assert.Equal(2, itemElements.Count);
+        Assert.Equal("Item A", itemElements[0].TextContent);
+        Assert.Equal("Item B", itemElements[1].TextContent);
+    }
+
+    [Fact]
+    public void HeatmapCell_RendersEmptyDashForEmptyItems()
+    {
+        var cut = RenderComponent<HeatmapCell>(parameters => parameters
+            .Add(p => p.Items, new List<string>())
+            .Add(p => p.ColorScheme, "green")
+            .Add(p => p.IsCurrentMonth, false));
+
+        var itemElements = cut.FindAll(".it");
+        Assert.Single(itemElements);
+        Assert.Equal("—", itemElements[0].TextContent);
+        Assert.Contains("color:#AAA", itemElements[0].GetAttribute("style") ?? "");
+    }
+
+    [Fact]
+    public void HeatmapCell_RendersEmptyDashForNullItems()
+    {
+        var cut = RenderComponent<HeatmapCell>(parameters => parameters
+            .Add(p => p.Items, (List<string>?)null)
+            .Add(p => p.ColorScheme, "blue")
+            .Add(p => p.IsCurrentMonth, false));
+
+        var itemElements = cut.FindAll(".it");
+        Assert.Single(itemElements);
+        Assert.Equal("—", itemElements[0].TextContent);
+    }
+
+    [Fact]
+    public void HeatmapCell_CurrentMonthAppliesCorrectCssClass()
+    {
+        var cut = RenderComponent<HeatmapCell>(parameters => parameters
+            .Add(p => p.Items, new List<string> { "Test" })
+            .Add(p => p.ColorScheme, "green")
+            .Add(p => p.IsCurrentMonth, true));
+
+        var cell = cut.Find(".hm-cell");
+        Assert.Contains("current-month", cell.ClassList);
+        Assert.Contains("ship-cell", cell.ClassList);
+    }
+
+    [Fact]
+    public void HeatmapCell_NonCurrentMonthDoesNotHaveCurrentMonthClass()
+    {
+        var cut = RenderComponent<HeatmapCell>(parameters => parameters
+            .Add(p => p.Items, new List<string> { "Test" })
+            .Add(p => p.ColorScheme, "blue")
+            .Add(p => p.IsCurrentMonth, false));
+
+        var cell = cut.Find(".hm-cell");
+        Assert.DoesNotContain("current-month", cell.ClassList);
+        Assert.Contains("prog-cell", cell.ClassList);
+    }
+
+    [Theory]
+    [InlineData("green", "ship-cell")]
+    [InlineData("blue", "prog-cell")]
+    [InlineData("amber", "carry-cell")]
+    [InlineData("red", "block-cell")]
+    public void HeatmapCell_ColorSchemeMapsToCorrectCssClass(string colorScheme, string expectedClass)
+    {
+        var cut = RenderComponent<HeatmapCell>(parameters => parameters
+            .Add(p => p.Items, new List<string> { "Item" })
+            .Add(p => p.ColorScheme, colorScheme)
+            .Add(p => p.IsCurrentMonth, false));
+
+        var cell = cut.Find(".hm-cell");
+        Assert.Contains(expectedClass, cell.ClassList);
+    }
+
+    [Fact]
+    public void HeatmapGrid_VariableMonthCount_RendersCorrectColumns()
+    {
+        var months = new List<string> { "Mar 2026", "Apr 2026", "May 2026" };
+        var categories = new List<HeatmapCategory>
+        {
+            new()
+            {
+                Name = "Shipped",
+                ColorScheme = "green",
+                Rows = new Dictionary<string, List<string>>
+                {
+                    ["Mar 2026"] = new() { "A" },
+                    ["Apr 2026"] = new() { "B" },
+                    ["May 2026"] = new()
+                }
+            }
+        };
+
+        var cut = RenderComponent<HeatmapGrid>(parameters => parameters
+            .Add(p => p.Categories, categories)
+            .Add(p => p.Months, months)
+            .Add(p => p.CurrentMonthIndex, 1));
+
+        var colHeaders = cut.FindAll(".hm-col-hdr");
+        Assert.Equal(3, colHeaders.Count);
+
+        var grid = cut.Find(".hm-grid");
+        var style = grid.GetAttribute("style") ?? "";
+        Assert.Contains("repeat(3", style);
+    }
+}


### PR DESCRIPTION
## Task Assignment
**Assigned To:** SoftwareEngineer
**Complexity:** Medium
**Branch:** `agent/softwareengineer/t3-heatmap-grid-component-w2`

## Requirements
Closes #1526

# PR: Heatmap Grid Component (T3)

**Issue:** #1526 | **Parent:** #1521 | **Depends on:** T1 (Foundation)

## Summary

Implements the `HeatmapGrid.razor` and `HeatmapCell.razor` Blazor components in `Components/Shared/`, completing the bottom section of the executive reporting dashboard. HeatmapGrid renders a CSS Grid displaying four color-coded status categories (Shipped, In Progress, Carryover, Blockers) across N month columns with current-month highlighting. HeatmapCell renders individual cells with bullet-pointed items using `::before` colored dots, or a muted dash for empty cells. Both components consume the `HeatmapCategory` model and CSS classes established by T1 — no new CSS or model files are created.

## Acceptance Criteria

- [ ] `HeatmapGrid.razor` accepts `[Parameter] List<HeatmapCategory> Categories`, `[Parameter] List<string> Months`, `[Parameter] int CurrentMonthIndex`
- [ ] Grid renders with inline style `grid-template-columns: 160px repeat(N, 1fr)` where N = `Months.Count`
- [ ] Grid renders with inline style `grid-template-rows: 36px repeat(4, 1fr)`
- [ ] Section title div with class `hm-title` displays "Monthly Execution Heatmap - Shipped · In Progress · Carryover · Blockers" (uppercase via CSS)
- [ ] Corner cell renders with class `hm-corner` containing text "STATUS"
- [ ] Month column headers use class `hm-col-hdr`; the header at index == `CurrentMonthIndex` also gets class `current-month`
- [ ] Row headers render with correct CSS class per category: `ship-hdr` (green), `prog-hdr` (blue), `carry-hdr` (amber), `block-hdr` (red)
- [ ] Row headers include emoji prefix: ✅ Shipped, 🔄 In Progress, 📋 Carryover, 🚫 Blockers
- [ ] `HeatmapCell.razor` accepts `[Parameter] List<string> Items`, `[Parameter] string ColorScheme`, `[Parameter] bool IsCurrentMonth`
- [ ] Cell applies category-specific CSS class: `ship-cell` / `prog-cell` / `carry-cell` / `block-cell` based on `ColorScheme`
- [ ] Cell applies additional `current-month` class when `IsCurrentMonth` is true
- [ ] Populated cells render each item as `<div class="it">@item</div>` (colored dot provided by `::before` in T1's CSS)
- [ ] Empty cells (null/empty Items list) render `<div class="it" style="color:#AAA">-</div>`
- [ ] `dotnet build` succeeds with zero errors and zero warnings
- [ ] All unit tests pass

## Implementation Steps

### Step 1: Scaffold component files and test project reference

Create the directory `ReportingDashboard/Components/Shared/` if it does not exist. Create empty `HeatmapGrid.razor` and `HeatmapCell.razor` files with the correct `@namespace ReportingDashboard.Components.Shared` directive and stub `@code` blocks with the required `[Parameter]` properties. Create `tests/ReportingDashboard.Tests/Unit/HeatmapComponentTests.cs` with the test class skeleton. Verify `ReportingDashboard.Tests.csproj` has a `<ProjectReference>` to the main project and the `bunit` package reference (both expected from T1). Run `dotnet build` to confirm the skeleton compiles.

**Files created:**
- `ReportingDashboard/Components/Shared/HeatmapGrid.razor`
- `ReportingDashboard/Components/Shared/HeatmapCell.razor`
- `tests/ReportingDashboard.Tests/Unit/HeatmapComponentTests.cs`

### Step 2: Implement HeatmapCell.razor

Implement the full rendering logic for `HeatmapCell`:

```razor
@namespace ReportingDashboard.Components.Shared

@{
    var schemePrefix = ColorScheme switch
    {
        "green" => "ship",
        "blue" => "prog",
        "amber" => "carry",
        "red" => "block",
        _ => "ship"
    };
    var cellClass = $"{schemePrefix}-cell{(IsCurrentMonth ? " current-month" : "")}";
}

<div class="hm-cell @cellClass">
    @if (Items is null || Items.Count == 0)
    {
        <div class="it" style="color:#AAA">-</div>
    }
    else
    {
        @foreach (var item in Items)
        {
            <div class="it">@item</div>
        }
    }
</div>

@code {
    [Parameter] public List<string>? Items { get; set; }
    [Parameter] public string ColorScheme { get; set; } = "green";
    [Parameter] public bool IsCurrentMonth { get; set; }
}
```

Run `dotnet build` to verify compilation.

### Step 3: Implement HeatmapGrid.razor

Implement the grid layout with section title, corner cell, month headers, row headers, and nested `HeatmapCell` instances:

```razor
@namespace ReportingDashboard.Components.Shared

<div class="hm-wrap">
    <div class="hm-title">Monthly Execution Heatmap - Shipped · In Progress · Carryover · Blockers</div>

    <div class="hm-grid" style="grid-template-columns: 160px repeat(@Months.Count, 1fr); grid-template-rows: 36px repeat(@Categories.Count, 1fr);">
        @* Header row *@
        <div class="hm-corner">STATUS</div>
        @for (int i = 0; i < Months.Count; i++)
        {
            var headerClass = "hm-col-hdr" + (i == CurrentMonthIndex ? " current-month" : "");
            <div class="@headerClass">@Months[i]</div>
        }

        @* Data rows *@
        @foreach (var category in Categories)
        {
            var rowHeaderClass = GetRowHeaderClass(category.ColorScheme);
            var emoji = GetEmoji(category.ColorScheme);
            <div class="hm-row-hdr @rowHeaderClass">@emoji @category.Name</div>

            @for (int i = 0; i < Months.Count; i++)
            {
                var monthKey = Months[i];
                List<string>? items = null;
                category.Rows?.TryGetValue(monthKey, out items);
                <HeatmapCell Items="@items"
                             ColorScheme="@category.ColorScheme"
                             IsCurrentMonth="@(i == CurrentMonthIndex)" />
            }
        }
    </div>
</div>

@code {
    [Parameter] public List<HeatmapCategory> Categories { get; set; } = new();
    [Parameter] public List<string> Months { get; set; } = new();
    [Parameter] public int CurrentMonthIndex { get; set; }

    private static string GetRowHeaderClass(string colorScheme) => colorScheme switch
    {
        "green" => "ship-hdr",
        "blue" => "prog-hdr",
        "amber" => "carry-hdr",
        "red" => "block-hdr",
        _ => "ship-hdr"
    };

    private static string GetEmoji(string colorScheme) => colorScheme switch
    {
        "green" => "✅",
        "blue" => "🔄",
        "amber" => "📋",
        "red" => "🚫",
        _ => ""
    };
}
```

Add `@using ReportingDashboard.Models` to the file or verify it is covered by `_Imports.razor` from T1. Run `dotnet build`.

### Step 4: Write unit tests

Implement bUnit tests in `HeatmapComponentTests.cs` covering the following scenarios:

```csharp
namespace ReportingDashboard.Tests.Unit;

using Bunit;
using ReportingDashboard.Components.Shared;
using ReportingDashboard.Models;

public class HeatmapComponentTests : TestContext
{
    // HeatmapCell tests:
    // 1. Renders_Items_With_It_Class - pass 3 items, assert 3 divs with class "it" and correct text
    // 2. Renders_Dash_For_Empty_Items - pass null/empty list, assert single div with text "-" and color:#AAA
    // 3. Applies_CurrentMonth_Class - pass IsCurrentMonth=true, assert "current-month" in cell class
    // 4. Maps_ColorScheme_To_CssPrefix - test each scheme (green→ship-cell, blue→prog-cell, amber→carry-cell, red→block-cell)

    // HeatmapGrid tests:
    // 5. Renders_Correct_Column_Count - pass 4 months, assert grid-template-columns contains "repeat(4, 1fr)"
    // 6. Renders_All_Category_Rows - pass 4 categories, assert 4 row headers with correct CSS classes
    // 7. Highlights_Current_Month_Header - pass CurrentMonthIndex=2, assert 3rd month header has "current-month" class
    // 8. Corner_Cell_Shows_STATUS - assert div.hm-corner contains "STATUS"
    // 9. Row_Headers_Have_Emoji_Prefix - assert shipped row contains "✅", blockers row contains "🚫"
}
```

Run `dotnet test` and confirm all tests pass.

### Step 5: Integration verification and cleanup

Verify the components can be referenced from `Dashboard.razor` (T1's orchestrator page) by confirming the namespace is importable. Ensure no build warnings. Run full `dotnet build` on the solution. Confirm no files outside the owned set were created or modified.

**Owned files (final):**
- `ReportingDashboard/Components/Shared/HeatmapGrid.razor`
- `ReportingDashboard/Components/Shared/HeatmapCell.razor`
- `tests/ReportingDashboard.Tests/Unit/HeatmapComponentTests.cs`

## Testing

| Test | Scenario | Assertion |
|------|----------|-----------|
| `HeatmapCell_Renders_Items` | Pass `["Item A", "Item B", "Item C"]` as Items | 3 `div.it` elements with matching text content |
| `HeatmapCell_Empty_Shows_Dash` | Pass `null` Items | Single `div.it` with text "-" and inline `color:#AAA` |
| `HeatmapCell_Empty_List_Shows_Dash` | Pass empty `List<string>()` | Single `div.it` with text "-" |
| `HeatmapCell_CurrentMonth_Class` | Set `IsCurrentMonth = true`, `ColorScheme = "green"` | Cell div contains classes `ship-cell` and `current-month` |
| `HeatmapCell_NonCurrentMonth_No_Class` | Set `IsCurrentMonth = false`, `ColorScheme = "blue"` | Cell div contains `prog-cell` but NOT `current-month` |
| `HeatmapCell_ColorScheme_Green` | `ColorScheme = "green"` | Cell class contains `ship-cell` |
| `HeatmapCell_ColorScheme_Blue` | `ColorScheme = "blue"` | Cell class contains `prog-cell` |
| `HeatmapCell_ColorScheme_Amber` | `ColorScheme = "amber"` | Cell class contains `carry-cell` |
| `HeatmapCell_ColorScheme_Red` | `ColorScheme = "red"` | Cell class contains `block-cell` |
| `HeatmapGrid_ColumnCount` | Pass 4 months | Inline style contains `repeat(4, 1fr)` |
| `HeatmapGrid_ThreeMonths` | Pass 3 months | Inline style contains `repeat(3, 1fr)` |
| `HeatmapGrid_CornerCell` | Render with any data | `div.hm-corner` contains "STATUS" |
| `HeatmapGrid_AllRowHeaders` | Pass 4 categories | Markup contains `ship-hdr`, `prog-hdr`, `carry-hdr`, `block-hdr` |
| `HeatmapGrid_CurrentMonthHeader` | `CurrentMonthIndex = 2`, 4 months | 3rd `.hm-col-hdr` has `current-month` class; others do not |
| `HeatmapGrid_EmojiPrefixes` | All 4 categories | Row headers contain ✅, 🔄, 📋, 🚫 respectively |
| `HeatmapGrid_Title` | Render with any data | `div.hm-title` contains "Monthly Execution Heatmap" |

## References
- Architecture: Architecture.md
- PM Spec: 

## Status
- [ ] Implementation
- [ ] Tests Written
- [ ] Ready for Review