### PR TITLE
SoftwareEngineer 1: Build Dashboard Header with Legend

### DIFF
--- a/ReportingDashboard/Components/Pages/Dashboard.razor
+++ b/ReportingDashboard/Components/Pages/Dashboard.razor
@@ -2,8 +2,8 @@
 @using ReportingDashboard.Data
 @inject DashboardDataService DataService
 
-<div class="dash-wrap" style="display:flex;flex-direction:column;width:1920px;height:1080px;overflow:hidden">
-    @if (ErrorMessage != null)
+<div class="dash-wrap" style="display:flex;flex-direction:column;width:1920px;height:1080px;overflow:hidden;">
+    @if (ErrorMessage is not null)
     {
         <div class="error-container">
             <h2>Unable to load dashboard data</h2>
@@ -11,9 +11,21 @@
             <p class="error-detail">@ErrorMessage</p>
         </div>
     }
-    else
+    else if (Data is not null)
     {
         <!-- HDR-SLOT -->
+        <div class="hdr">
+            <div>
+                <h1 class="hdr-title">@Data.Header.Title <a href="@Data.Header.BacklogLink" target="_blank">&#128279; ADO Backlog</a></h1>
+                <div class="sub">@Data.Header.Subtitle</div>
+            </div>
+            <div class="legend">
+                <span class="legend-item"><span class="legend-diamond poc"></span>PoC Milestone</span>
+                <span class="legend-item"><span class="legend-diamond prod"></span>Production Release</span>
+                <span class="legend-item"><span class="legend-circle"></span>Checkpoint</span>
+                <span class="legend-item"><span class="legend-now-bar"></span>Now</span>
+            </div>
+        </div>
         <!-- TL-SLOT -->
         <!-- HM-SLOT -->
     }

