### PR TITLE
SoftwareEngineer: Project Foundation & Scaffolding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,21 @@
+# Build results
+bin/
+obj/
+.vs/
+*.user
+*.suo
+*.sln.docstates
+
+# Data files (keep example, ignore real data)
+Data/data.json
+
+# IDE
+.vscode/
+.idea/
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Published folder
+publish/

--- a/ReportingDashboard.sln
+++ b/ReportingDashboard.sln
@@ -1,18 +1,53 @@
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31919.166
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ReportingDashboard", "ReportingDashboard\ReportingDashboard.csproj", "{A1B2C3D4-E5F6-47A8-B9C0-D1E2F3A4B5C6}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{0AB3BF05-4346-4AA6-1389-037BE0695223}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ReportingDashboard.Tests", "tests\ReportingDashboard.Tests\ReportingDashboard.Tests.csproj", "{B284A522-4A8A-4659-9F67-3A8528A245A8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{A1B2C3D4-E5F6-47A8-B9C0-D1E2F3A4B5C6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{A1B2C3D4-E5F6-47A8-B9C0-D1E2F3A4B5C6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A1B2C3D4-E5F6-47A8-B9C0-D1E2F3A4B5C6}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A1B2C3D4-E5F6-47A8-B9C0-D1E2F3A4B5C6}.Debug|x64.Build.0 = Debug|Any CPU
+		{A1B2C3D4-E5F6-47A8-B9C0-D1E2F3A4B5C6}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A1B2C3D4-E5F6-47A8-B9C0-D1E2F3A4B5C6}.Debug|x86.Build.0 = Debug|Any CPU
 		{A1B2C3D4-E5F6-47A8-B9C0-D1E2F3A4B5C6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A1B2C3D4-E5F6-47A8-B9C0-D1E2F3A4B5C6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A1B2C3D4-E5F6-47A8-B9C0-D1E2F3A4B5C6}.Release|x64.ActiveCfg = Release|Any CPU
+		{A1B2C3D4-E5F6-47A8-B9C0-D1E2F3A4B5C6}.Release|x64.Build.0 = Release|Any CPU
+		{A1B2C3D4-E5F6-47A8-B9C0-D1E2F3A4B5C6}.Release|x86.ActiveCfg = Release|Any CPU
+		{A1B2C3D4-E5F6-47A8-B9C0-D1E2F3A4B5C6}.Release|x86.Build.0 = Release|Any CPU
+		{B284A522-4A8A-4659-9F67-3A8528A245A8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B284A522-4A8A-4659-9F67-3A8528A245A8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B284A522-4A8A-4659-9F67-3A8528A245A8}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B284A522-4A8A-4659-9F67-3A8528A245A8}.Debug|x64.Build.0 = Debug|Any CPU
+		{B284A522-4A8A-4659-9F67-3A8528A245A8}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B284A522-4A8A-4659-9F67-3A8528A245A8}.Debug|x86.Build.0 = Debug|Any CPU
+		{B284A522-4A8A-4659-9F67-3A8528A245A8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B284A522-4A8A-4659-9F67-3A8528A245A8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B284A522-4A8A-4659-9F67-3A8528A245A8}.Release|x64.ActiveCfg = Release|Any CPU
+		{B284A522-4A8A-4659-9F67-3A8528A245A8}.Release|x64.Build.0 = Release|Any CPU
+		{B284A522-4A8A-4659-9F67-3A8528A245A8}.Release|x86.ActiveCfg = Release|Any CPU
+		{B284A522-4A8A-4659-9F67-3A8528A245A8}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{B284A522-4A8A-4659-9F67-3A8528A245A8} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 	EndGlobalSection
 EndGlobal

--- a/ReportingDashboard.sln
+++ b/ReportingDashboard.sln
@@ -1,0 +1,18 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31919.166
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ReportingDashboard", "ReportingDashboard\ReportingDashboard.csproj", "{A1B2C3D4-E5F6-47A8-B9C0-D1E2F3A4B5C6}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A1B2C3D4-E5F6-47A8-B9C0-D1E2F3A4B5C6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A1B2C3D4-E5F6-47A8-B9C0-D1E2F3A4B5C6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A1B2C3D4-E5F6-47A8-B9C0-D1E2F3A4B5C6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A1B2C3D4-E5F6-47A8-B9C0-D1E2F3A4B5C6}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/ReportingDashboard/Components/App.razor
+++ b/ReportingDashboard/Components/App.razor
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=1920, height=1080, initial-scale=1.0" />
+    <title>Executive Reporting Dashboard</title>
+    <link rel="stylesheet" href="css/app.css" />
+    <link rel="stylesheet" href="ReportingDashboard.styles.css" />
+</head>
+<body>
+    <Routes />
+    <script src="_framework/blazor.web.js"></script>
+    <div id="blazor-error-ui" style="display: none;">
+        An unhandled error has occurred.
+        <a href="" class="reload">Reload</a>
+        <a class="dismiss">🗙</a>
+    </div>
+</body>
+</html>

--- a/ReportingDashboard/Components/Layout/MainLayout.razor
+++ b/ReportingDashboard/Components/Layout/MainLayout.razor
@@ -1,0 +1,5 @@
+@inherits LayoutComponentBase
+
+<main>
+    @Body
+</main>

--- a/ReportingDashboard/Components/Layout/MainLayout.razor.css
+++ b/ReportingDashboard/Components/Layout/MainLayout.razor.css
@@ -1,0 +1,7 @@
+main {
+    width: 1920px;
+    height: 1080px;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+}

--- a/ReportingDashboard/Components/Pages/Dashboard.razor
+++ b/ReportingDashboard/Components/Pages/Dashboard.razor
@@ -1,0 +1,39 @@
+@page "/"
+@inject DashboardDataService DataService
+
+@if (ErrorMessage != null)
+{
+    <div class="error-container">
+        <h2>Unable to load dashboard data</h2>
+        <p>Please check that data.json exists and contains valid JSON.</p>
+        <p class="error-detail">@ErrorMessage</p>
+    </div>
+}
+else if (Data != null)
+{
+    <!-- Dashboard content will be rendered here -->
+    <div class="dashboard">
+        <p>Dashboard content pending implementation</p>
+    </div>
+}
+else
+{
+    <p>Loading...</p>
+}
+
+@code {
+    private DashboardReport? Data;
+    private string? ErrorMessage;
+
+    protected override async Task OnInitializedAsync()
+    {
+        try
+        {
+            Data = await DataService.GetDataAsync();
+        }
+        catch (Exception ex)
+        {
+            ErrorMessage = ex.Message;
+        }
+    }
+}

--- a/ReportingDashboard/Components/Pages/Dashboard.razor.css
+++ b/ReportingDashboard/Components/Pages/Dashboard.razor.css
@@ -1,0 +1,43 @@
+.error-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+    background: #FFFFFF;
+    color: #111;
+    padding: 20px;
+    box-sizing: border-box;
+}
+
+.error-container h2 {
+    font-size: 24px;
+    margin-bottom: 16px;
+    color: #EA4335;
+}
+
+.error-container p {
+    font-size: 14px;
+    margin: 8px 0;
+    max-width: 600px;
+    text-align: center;
+}
+
+.error-detail {
+    font-family: monospace;
+    background-color: #F5F5F5;
+    padding: 12px;
+    border-radius: 4px;
+    color: #666;
+    font-size: 12px;
+    margin-top: 12px;
+}
+
+.dashboard {
+    width: 100%;
+    height: 100%;
+    background: #FFFFFF;
+    display: flex;
+    flex-direction: column;
+}

--- a/ReportingDashboard/Components/Pages/ErrorComponent.razor
+++ b/ReportingDashboard/Components/Pages/ErrorComponent.razor
@@ -1,0 +1,4 @@
+<!-- Error component stub -->
+<div class="error-component">
+    <!-- Error content will be implemented here -->
+</div>

--- a/ReportingDashboard/Components/Pages/ErrorComponent.razor.css
+++ b/ReportingDashboard/Components/Pages/ErrorComponent.razor.css
@@ -1,0 +1,3 @@
+.error-component {
+    /* Error styles will be implemented here */
+}

--- a/ReportingDashboard/Components/Pages/HeaderComponent.razor
+++ b/ReportingDashboard/Components/Pages/HeaderComponent.razor
@@ -1,0 +1,4 @@
+<!-- Header component stub -->
+<div class="header-component">
+    <!-- Header content will be implemented here -->
+</div>

--- a/ReportingDashboard/Components/Pages/HeaderComponent.razor.css
+++ b/ReportingDashboard/Components/Pages/HeaderComponent.razor.css
@@ -1,0 +1,3 @@
+.header-component {
+    /* Header styles will be implemented here */
+}

--- a/ReportingDashboard/Components/Pages/HeatmapComponent.razor
+++ b/ReportingDashboard/Components/Pages/HeatmapComponent.razor
@@ -1,0 +1,4 @@
+<!-- Heatmap component stub -->
+<div class="heatmap-component">
+    <!-- Heatmap content will be implemented here -->
+</div>

--- a/ReportingDashboard/Components/Pages/HeatmapComponent.razor.css
+++ b/ReportingDashboard/Components/Pages/HeatmapComponent.razor.css
@@ -1,0 +1,3 @@
+.heatmap-component {
+    /* Heatmap styles will be implemented here */
+}

--- a/ReportingDashboard/Components/Pages/TimelineComponent.razor
+++ b/ReportingDashboard/Components/Pages/TimelineComponent.razor
@@ -1,0 +1,4 @@
+<!-- Timeline component stub -->
+<div class="timeline-component">
+    <!-- Timeline content will be implemented here -->
+</div>

--- a/ReportingDashboard/Components/Pages/TimelineComponent.razor.css
+++ b/ReportingDashboard/Components/Pages/TimelineComponent.razor.css
@@ -1,0 +1,3 @@
+.timeline-component {
+    /* Timeline styles will be implemented here */
+}

--- a/ReportingDashboard/Components/_Imports.razor
+++ b/ReportingDashboard/Components/_Imports.razor
@@ -1,0 +1,5 @@
+@using System.ComponentModel.DataAnnotations
+@using ReportingDashboard
+@using ReportingDashboard.Components
+@using ReportingDashboard.Components.Layout
+@using ReportingDashboard.Data