--- a/tests/ReportingDashboard.UITests/DashboardHeaderUITests.cs
+++ b/tests/ReportingDashboard.UITests/DashboardHeaderUITests.cs
@@ -1,0 +1,138 @@
+using Microsoft.Playwright;
+using Xunit;
+
+namespace ReportingDashboard.UITests;
+
+[Trait("Category", "UI")]
+[Collection("Playwright")]
+public class DashboardHeaderUITests
+{
+    private readonly PlaywrightFixture _fixture;
+
+    public DashboardHeaderUITests(PlaywrightFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    private async Task<IPage> NewPageAsync()
+    {
+        var page = await _fixture.Browser.NewPageAsync(new BrowserNewPageOptions
+        {
+            ViewportSize = new ViewportSize { Width = 1920, Height = 1080 }
+        });
+        page.SetDefaultTimeout(60000);
+        return page;
+    }
+
+    [Fact]
+    public async Task Header_HdrElement_IsPresent_WhenDataLoads()
+    {
+        var page = await NewPageAsync();
+        await page.GotoAsync(_fixture.BaseUrl);
+        await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        var hdr = page.Locator(".hdr");
+        var count = await hdr.CountAsync();
+
+        // Only assert header present if no error state
+        var errorCount = await page.Locator(".error-container").CountAsync();
+        if (errorCount == 0)
+        {
+            Assert.Equal(1, count);
+        }
+
+        await page.CloseAsync();
+    }
+
+    [Fact]
+    public async Task Header_H1Title_IsRendered_WhenDataLoads()
+    {
+        var page = await NewPageAsync();
+        await page.GotoAsync(_fixture.BaseUrl);
+        await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        var errorCount = await page.Locator(".error-container").CountAsync();
+        if (errorCount == 0)
+        {
+            var h1 = page.Locator(".hdr-title");
+            Assert.Equal(1, await h1.CountAsync());
+
+            var text = await h1.TextContentAsync();
+            Assert.False(string.IsNullOrWhiteSpace(text), "h1.hdr-title should have non-empty text content");
+        }
+
+        await page.CloseAsync();
+    }
+
+    [Fact]
+    public async Task Header_ADOBacklogLink_HasTargetBlank_WhenDataLoads()
+    {
+        var page = await NewPageAsync();
+        await page.GotoAsync(_fixture.BaseUrl);
+        await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        var errorCount = await page.Locator(".error-container").CountAsync();
+        if (errorCount == 0)
+        {
+            var link = page.Locator(".hdr-title a");
+            Assert.Equal(1, await link.CountAsync());
+
+            var target = await link.GetAttributeAsync("target");
+            Assert.Equal("_blank", target);
+
+            var href = await link.GetAttributeAsync("href");
+            Assert.False(string.IsNullOrWhiteSpace(href), "ADO Backlog link must have a non-empty href");
+        }
+
+        await page.CloseAsync();
+    }
+
+    [Fact]
+    public async Task Header_Legend_HasExactlyFourItems_WhenDataLoads()
+    {
+        var page = await NewPageAsync();
+        await page.GotoAsync(_fixture.BaseUrl);
+        await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        var errorCount = await page.Locator(".error-container").CountAsync();
+        if (errorCount == 0)
+        {
+            var legendItems = page.Locator(".legend .legend-item");
+            Assert.Equal(4, await legendItems.CountAsync());
+
+            var texts = new[]
+            {
+                await legendItems.Nth(0).TextContentAsync(),
+                await legendItems.Nth(1).TextContentAsync(),
+                await legendItems.Nth(2).TextContentAsync(),
+                await legendItems.Nth(3).TextContentAsync(),
+            };
+
+            Assert.Contains("PoC Milestone", texts[0]);
+            Assert.Contains("Production Release", texts[1]);
+            Assert.Contains("Checkpoint", texts[2]);
+            Assert.Contains("Now", texts[3]);
+        }
+
+        await page.CloseAsync();
+    }
+
+    [Fact]
+    public async Task Header_LegendShapeClasses_ArePresent_WhenDataLoads()
+    {
+        var page = await NewPageAsync();
+        await page.GotoAsync(_fixture.BaseUrl);
+        await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        var errorCount = await page.Locator(".error-container").CountAsync();
+        if (errorCount == 0)
+        {
+            Assert.Equal(1, await page.Locator(".legend-diamond.poc").CountAsync());
+            Assert.Equal(1, await page.Locator(".legend-diamond.prod").CountAsync());
+            Assert.Equal(1, await page.Locator(".legend-circle").CountAsync());
+            Assert.Equal(1, await page.Locator(".legend-now-bar").CountAsync());
+        }
+
+        await page.CloseAsync();
+    }
+}


### PR DESCRIPTION
## Task Assignment
**Assigned To:** SoftwareEngineer 1
**Complexity:** Medium
**Branch:** `agent/softwareengineer-1/t-1760-build-dashboard-header-with-legend`

## Requirements
Closes #1760

## T3: Build Dashboard Header with Legend

### Summary

Fills in the `<!-- HDR-SLOT -->` placeholder in `ReportingDashboard/Components/Pages/Dashboard.razor` with the complete header bar section (`.hdr`). The header renders two flex children: a left side with the project title (`<h1>`), an inline ADO Backlog link, and a subtitle line — all bound to `Data.Header`; and a right side legend with four statically-rendered symbol+label pairs (PoC diamond, Production diamond, Checkpoint circle, Now bar). All CSS classes (`.hdr`, `.sub`, `.legend`, `.legend-diamond`, `.legend-circle`, `.legend-now-bar`, `.poc`, `.prod`) are consumed from the already-existing `Dashboard.razor.css` and must not be modified.

---

### Acceptance Criteria

- [ ] Project title from `Data.Header.Title` renders in the `<h1 class="hdr-title">` element — visually 24px bold at top-left
- [ ] Subtitle from `Data.Header.Subtitle` renders in `<div class="sub">` at 12px `#888` below the title
- [ ] "🔗 ADO Backlog" link uses `href="@Data.Header.BacklogLink"` and `target="_blank"` — renders in `#0078D4`, opens a new tab
- [ ] No hardcoded text appears in the header markup — every string is from `Data.Header.*`
- [ ] Right-side legend contains exactly four items in order: PoC Milestone, Production Release, Checkpoint, Now
- [ ] PoC legend item: `<span class="legend-diamond poc">` (gold `#F4B400`, 12×12px rotated square) + label "PoC Milestone"
- [ ] Production legend item: `<span class="legend-diamond prod">` (green `#34A853`) + label "Production Release"
- [ ] Checkpoint legend item: `<span class="legend-circle">` (gray `#999`, 8×8px circle) + label "Checkpoint"
- [ ] Now legend item: `<span class="legend-now-bar">` (red `#EA4335`, 2×14px bar) + label "Now"
- [ ] Legend items are right-aligned, 12px font, 22px gap between items
- [ ] Header has `1px solid #E0E0E0` bottom border and `12px 44px 10px` padding (from `.hdr` CSS class)
- [ ] Full-page screenshot at 1920×1080 matches the header section of `OriginalDesignConcept.html` pixel-for-pixel
- [ ] `Dashboard.razor.css` is not modified by this PR

---

### Implementation Steps

1. **Verify slot and CSS prerequisites**
   Confirm `<!-- HDR-SLOT -->` exists in `Dashboard.razor` and that `Dashboard.razor.css` already defines `.hdr`, `.sub`, `.legend`, `.legend-diamond`, `.legend-circle`, `.legend-now-bar`, `.poc`, `.prod`. Confirm `Data` field is non-null at render time (depends on T6 outer structure). No files are modified in this step — it is a read-only verification commit that adds a comment documenting the dependency contract.

2. **Implement the header Razor markup**
   Replace `<!-- HDR-SLOT -->` with the complete `.hdr` section:
   ```razor
   <div class="hdr">
     <div>
       <h1 class="hdr-title">
         @Data!.Header.Title
         <a href="@Data.Header.BacklogLink" target="_blank">&#128279; ADO Backlog</a>
       </h1>
       <div class="sub">@Data.Header.Subtitle</div>
     </div>
     <div class="legend">
       <span><span class="legend-diamond poc"></span>PoC Milestone</span>
       <span><span class="legend-diamond prod"></span>Production Release</span>
       <span><span class="legend-circle"></span>Checkpoint</span>
       <span><span class="legend-now-bar"></span>Now</span>
     </div>
   </div>
   ```
   Only `Dashboard.razor` is modified. Build must succeed with `dotnet build`.

3. **Visual verification and screenshot comparison**
   Run `dotnet run`, navigate to `http://localhost:5000` in Chrome/Edge at 1920×1080. Use DevTools Device Toolbar to set exact viewport. Capture a full-size screenshot. Overlay or side-by-side compare against `OriginalDesignConcept.html` rendered in browser. Fix any spacing, alignment, or color discrepancies by adjusting only the Razor markup (class names, element nesting) — not the CSS file. Commit the passing screenshot to `docs/design-screenshots/header-verification.png` as a review artifact.

---

### Testing

Since unit and component tests are out of scope for MVP, verification is manual:

- **Data binding:** Temporarily change `title`, `subtitle`, and `backlogLink` in `data.json`, refresh with F5 — header must reflect new values with no code change
- **Link behavior:** Click "🔗 ADO Backlog" — must open the URL from `data.json` in a new tab; original tab unchanged
- **Legend rendering:** Inspect each legend item in DevTools — verify computed color, size, and transform on each shape span matches spec (`#F4B400` PoC, `#34A853` prod, `#999` checkpoint, `#EA4335` now bar)
- **No hardcoded text:** Search `Dashboard.razor` for any string literal that should come from data (title, subtitle, backlog URL) — none should be present
- **Screenshot fidelity at 1920×1080:** Full-page capture must show header with correct padding (`44px` horizontal), bottom border, font sizes, and legend alignment — no visual diff against `OriginalDesignConcept.html` header section
- **Error path:** With `data.json` deleted, navigate to `/` — error container must render instead of header (verifies the null-guard on `Data` still holds after this change)
- **No CSS regression:** Confirm `Dashboard.razor.css` diff is empty — `git diff ReportingDashboard/Components/Pages/Dashboard.razor.css` must show no changes

## References
- Architecture: Architecture.md
- PM Spec: 

## Status
- [ ] Implementation
- [ ] Tests Written
- [ ] Ready for Review