--- a/ReportingDashboard/Data/DashboardData.cs
+++ b/ReportingDashboard/Data/DashboardData.cs
@@ -1,0 +1,50 @@
+namespace ReportingDashboard.Data;
+
+public record DashboardReport
+{
+    public HeaderInfo Header { get; init; } = new();
+    public List<TimelineTrack> TimelineTracks { get; init; } = [];
+    public HeatmapData Heatmap { get; init; } = new();
+}
+
+public record HeaderInfo
+{
+    public string Title { get; init; } = "";
+    public string Subtitle { get; init; } = "";
+    public string BacklogLink { get; init; } = "#";
+    public string ReportDate { get; init; } = "";
+    public string TimelineStartDate { get; init; } = "";
+    public string TimelineEndDate { get; init; } = "";
+    public List<string> TimelineMonths { get; init; } = [];
+}
+
+public record TimelineTrack
+{
+    public string Id { get; init; } = "";
+    public string Name { get; init; } = "";
+    public string Description { get; init; } = "";
+    public string Color { get; init; } = "#999";
+    public List<Milestone> Milestones { get; init; } = [];
+}
+
+public record Milestone
+{
+    public string Label { get; init; } = "";
+    public string Date { get; init; } = "";
+    public string Type { get; init; } = "checkpoint";
+    public string? LabelPosition { get; init; }
+}
+
+public record HeatmapData
+{
+    public List<string> Columns { get; init; } = [];
+    public int HighlightColumnIndex { get; init; }
+    public List<HeatmapRow> Rows { get; init; } = [];
+}
+
+public record HeatmapRow
+{
+    public string Category { get; init; } = "";
+    public string Label { get; init; } = "";
+    public List<List<string>> CellItems { get; init; } = [];
+}

--- a/ReportingDashboard/Data/DashboardDataService.cs
+++ b/ReportingDashboard/Data/DashboardDataService.cs
@@ -1,0 +1,34 @@
+using System.Text.Json;
+
+namespace ReportingDashboard.Data;
+
+public class DashboardDataService
+{
+    private readonly string _filePath;
+
+    public DashboardDataService(IConfiguration config)
+    {
+        _filePath = config.GetValue<string>("DashboardDataPath") ?? "Data/data.json";
+    }
+
+    public async Task<DashboardReport> GetDataAsync()
+    {
+        if (!File.Exists(_filePath))
+        {
+            throw new FileNotFoundException(
+                $"Dashboard data file not found at: {Path.GetFullPath(_filePath)}");
+        }
+
+        try
+        {
+            var json = await File.ReadAllTextAsync(_filePath);
+            var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+            return JsonSerializer.Deserialize<DashboardReport>(json, options)
+                ?? throw new InvalidOperationException("data.json deserialized to null");
+        }
+        catch (JsonException ex)
+        {
+            throw new InvalidOperationException($"Invalid JSON in data.json: {ex.Message}", ex);
+        }
+    }
+}

--- a/ReportingDashboard/Data/data.example.json
+++ b/ReportingDashboard/Data/data.example.json
@@ -1,0 +1,137 @@
+{
+  "header": {
+    "title": "Project Phoenix Release Roadmap",
+    "subtitle": "Engineering Division • Platform Modernization • April 2026",
+    "backlogLink": "https://dev.azure.com/example/projectphoenix/_backlogs/backlog",
+    "reportDate": "2026-04-17",
+    "timelineStartDate": "2026-01-01",
+    "timelineEndDate": "2026-07-01",
+    "timelineMonths": ["Jan", "Feb", "Mar", "Apr", "May", "Jun"]
+  },
+  "timelineTracks": [
+    {
+      "id": "M1",
+      "name": "M1",
+      "description": "Core API & Auth",
+      "color": "#0078D4",
+      "milestones": [
+        {
+          "label": "Jan 15 PoC",
+          "date": "2026-01-15",
+          "type": "poc",
+          "labelPosition": "above"
+        },
+        {
+          "label": "Feb 28 Checkpoint",
+          "date": "2026-02-28",
+          "type": "checkpoint",
+          "labelPosition": "below"
+        },
+        {
+          "label": "Apr 30 Production",
+          "date": "2026-04-30",
+          "type": "production",
+          "labelPosition": "above"
+        }
+      ]
+    },
+    {
+      "id": "M2",
+      "name": "M2",
+      "description": "Data & Reporting",
+      "color": "#00897B",
+      "milestones": [
+        {
+          "label": "Feb 15 PoC",
+          "date": "2026-02-15",
+          "type": "poc",
+          "labelPosition": "above"
+        },
+        {
+          "label": "Apr 15 Checkpoint",
+          "date": "2026-04-15",
+          "type": "checkpoint",
+          "labelPosition": "below"
+        },
+        {
+          "label": "Jun 15 Production",
+          "date": "2026-06-15",
+          "type": "production",
+          "labelPosition": "above"
+        }
+      ]
+    },
+    {
+      "id": "M3",
+      "name": "M3",
+      "description": "Integration & Testing",
+      "color": "#546E7A",
+      "milestones": [
+        {
+          "label": "Mar 1 Checkpoint",
+          "date": "2026-03-01",
+          "type": "checkpoint",
+          "labelPosition": "above"
+        },
+        {
+          "label": "May 1 Checkpoint",
+          "date": "2026-05-01",
+          "type": "checkpoint",
+          "labelPosition": "below"
+        },
+        {
+          "label": "Jun 30 Production",
+          "date": "2026-06-30",
+          "type": "production",
+          "labelPosition": "above"
+        }
+      ]
+    }
+  ],
+  "heatmap": {
+    "columns": ["January", "February", "March", "April"],
+    "highlightColumnIndex": 3,
+    "rows": [
+      {
+        "category": "shipped",
+        "label": "SHIPPED",
+        "cellItems": [
+          ["Auth module", "API v1"],
+          ["Database schema", "Migration tools"],
+          ["Unit tests"],
+          ["Integration tests"]
+        ]
+      },
+      {
+        "category": "in-progress",
+        "label": "IN PROGRESS",
+        "cellItems": [
+          ["Frontend components"],
+          ["API v2", "Caching layer"],
+          ["E2E tests", "Load testing"],
+          ["Performance optimization"]
+        ]
+      },
+      {
+        "category": "carryover",
+        "label": "CARRYOVER",
+        "cellItems": [
+          [],
+          ["Documentation"],
+          ["Admin dashboard"],
+          []
+        ]
+      },
+      {
+        "category": "blockers",
+        "label": "BLOCKERS",
+        "cellItems": [
+          [],
+          ["Dependency on third-party API"],
+          [],
+          ["Database migration risk"]
+        ]
+      }
+    ]
+  }
+}

--- a/ReportingDashboard/Program.cs
+++ b/ReportingDashboard/Program.cs
@@ -1,0 +1,26 @@
+using ReportingDashboard.Data;
+using ReportingDashboard.Components;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.WebHost.ConfigureKestrel(options =>
+{
+    options.ListenLocalhost(5000);
+});
+
+builder.Services.AddRazorComponents();
+builder.Services.AddScoped<DashboardDataService>();
+
+var app = builder.Build();
+
+if (!app.Environment.IsDevelopment())
+{
+    app.UseExceptionHandler("/Error");
+}
+
+app.UseStaticFiles();
+app.UseAntiforgery();
+
+app.MapRazorComponents<App>();
+
+app.Run();

--- a/ReportingDashboard/Properties/launchSettings.json
+++ b/ReportingDashboard/Properties/launchSettings.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "ReportingDashboard": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:5000",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/ReportingDashboard/ReportingDashboard.csproj
+++ b/ReportingDashboard/ReportingDashboard.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/ReportingDashboard/appsettings.json
+++ b/ReportingDashboard/appsettings.json
@@ -1,0 +1,10 @@
+{
+  "DashboardDataPath": "Data/data.json",
+  "Logging": {
+    "LogLevel": {
+      "Default": "Warning",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/ReportingDashboard/wwwroot/css/app.css
+++ b/ReportingDashboard/wwwroot/css/app.css
@@ -1,0 +1,39 @@
+*,
+*::before,
+*::after {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+html,
+body {
+    width: 1920px;
+    height: 1080px;
+    margin: 0;
+    padding: 0;
+    overflow: hidden;
+}
+
+body {
+    background: #FFFFFF;
+    font-family: 'Segoe UI', -apple-system, Arial, sans-serif;
+    color: #111;
+}
+
+a {
+    color: #0078D4;
+    text-decoration: none;
+}
+
+a:hover {
+    text-decoration: underline;
+}
+
+#blazor-error-ui {
+    display: none !important;
+}
+
+Routes {
+    display: contents;
+}

--- a/tests/ReportingDashboard.Tests/Integration/DashboardDataServiceIntegrationTests.cs
+++ b/tests/ReportingDashboard.Tests/Integration/DashboardDataServiceIntegrationTests.cs
@@ -1,0 +1,182 @@
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using ReportingDashboard.Data;
+using Xunit;
+
+namespace ReportingDashboard.Tests.Integration;
+
+[Trait("Category", "Integration")]
+public class DashboardDataServiceIntegrationTests
+{
+    [Fact]
+    public async Task GetDataAsync_WithRealDataFile_DeserializesCompleteStructure()
+    {
+        // Arrange
+        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(tempDir);
+        var dataFile = Path.Combine(tempDir, "data.json");
+
+        var sampleData = """
+            {
+              "header": {
+                "title": "Project Phoenix",
+                "subtitle": "Engineering Division",
+                "backlogLink": "https://ado.example.com/backlog",
+                "reportDate": "2026-04",
+                "timelineStartDate": "2026-01-01",
+                "timelineEndDate": "2026-06-30",
+                "timelineMonths": ["Jan", "Feb", "Mar", "Apr", "May", "Jun"]
+              },
+              "timelineTracks": [
+                {
+                  "id": "M1",
+                  "name": "Platform",
+                  "description": "Core platform work",
+                  "color": "#4285F4",
+                  "milestones": [
+                    {"label": "Alpha", "date": "2026-02-15", "type": "poc", "labelPosition": "top"}
+                  ]
+                }
+              ],
+              "heatmap": {
+                "columns": ["Jan", "Feb", "Mar", "Apr"],
+                "highlightColumnIndex": 3,
+                "rows": [
+                  {"category": "shipped", "label": "Shipped Items", "cellItems": [["item1"], ["item2"], [], []]}
+                ]
+              }
+            }
+            """;
+
+        await File.WriteAllTextAsync(dataFile, sampleData);
+
+        var configBuilder = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                { "DashboardDataPath", dataFile }
+            });
+        var config = configBuilder.Build();
+        var service = new DashboardDataService(config);
+
+        // Act
+        var result = await service.GetDataAsync();
+
+        // Assert
+        result.Header.Title.Should().Be("Project Phoenix");
+        result.Header.Subtitle.Should().Be("Engineering Division");
+        result.Header.TimelineMonths.Should().HaveCount(6);
+        result.TimelineTracks.Should().HaveCount(1);
+        result.TimelineTracks[0].Id.Should().Be("M1");
+        result.TimelineTracks[0].Milestones.Should().HaveCount(1);
+        result.Heatmap.Columns.Should().HaveCount(4);
+        result.Heatmap.HighlightColumnIndex.Should().Be(3);
+        result.Heatmap.Rows.Should().HaveCount(1);
+
+        Directory.Delete(tempDir, true);
+    }
+
+    [Fact]
+    public async Task GetDataAsync_WithConfigurationFromBuilder_SuccessfullyLoadsData()
+    {
+        // Arrange
+        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(tempDir);
+        var appSettingsFile = Path.Combine(tempDir, "appsettings.json");
+        var dataFile = Path.Combine(tempDir, "data.json");
+
+        var appSettingsJson = $$"""
+            {
+              "DashboardDataPath": "{{dataFile.Replace("\\", "\\\\")}}"
+            }
+            """;
+
+        var dataJson = """
+            {
+              "header": {"title": "Config Test", "subtitle": "", "backlogLink": "#", "reportDate": "", "timelineStartDate": "", "timelineEndDate": "", "timelineMonths": []},
+              "timelineTracks": [],
+              "heatmap": {"columns": [], "highlightColumnIndex": 0, "rows": []}
+            }
+            """;
+
+        await File.WriteAllTextAsync(appSettingsFile, appSettingsJson);
+        await File.WriteAllTextAsync(dataFile, dataJson);
+
+        var configBuilder = new ConfigurationBuilder()
+            .AddJsonFile(appSettingsFile);
+        var config = configBuilder.Build();
+        var service = new DashboardDataService(config);
+
+        // Act
+        var result = await service.GetDataAsync();
+
+        // Assert
+        result.Header.Title.Should().Be("Config Test");
+
+        Directory.Delete(tempDir, true);
+    }
+
+    [Fact]
+    public async Task GetDataAsync_WithNestedComplexData_PreservesHierarchy()
+    {
+        // Arrange
+        var tempFile = Path.Combine(Path.GetTempPath(), "complex-data.json");
+
+        var complexData = """
+            {
+              "header": {"title": "Complex", "subtitle": "Test", "backlogLink": "link", "reportDate": "date", "timelineStartDate": "start", "timelineEndDate": "end", "timelineMonths": ["M1", "M2"]},
+              "timelineTracks": [
+                {
+                  "id": "T1",
+                  "name": "Track 1",
+                  "description": "Description",
+                  "color": "#ABC",
+                  "milestones": [
+                    {"label": "M1", "date": "2026-01-01", "type": "production", "labelPosition": "bottom"},
+                    {"label": "M2", "date": "2026-02-01", "type": "checkpoint"}
+                  ]
+                },
+                {
+                  "id": "T2",
+                  "name": "Track 2",
+                  "description": "Desc2",
+                  "color": "#DEF",
+                  "milestones": []
+                }
+              ],
+              "heatmap": {
+                "columns": ["Col1", "Col2", "Col3"],
+                "highlightColumnIndex": 1,
+                "rows": [
+                  {"category": "shipped", "label": "Shipped", "cellItems": [["a", "b"], ["c"], []]},
+                  {"category": "blocked", "label": "Blocked", "cellItems": [[], ["x"], ["y", "z"]]}
+                ]
+              }
+            }
+            """;
+
+        await File.WriteAllTextAsync(tempFile, complexData);
+
+        var configMock = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                { "DashboardDataPath", tempFile }
+            })
+            .Build();
+        var service = new DashboardDataService(configMock);
+
+        // Act
+        var result = await service.GetDataAsync();
+
+        // Assert
+        result.TimelineTracks.Should().HaveCount(2);
+        result.TimelineTracks[0].Milestones.Should().HaveCount(2);
+        result.TimelineTracks[0].Milestones[0].Type.Should().Be("production");
+        result.TimelineTracks[0].Milestones[0].LabelPosition.Should().Be("bottom");
+        result.TimelineTracks[1].Milestones.Should().BeEmpty();
+        result.Heatmap.Rows.Should().HaveCount(2);
+        result.Heatmap.Rows[0].CellItems[0].Should().HaveCount(2);
+        result.Heatmap.Rows[1].CellItems[2].Should().HaveCount(2);
+
+        File.Delete(tempFile);
+    }
+}

--- a/tests/ReportingDashboard.Tests/ReportingDashboard.Tests.csproj
+++ b/tests/ReportingDashboard.Tests/ReportingDashboard.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="bunit" Version="1.28.9" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="xunit" Version="2.7.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\ReportingDashboard\ReportingDashboard.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/ReportingDashboard.Tests/Unit/DashboardDataModelTests.cs
+++ b/tests/ReportingDashboard.Tests/Unit/DashboardDataModelTests.cs
@@ -1,0 +1,76 @@
+using FluentAssertions;
+using ReportingDashboard.Data;
+using Xunit;
+
+namespace ReportingDashboard.Tests.Unit;
+
+[Trait("Category", "Unit")]
+public class DashboardDataModelTests
+{
+    [Fact]
+    public void DashboardReport_DefaultConstructor_HasDefaultValues()
+    {
+        // Act
+        var report = new DashboardReport();
+
+        // Assert
+        report.Header.Should().NotBeNull();
+        report.TimelineTracks.Should().NotBeNull().And.BeEmpty();
+        report.Heatmap.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void HeaderInfo_DefaultConstructor_HasEmptyStringDefaults()
+    {
+        // Act
+        var header = new HeaderInfo();
+
+        // Assert
+        header.Title.Should().Be("");
+        header.Subtitle.Should().Be("");
+        header.BacklogLink.Should().Be("#");
+        header.ReportDate.Should().Be("");
+        header.TimelineStartDate.Should().Be("");
+        header.TimelineEndDate.Should().Be("");
+        header.TimelineMonths.Should().NotBeNull().And.BeEmpty();
+    }
+
+    [Fact]
+    public void TimelineTrack_DefaultConstructor_HasEmptyValuesAndDefaultColor()
+    {
+        // Act
+        var track = new TimelineTrack();
+
+        // Assert
+        track.Id.Should().Be("");
+        track.Name.Should().Be("");
+        track.Description.Should().Be("");
+        track.Color.Should().Be("#999");
+        track.Milestones.Should().NotBeNull().And.BeEmpty();
+    }
+
+    [Fact]
+    public void Milestone_DefaultConstructor_HasDefaults()
+    {
+        // Act
+        var milestone = new Milestone();
+
+        // Assert
+        milestone.Label.Should().Be("");
+        milestone.Date.Should().Be("");
+        milestone.Type.Should().Be("checkpoint");
+        milestone.LabelPosition.Should().BeNull();
+    }
+
+    [Fact]
+    public void HeatmapData_DefaultConstructor_HasEmptyDefaults()
+    {
+        // Act
+        var heatmap = new HeatmapData();
+
+        // Assert
+        heatmap.Columns.Should().NotBeNull().And.BeEmpty();
+        heatmap.HighlightColumnIndex.Should().Be(0);
+        heatmap.Rows.Should().NotBeNull().And.BeEmpty();
+    }
+}

--- a/tests/ReportingDashboard.Tests/Unit/DashboardDataServiceTests.cs
+++ b/tests/ReportingDashboard.Tests/Unit/DashboardDataServiceTests.cs
@@ -1,0 +1,124 @@
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using ReportingDashboard.Data;
+using Xunit;
+
+namespace ReportingDashboard.Tests.Unit;
+
+[Trait("Category", "Unit")]
+public class DashboardDataServiceTests
+{
+    [Fact]
+    public async Task GetDataAsync_WithValidJsonFile_ReturnsDashboardReport()
+    {
+        // Arrange
+        var tempFile = Path.Combine(Path.GetTempPath(), "test-data.json");
+        var validJson = """
+            {
+              "header": {"title": "Test", "subtitle": "Sub", "backlogLink": "#", "reportDate": "2026-04", "timelineStartDate": "2026-01-01", "timelineEndDate": "2026-04-30", "timelineMonths": ["Jan", "Feb", "Mar", "Apr"]},
+              "timelineTracks": [],
+              "heatmap": {"columns": [], "highlightColumnIndex": 0, "rows": []}
+            }
+            """;
+        await File.WriteAllTextAsync(tempFile, validJson);
+
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                { "DashboardDataPath", tempFile }
+            })
+            .Build();
+        var service = new DashboardDataService(config);
+
+        // Act
+        var result = await service.GetDataAsync();
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Header.Title.Should().Be("Test");
+        result.Header.Subtitle.Should().Be("Sub");
+        result.TimelineTracks.Should().BeEmpty();
+        result.Heatmap.Columns.Should().BeEmpty();
+
+        File.Delete(tempFile);
+    }
+
+    [Fact]
+    public async Task GetDataAsync_WithMissingFile_ThrowsFileNotFoundException()
+    {
+        // Arrange
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                { "DashboardDataPath", "/nonexistent/path/data.json" }
+            })
+            .Build();
+        var service = new DashboardDataService(config);
+
+        // Act & Assert
+        var act = () => service.GetDataAsync();
+        await act.Should().ThrowAsync<FileNotFoundException>()
+            .WithMessage("*Dashboard data file not found*");
+    }
+
+    [Fact]
+    public async Task GetDataAsync_WithInvalidJson_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var tempFile = Path.Combine(Path.GetTempPath(), "invalid-data.json");
+        await File.WriteAllTextAsync(tempFile, "{invalid json}");
+
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                { "DashboardDataPath", tempFile }
+            })
+            .Build();
+        var service = new DashboardDataService(config);
+
+        // Act & Assert
+        var act = () => service.GetDataAsync();
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*Invalid JSON in data.json*");
+
+        File.Delete(tempFile);
+    }
+
+    [Fact]
+    public void Constructor_WithoutConfigDashboardDataPath_UsesDefaultPath()
+    {
+        // Arrange
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>())
+            .Build();
+
+        // Act
+        var service = new DashboardDataService(config);
+
+        // Assert
+        service.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task GetDataAsync_WithNullDeserialization_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var tempFile = Path.Combine(Path.GetTempPath(), "null-data.json");
+        await File.WriteAllTextAsync(tempFile, "null");
+
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                { "DashboardDataPath", tempFile }
+            })
+            .Build();
+        var service = new DashboardDataService(config);
+
+        // Act & Assert
+        var act = () => service.GetDataAsync();
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*data.json deserialized to null*");
+
+        File.Delete(tempFile);
+    }
+}


### PR DESCRIPTION
## Task Assignment
**Assigned To:** SoftwareEngineer
**Complexity:** High
**Branch:** `agent/softwareengineer/t1-project-foundation-scaffolding`

## Requirements
Closes #1737

# PR: Project Foundation & Scaffolding

## Summary

This PR establishes the complete project foundation for the Executive Reporting Dashboard, a single-page Blazor Server (.NET 8) application for rendering executive status reports as screenshot-optimized dashboards.

The PR creates:
- **Project structure:** Solution file, project file, directory layout (Components/, Data/, wwwroot/)
- **Blazor configuration:** App.razor, MainLayout, _Imports.razor, Static SSR setup in Program.cs
- **Data models:** DashboardData.cs with record types (DashboardReport, HeaderInfo, TimelineTrack, Milestone, HeatmapData, HeatmapRow)
- **Core service:** DashboardDataService (scoped) for reading data.json
- **Stub components:** Empty Dashboard, HeaderComponent, TimelineComponent, HeatmapComponent, ErrorComponent (placeholders for parallel work)
- **Styling:** Global app.css (resets) and scoped .razor.css files for each component
- **Configuration:** appsettings.json, launchSettings.json, data.example.json
- **.gitignore:** .NET 8 build artifacts, user secrets, data files

After merge, `dotnet run` compiles and starts successfully with no stub components implemented. All parallel tasks can begin work immediately with clear file ownership and component boundaries.

---

## Acceptance Criteria

- [ ] Solution file `ReportingDashboard.sln` exists at repo root
- [ ] Project file `ReportingDashboard/ReportingDashboard.csproj` targets `net8.0` with nullable enable and implicit usings
- [ ] `Program.cs` registers Blazor components (Static SSR, no SignalR), configures Kestrel for `127.0.0.1:5000`, registers `DashboardDataService` as scoped, maps `App` as root component
- [ ] `DashboardData.cs` defines all record types: `DashboardReport`, `HeaderInfo`, `TimelineTrack`, `Milestone`, `HeatmapData`, `HeatmapRow` with default values and JSON-friendly property names
- [ ] `DashboardDataService.cs` implements `GetDataAsync()` returning `DashboardReport?`, reads from configurable path (default `Data/data.json`), catches `JsonException`/`FileNotFoundException`/`InvalidOperationException` and throws with user-friendly message
- [ ] `App.razor` includes DOCTYPE, links `css/app.css`, links Blazor scoped CSS bundle, hides `#blazor-error-ui` with `display:none`, uses `MainLayout` as default
- [ ] `MainLayout.razor` contains only `<main>@Body</main>`; scoped CSS sets `main` to `width: 1920px; height: 1080px; overflow: hidden`
- [ ] `_Imports.razor` has required using directives for Blazor and Microsoft namespaces
- [ ] `Dashboard.razor` at route `/` (page placeholder, empty markup for now)
- [ ] `app.css` resets all margins/padding, sets `body` to `1920x1080`, `overflow: hidden`, font stack `'Segoe UI', Arial, sans-serif`, hides error UI
- [ ] `data.example.json` contains valid fictional Project Phoenix data with all schema fields populated
- [ ] `.gitignore` includes `.NET` patterns: `bin/`, `obj/`, `*.user`, `user secrets, `Data/data.json` (real data), keeps `data.example.json`
- [ ] All component files (HeaderComponent, TimelineComponent, HeatmapComponent, ErrorComponent) exist as empty stubs with `@code {}` block and corresponding `.razor.css` files
- [ ] `dotnet build` compiles with zero warnings
- [ ] `dotnet run` starts without errors; `http://localhost:5000` returns a blank 1920x1080 white page (empty Dashboard.razor renders)
- [ ] File count: exactly 23 created files (as listed in File Plan)

---

## Implementation Steps

### Step 1: Scaffolding - Create Solution, Project, Configuration, and Directory Structure

**Produces:** 
- `ReportingDashboard.sln`
- `ReportingDashboard/ReportingDashboard.csproj` (net8.0, nullable enable, implicit usings)
- `ReportingDashboard/Properties/launchSettings.json` (localhost:5000)
- `ReportingDashboard/appsettings.json` (DashboardDataPath setting)
- Complete directory structure: `Components/`, `Components/Layout/`, `Components/Pages/`, `Data/`, `wwwroot/css/`
- `.gitignore` (.NET patterns, Data/data.json, but include data.example.json)

**Scope:** Project file setup only; no Razor or C# implementation yet.

**Verification:** `dotnet build` compiles without errors (no components exist yet, project file is valid).

---

### Step 2: Blazor Core Infrastructure - Program.cs, App.razor, MainLayout, _Imports.razor

**Produces:**
- `Program.cs`: Kestrel binding to `127.0.0.1:5000`, `AddRazorComponents()` (Static SSR only), `AddScoped<DashboardDataService>()` registration, static files, antiforgery, `MapRazorComponents<App>` with no interactive render mode
- `App.razor`: Minimal HTML shell with DOCTYPE, `<html>/<head>/<body>`, link to `css/app.css`, link to Blazor scoped CSS bundle, script `_framework/blazor.web.js`, hide `#blazor-error-ui`
- `MainLayout.razor`: `@inherits LayoutComponentBase`, wraps `@Body` in `<main>` element
- `MainLayout.razor.css`: Sets `main` to fixed `1920x1080`, `overflow: hidden`, flexbox column
- `_Imports.razor`: Global using directives for Blazor, Microsoft namespaces, layout imports

**Scope:** Framework configuration only.

**Verification:** `dotnet run` starts successfully; `http://localhost:5000` loads (blank, because Dashboard.razor is empty).

---

### Step 3: Data Models and Service - DashboardData.cs, DashboardDataService.cs

**Produces:**
- `DashboardData.cs`: C# record types with default values:
  - `DashboardReport` (Header, TimelineTracks[], Heatmap)
  - `HeaderInfo` (Title, Subtitle, BacklogLink, ReportDate, TimelineStartDate, TimelineEndDate, TimelineMonths[])
  - `TimelineTrack` (Id, Name, Description, Color, Milestones[])
  - `Milestone` (Label, Date, Type, LabelPosition)
  - `HeatmapData` (Columns[], HighlightColumnIndex, Rows[])
  - `HeatmapRow` (Category, Label, CellItems[][])
- `DashboardDataService.cs`: Scoped service with `GetDataAsync()` method, reads file from `IConfiguration` path, deserializes with `System.Text.Json` (PropertyNameCaseInsensitive), catches exceptions and throws with user-friendly messages

**Scope:** Data layer only; no UI consumption yet.

**Verification:** `dotnet build` compiles; `new DashboardReport()` instantiates with default values.

---

### Step 4: Sample Data and Configuration - data.example.json, appsettings.json

**Produces:**
- `data.example.json`: Fictional "Project Phoenix Release Roadmap" with all schema fields:
  - Header: title, subtitle, backlogLink, reportDate, timelineStartDate, timelineEndDate, timelineMonths
  - 3 TimelineTrack items (M1, M2, M3) with 2-3 milestones each (mix of checkpoint, poc, production types)
  - Heatmap: 4 columns (Jan-Apr), highlightColumnIndex=3, 4 rows (shipped, in-progress, carryover, blockers) with varied cellItems
- `appsettings.json`: DashboardDataPath setting, Logging configuration

**Scope:** Data files; static configuration.

**Verification:** `data.example.json` is valid JSON; parses to DashboardReport with no null fields.

---

### Step 5: Global and Component Stylesheet Stubs - app.css, Component .razor.css Files

**Produces:**
- `wwwroot/css/app.css`: CSS reset (margin/padding 0), body fixed 1920x1080, overflow hidden, font stack, color #111, #blazor-error-ui hidden
- `Dashboard.razor.css`: Scoped CSS stub (empty for now)
- `HeaderComponent.razor.css`, `TimelineComponent.razor.css`, `HeatmapComponent.razor.css`, `ErrorComponent.razor.css`: Empty stubs

**Scope:** Styling infrastructure; no visual implementation yet.

**Verification:** `dotnet run` page loads; page is white (no styles applied to empty components yet).

---

### Step 6: Component Stubs - Dashboard, Header, Timeline, Heatmap, Error Components

**Produces:**
- `Dashboard.razor`: `@page "/"`, `@layout MainLayout`, empty `@code { }` block (no implementation)
- `HeaderComponent.razor`: Empty Razor markup, `@code { }` block
- `TimelineComponent.razor`: Empty Razor markup, `@code { }` block
- `HeatmapComponent.razor`: Empty Razor markup, `@code { }` block
- `ErrorComponent.razor`: Empty Razor markup, `@code { }` block
- Corresponding `.razor.css` files for each component

**Scope:** Component structure and placeholders; full implementation deferred to parallel tasks.

**Verification:** 
- `dotnet build` compiles all component files with zero warnings
- `dotnet run` starts and renders blank 1920x1080 white page
- All files exist with correct namespaces and file paths per File Plan
- No null reference errors during page load (empty stubs are valid Razor)

---

## Testing

### Manual Verification (MVP has no unit tests)

1. **Build and Start:**
   - Run `dotnet build ReportingDashboard.sln` → zero warnings, output contains `ReportingDashboard.dll`
   - Run `dotnet run` → output logs "Now listening on http://127.0.0.1:5000"

2. **Page Load:**
   - Navigate to `http://localhost:5000`
   - Page renders within < 1 second
   - Page is white background, 1920x1080 fixed viewport
   - No scrollbars, no browser zoom needed
   - No Blazor error boundaries, no "reconnecting" banners

3. **File Structure:**
   - `ReportingDashboard.sln` opens in Visual Studio
   - All 23 files exist in correct paths
   - `.gitignore` excludes `bin/`, `obj/`, `Data/data.json` but includes `data.example.json`
   - No build artifacts in source tree after `dotnet clean`

4. **Data Model Validation:**
   - `DashboardDataService.GetDataAsync()` called on test data
   - Returns `DashboardReport` instance with non-null properties
   - Handles missing file gracefully (throws `FileNotFoundException`)
   - Handles malformed JSON gracefully (throws `JsonException`)

5. **Configuration:**
   - `appsettings.json` is valid JSON
   - `DashboardDataPath` setting reads correctly via `IConfiguration`
   - `data.example.json` deserializes to `DashboardReport` without null fields

### Checklist for Parallel Work

After this PR merges, each parallel task can verify:
- [ ] Component files exist and compile
- [ ] Services can be injected via DI (`@inject DashboardDataService`)
- [ ] Models instantiate with default values
- [ ] No blocking file conflicts exist

---

## Notes

- **Scoped Service Lifetime:** `DashboardDataService` is scoped (not singleton) to re-read `data.json` on each request, supporting edit-and-F5 workflows.
- **Static SSR:** No SignalR connection; eliminates reconnection UI issues for a read-only dashboard.
- **Empty Components:** Dashboard, Header, Timeline, Heatmap, Error components are intentionally empty stubs to enable parallel implementation by multiple engineers without merge conflicts.
- **File Ownership:** Each file in the File Plan is owned by T1; subsequent tasks only *consume* these files, never create or modify them (except where explicitly noted in task dependencies).
- **Verification Command:** `dotnet run` followed by browser visit to `http://localhost:5000` should complete in < 60 seconds and show a blank white 1920x1080 page.

## References
- Architecture: Architecture.md
- PM Spec: 

## Status
- [ ] Implementation
- [ ] Tests Written
- [ ] Ready for Review