### PR TITLE
SoftwareEngineer: Project Foundation & Scaffolding

### DIFF
--- a/.agentsquad/project-foundation-scaffolding.task
+++ b/.agentsquad/project-foundation-scaffolding.task
@@ -1,0 +1,4 @@
+agent: SoftwareEngineer
+task: Project Foundation & Scaffolding
+complexity: Medium
+status: in-progress

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = crlf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+
+[*.{json,yml,yaml,razor,cshtml,html,css,md}]
+indent_size = 2
+
+[*.cs]
+dotnet_sort_system_directives_first = true
+csharp_new_line_before_open_brace = all
+csharp_style_namespace_declarations = file_scoped:suggestion
+dotnet_style_qualification_for_field = false:suggestion
+dotnet_style_qualification_for_property = false:suggestion

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,64 @@
+## .NET
+bin/
+obj/
+out/
+*.user
+*.suo
+*.userosscache
+*.sln.docstates
+*.userprefs
+
+## Visual Studio / Rider / VS Code
+.vs/
+.vscode/
+.idea/
+*.swp
+*.swo
+
+## Build results
+[Dd]ebug/
+[Rr]elease/
+x64/
+x86/
+[Ww][Ii][Nn]32/
+[Aa][Rr][Mm]/
+[Aa][Rr][Mm]64/
+bld/
+[Bb]in/
+[Oo]bj/
+[Ll]og/
+[Ll]ogs/
+
+## Test
+[Tt]est[Rr]esult*/
+[Bb]uild[Ll]og.*
+coverage*.json
+coverage*.xml
+coverage*.info
+*.coverage
+*.coveragexml
+TestResults/
+
+## NuGet
+*.nupkg
+*.snupkg
+**/[Pp]ackages/*
+!**/[Pp]ackages/build/
+*.nuget.props
+*.nuget.targets
+
+## Rider
+*.DotSettings.user
+
+## macOS / Linux
+.DS_Store
+Thumbs.db
+
+## Publish
+[Pp]ublish/
+PublishScripts/
+
+## Misc
+*.log
+*.tlog
+*.pdb

--- a/ReportingDashboard.sln
+++ b/ReportingDashboard.sln
@@ -1,0 +1,28 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.8.0.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ReportingDashboard.Web", "src\ReportingDashboard.Web\ReportingDashboard.Web.csproj", "{4B2D9E1A-7F1C-4E8E-9A5C-111111111111}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ReportingDashboard.Tests", "tests\ReportingDashboard.Tests\ReportingDashboard.Tests.csproj", "{9C3D4E2B-8A2D-4F1F-8B6D-222222222222}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{4B2D9E1A-7F1C-4E8E-9A5C-111111111111}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4B2D9E1A-7F1C-4E8E-9A5C-111111111111}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4B2D9E1A-7F1C-4E8E-9A5C-111111111111}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4B2D9E1A-7F1C-4E8E-9A5C-111111111111}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9C3D4E2B-8A2D-4F1F-8B6D-222222222222}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9C3D4E2B-8A2D-4F1F-8B6D-222222222222}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9C3D4E2B-8A2D-4F1F-8B6D-222222222222}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9C3D4E2B-8A2D-4F1F-8B6D-222222222222}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/src/ReportingDashboard.Web/Components/App.razor
+++ b/src/ReportingDashboard.Web/Components/App.razor
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=1920" />
+    <title>Reporting Dashboard</title>
+    <base href="/" />
+    <link rel="stylesheet" href="site.css" />
+    <link rel="stylesheet" href="ReportingDashboard.Web.styles.css" />
+</head>
+<body>
+    <Routes />
+</body>
+</html>

--- a/src/ReportingDashboard.Web/Components/Pages/Dashboard.razor
+++ b/src/ReportingDashboard.Web/Components/Pages/Dashboard.razor
@@ -1,0 +1,6 @@
+@page "/"
+@inject DashboardDataProvider Data
+
+<div class="dashboard-root">
+    Dashboard
+</div>

--- a/src/ReportingDashboard.Web/Components/Pages/Error.razor
+++ b/src/ReportingDashboard.Web/Components/Pages/Error.razor
@@ -1,0 +1,3 @@
+@page "/error"
+
+<pre>An error occurred. See server console for details.</pre>

--- a/src/ReportingDashboard.Web/Components/Routes.razor
+++ b/src/ReportingDashboard.Web/Components/Routes.razor
@@ -1,0 +1,8 @@
+<Router AppAssembly="typeof(Program).Assembly">
+    <Found Context="routeData">
+        <RouteView RouteData="@routeData" DefaultLayout="null" />
+    </Found>
+    <NotFound>
+        <p>Not found</p>
+    </NotFound>
+</Router>

--- a/src/ReportingDashboard.Web/Components/Shared/Header.razor
+++ b/src/ReportingDashboard.Web/Components/Shared/Header.razor
@@ -1,0 +1,5 @@
+@code {
+    [Parameter] public ProjectInfo? Project { get; set; }
+}
+
+<div class="hdr">Header placeholder</div>

--- a/src/ReportingDashboard.Web/Components/Shared/HeatmapCell.razor
+++ b/src/ReportingDashboard.Web/Components/Shared/HeatmapCell.razor
@@ -1,0 +1,7 @@
+@code {
+    [Parameter] public IReadOnlyList<string>? Items { get; set; }
+    [Parameter] public string RowClass { get; set; } = "ship";
+    [Parameter] public bool IsCurrentMonth { get; set; }
+}
+
+<div class="hm-cell"></div>

--- a/src/ReportingDashboard.Web/Components/Shared/HeatmapGrid.razor
+++ b/src/ReportingDashboard.Web/Components/Shared/HeatmapGrid.razor
@@ -1,0 +1,5 @@
+@code {
+    [Parameter] public HeatmapConfig? Heatmap { get; set; }
+}
+
+<div class="hm-wrap">Heatmap placeholder</div>

--- a/src/ReportingDashboard.Web/Components/Shared/TimelineSvg.razor
+++ b/src/ReportingDashboard.Web/Components/Shared/TimelineSvg.razor
@@ -1,0 +1,5 @@
+@code {
+    [Parameter] public TimelineConfig? Timeline { get; set; }
+}
+
+<div class="tl-area">Timeline placeholder</div>

--- a/src/ReportingDashboard.Web/Components/_Imports.razor
+++ b/src/ReportingDashboard.Web/Components/_Imports.razor
@@ -1,0 +1,12 @@
+@using System.Net.Http
+@using Microsoft.AspNetCore.Components
+@using Microsoft.AspNetCore.Components.Forms
+@using Microsoft.AspNetCore.Components.Routing
+@using Microsoft.AspNetCore.Components.Web
+@using Microsoft.JSInterop
+@using ReportingDashboard.Web
+@using ReportingDashboard.Web.Components
+@using ReportingDashboard.Web.Components.Pages
+@using ReportingDashboard.Web.Components.Shared
+@using ReportingDashboard.Web.Models
+@using ReportingDashboard.Web.Services

--- a/src/ReportingDashboard.Web/Models/DashboardData.cs
+++ b/src/ReportingDashboard.Web/Models/DashboardData.cs
@@ -1,0 +1,8 @@
+namespace ReportingDashboard.Web.Models;
+
+public sealed record DashboardData
+{
+    public ProjectInfo Project { get; init; } = new();
+    public TimelineConfig Timeline { get; init; } = new();
+    public HeatmapConfig Heatmap { get; init; } = new();
+}

--- a/src/ReportingDashboard.Web/Models/DashboardDataException.cs
+++ b/src/ReportingDashboard.Web/Models/DashboardDataException.cs
@@ -1,0 +1,7 @@
+namespace ReportingDashboard.Web.Models;
+
+public sealed class DashboardDataException : Exception
+{
+    public DashboardDataException(string message) : base(message) { }
+    public DashboardDataException(string message, Exception inner) : base(message, inner) { }
+}

--- a/src/ReportingDashboard.Web/Models/HeatmapConfig.cs
+++ b/src/ReportingDashboard.Web/Models/HeatmapConfig.cs
@@ -1,0 +1,8 @@
+namespace ReportingDashboard.Web.Models;
+
+public sealed record HeatmapConfig
+{
+    public IReadOnlyList<string> Months { get; init; } = Array.Empty<string>();
+    public int CurrentMonthIndex { get; init; }
+    public HeatmapRows Rows { get; init; } = new();
+}

--- a/src/ReportingDashboard.Web/Models/HeatmapRows.cs
+++ b/src/ReportingDashboard.Web/Models/HeatmapRows.cs
@@ -1,0 +1,9 @@
+namespace ReportingDashboard.Web.Models;
+
+public sealed record HeatmapRows
+{
+    public IReadOnlyList<IReadOnlyList<string>> Shipped { get; init; } = Array.Empty<IReadOnlyList<string>>();
+    public IReadOnlyList<IReadOnlyList<string>> InProgress { get; init; } = Array.Empty<IReadOnlyList<string>>();
+    public IReadOnlyList<IReadOnlyList<string>> Carryover { get; init; } = Array.Empty<IReadOnlyList<string>>();
+    public IReadOnlyList<IReadOnlyList<string>> Blockers { get; init; } = Array.Empty<IReadOnlyList<string>>();
+}

--- a/src/ReportingDashboard.Web/Models/LabelPosition.cs
+++ b/src/ReportingDashboard.Web/Models/LabelPosition.cs
@@ -1,0 +1,7 @@
+namespace ReportingDashboard.Web.Models;
+
+public enum LabelPosition
+{
+    Above,
+    Below
+}

--- a/src/ReportingDashboard.Web/Models/Milestone.cs
+++ b/src/ReportingDashboard.Web/Models/Milestone.cs
@@ -1,0 +1,9 @@
+namespace ReportingDashboard.Web.Models;
+
+public sealed record Milestone
+{
+    public DateOnly Date { get; init; }
+    public MilestoneType Type { get; init; }
+    public string Label { get; init; } = string.Empty;
+    public LabelPosition? LabelPosition { get; init; }
+}

--- a/src/ReportingDashboard.Web/Models/MilestoneType.cs
+++ b/src/ReportingDashboard.Web/Models/MilestoneType.cs
@@ -1,0 +1,9 @@
+namespace ReportingDashboard.Web.Models;
+
+public enum MilestoneType
+{
+    Poc,
+    Prod,
+    Checkpoint,
+    CheckpointMinor
+}

--- a/src/ReportingDashboard.Web/Models/ProjectInfo.cs
+++ b/src/ReportingDashboard.Web/Models/ProjectInfo.cs
@@ -1,0 +1,9 @@
+namespace ReportingDashboard.Web.Models;
+
+public sealed record ProjectInfo
+{
+    public string Title { get; init; } = string.Empty;
+    public string Subtitle { get; init; } = string.Empty;
+    public string? BacklogUrl { get; init; }
+    public DateOnly AsOfDate { get; init; }
+}

--- a/src/ReportingDashboard.Web/Models/Swimlane.cs
+++ b/src/ReportingDashboard.Web/Models/Swimlane.cs
@@ -1,0 +1,9 @@
+namespace ReportingDashboard.Web.Models;
+
+public sealed record Swimlane
+{
+    public string Id { get; init; } = string.Empty;
+    public string Label { get; init; } = string.Empty;
+    public string Color { get; init; } = "#0078D4";
+    public IReadOnlyList<Milestone> Milestones { get; init; } = Array.Empty<Milestone>();
+}

--- a/src/ReportingDashboard.Web/Models/TimelineConfig.cs
+++ b/src/ReportingDashboard.Web/Models/TimelineConfig.cs
@@ -1,0 +1,10 @@
+namespace ReportingDashboard.Web.Models;
+
+public sealed record TimelineConfig
+{
+    public DateOnly StartDate { get; init; }
+    public DateOnly EndDate { get; init; }
+    public DateOnly NowDate { get; init; }
+    public IReadOnlyList<string>? MonthLabels { get; init; }
+    public IReadOnlyList<Swimlane> Swimlanes { get; init; } = Array.Empty<Swimlane>();
+}

--- a/src/ReportingDashboard.Web/Program.cs
+++ b/src/ReportingDashboard.Web/Program.cs
@@ -1,0 +1,36 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.Options;
+using ReportingDashboard.Web.Components;
+using ReportingDashboard.Web.Models;
+using ReportingDashboard.Web.Services;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.WebHost.UseUrls("http://127.0.0.1:5000");
+
+builder.Configuration.AddJsonFile("data.json", optional: false, reloadOnChange: true);
+
+builder.Services.Configure<JsonSerializerOptions>(o =>
+{
+    o.PropertyNameCaseInsensitive = true;
+    o.Converters.Add(new DateOnlyJsonConverter());
+    o.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.CamelCase));
+});
+
+builder.Services.Configure<DashboardData>(builder.Configuration);
+builder.Services.AddSingleton<DashboardDataProvider>();
+
+builder.Services.AddRazorComponents();
+
+var app = builder.Build();
+
+app.UseExceptionHandler("/error", createScopeForErrors: true);
+app.UseStatusCodePagesWithReExecute("/error", "?code={0}");
+
+app.UseStaticFiles();
+app.UseAntiforgery();
+
+app.MapRazorComponents<App>();
+
+app.Run();

--- a/src/ReportingDashboard.Web/Properties/launchSettings.json
+++ b/src/ReportingDashboard.Web/Properties/launchSettings.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://127.0.0.1:5000",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/ReportingDashboard.Web/ReportingDashboard.Web.csproj
+++ b/src/ReportingDashboard.Web/ReportingDashboard.Web.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>ReportingDashboard.Web</RootNamespace>
+    <AssemblyName>ReportingDashboard.Web</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="data.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/src/ReportingDashboard.Web/Services/DashboardDataProvider.cs
+++ b/src/ReportingDashboard.Web/Services/DashboardDataProvider.cs
@@ -1,0 +1,53 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using ReportingDashboard.Web.Models;
+
+namespace ReportingDashboard.Web.Services;
+
+public sealed class DashboardDataProvider
+{
+    private readonly IOptionsMonitor<DashboardData> _monitor;
+    private readonly ILogger<DashboardDataProvider> _logger;
+    private readonly List<string> _warnings = new();
+
+    public DashboardDataProvider(IOptionsMonitor<DashboardData> monitor, ILogger<DashboardDataProvider> logger)
+    {
+        _monitor = monitor;
+        _logger = logger;
+        _monitor.OnChange(_ => Revalidate());
+        Revalidate();
+    }
+
+    public DashboardData Current => _monitor.CurrentValue;
+
+    public IReadOnlyList<string> Warnings => _warnings;
+
+    public IDisposable? OnChange(Action<DashboardData> listener) => _monitor.OnChange(listener);
+
+    public DashboardData CurrentOrThrow()
+    {
+        Validate(Current);
+        return Current;
+    }
+
+    public void Validate(DashboardData data)
+    {
+        if (data is null)
+        {
+            throw new DashboardDataException("data.json failed to bind to DashboardData.");
+        }
+    }
+
+    private void Revalidate()
+    {
+        _warnings.Clear();
+        try
+        {
+            Validate(_monitor.CurrentValue);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "DashboardData validation failed.");
+        }
+    }
+}

--- a/src/ReportingDashboard.Web/Services/DateOnlyJsonConverter.cs
+++ b/src/ReportingDashboard.Web/Services/DateOnlyJsonConverter.cs
@@ -1,0 +1,25 @@
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace ReportingDashboard.Web.Services;
+
+public sealed class DateOnlyJsonConverter : JsonConverter<DateOnly>
+{
+    private const string Format = "yyyy-MM-dd";
+
+    public override DateOnly Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        var s = reader.GetString();
+        if (string.IsNullOrWhiteSpace(s))
+        {
+            return default;
+        }
+        return DateOnly.ParseExact(s, Format, CultureInfo.InvariantCulture);
+    }
+
+    public override void Write(Utf8JsonWriter writer, DateOnly value, JsonSerializerOptions options)
+    {
+        writer.WriteStringValue(value.ToString(Format, CultureInfo.InvariantCulture));
+    }
+}

--- a/src/ReportingDashboard.Web/Services/MilestoneLayout.cs
+++ b/src/ReportingDashboard.Web/Services/MilestoneLayout.cs
@@ -1,0 +1,53 @@
+namespace ReportingDashboard.Web.Services;
+
+public static class MilestoneLayout
+{
+    public const int SvgWidth = 1560;
+    public const int SvgHeight = 185;
+    public const int FirstLaneY = 42;
+    public const int LastLaneY = 154;
+
+    public static double DateToX(DateOnly date, DateOnly start, DateOnly end, int width = SvgWidth)
+    {
+        var total = (end.ToDateTime(TimeOnly.MinValue) - start.ToDateTime(TimeOnly.MinValue)).TotalDays;
+        if (total <= 0) return 0;
+        var offset = (date.ToDateTime(TimeOnly.MinValue) - start.ToDateTime(TimeOnly.MinValue)).TotalDays;
+        return (offset / total) * width;
+    }
+
+    public static (double X, bool Clamped) DateToClampedX(DateOnly date, DateOnly start, DateOnly end, int width = SvgWidth)
+    {
+        var x = DateToX(date, start, end, width);
+        if (x < 0) return (0, true);
+        if (x > width) return (width, true);
+        return (x, false);
+    }
+
+    public static int SwimlaneY(int index, int count)
+    {
+        if (count <= 1) return 98;
+        return FirstLaneY + index * ((LastLaneY - FirstLaneY) / Math.Max(1, count - 1));
+    }
+
+    public static IEnumerable<double> MonthBoundaries(DateOnly start, DateOnly end, int width = SvgWidth)
+    {
+        var cursor = new DateOnly(start.Year, start.Month, 1);
+        if (cursor < start) cursor = cursor.AddMonths(1);
+        while (cursor <= end)
+        {
+            yield return DateToX(cursor, start, end, width);
+            cursor = cursor.AddMonths(1);
+        }
+    }
+
+    public static IEnumerable<(string Label, double X)> MonthTicks(DateOnly start, DateOnly end, int width = SvgWidth)
+    {
+        var cursor = new DateOnly(start.Year, start.Month, 1);
+        while (cursor <= end)
+        {
+            var x = DateToX(cursor, start, end, width);
+            yield return (cursor.ToString("MMM", System.Globalization.CultureInfo.InvariantCulture), x);
+            cursor = cursor.AddMonths(1);
+        }
+    }
+}

--- a/src/ReportingDashboard.Web/appsettings.json
+++ b/src/ReportingDashboard.Web/appsettings.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/src/ReportingDashboard.Web/data.json
+++ b/src/ReportingDashboard.Web/data.json
@@ -1,0 +1,73 @@
+{
+  "Project": {
+    "Title": "Privacy Automation Release Roadmap",
+    "Subtitle": "Trusted Platform · Privacy Automation Workstream · April 2026",
+    "BacklogUrl": "https://ado.example.com/backlog",
+    "AsOfDate": "2026-04-19"
+  },
+  "Timeline": {
+    "StartDate": "2026-01-01",
+    "EndDate": "2026-04-30",
+    "NowDate": "2026-04-19",
+    "Swimlanes": [
+      {
+        "Id": "M1",
+        "Label": "Chatbot & MS Role",
+        "Color": "#0078D4",
+        "Milestones": [
+          { "Date": "2026-01-12", "Type": "checkpoint", "Label": "Jan 12 Checkpoint" },
+          { "Date": "2026-03-26", "Type": "poc", "Label": "Mar 26 PoC" },
+          { "Date": "2026-04-15", "Type": "prod", "Label": "Apr Prod" }
+        ]
+      },
+      {
+        "Id": "M2",
+        "Label": "PDS & Data Inventory",
+        "Color": "#00897B",
+        "Milestones": [
+          { "Date": "2026-02-11", "Type": "checkpoint", "Label": "Feb 11" },
+          { "Date": "2026-04-02", "Type": "poc", "Label": "Apr 2 PoC" }
+        ]
+      },
+      {
+        "Id": "M3",
+        "Label": "Auto Review DFD",
+        "Color": "#546E7A",
+        "Milestones": [
+          { "Date": "2026-03-10", "Type": "checkpointMinor", "Label": "" },
+          { "Date": "2026-04-22", "Type": "prod", "Label": "Apr Prod" }
+        ]
+      }
+    ]
+  },
+  "Heatmap": {
+    "Months": ["Jan", "Feb", "Mar", "Apr"],
+    "CurrentMonthIndex": 3,
+    "Rows": {
+      "Shipped": [
+        ["Consent API v1"],
+        ["MS Role GA"],
+        ["PDS schema v2"],
+        ["Chatbot beta"]
+      ],
+      "InProgress": [
+        [],
+        ["Review DFD spike"],
+        ["Auto-Review v0"],
+        ["Chatbot RC", "MS Role v2 planning"]
+      ],
+      "Carryover": [
+        [],
+        [],
+        ["Telemetry dashboard"],
+        ["Docs cleanup"]
+      ],
+      "Blockers": [
+        [],
+        [],
+        [],
+        ["Legal review of AI prompts"]
+      ]
+    }
+  }
+}

--- a/src/ReportingDashboard.Web/wwwroot/site.css
+++ b/src/ReportingDashboard.Web/wwwroot/site.css
@@ -1,0 +1,7 @@
+/* GLOBAL */
+
+/* HEADER */
+
+/* TIMELINE */
+
+/* HEATMAP */

--- a/tests/ReportingDashboard.Tests/Fixtures/malformed-data.json
+++ b/tests/ReportingDashboard.Tests/Fixtures/malformed-data.json
@@ -1,0 +1,3 @@
+{
+  "Project": {
+    "Title": "Broken

--- a/tests/ReportingDashboard.Tests/Placeholder.cs
+++ b/tests/ReportingDashboard.Tests/Placeholder.cs
@@ -1,0 +1,7 @@
+namespace ReportingDashboard.Tests;
+
+public class Placeholder
+{
+    [Xunit.Fact]
+    public void Compiles() { }
+}

--- a/tests/ReportingDashboard.Tests/ReportingDashboard.Tests.csproj
+++ b/tests/ReportingDashboard.Tests/ReportingDashboard.Tests.csproj
@@ -1,0 +1,36 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="bunit" Version="1.33.3" />
+    <PackageReference Include="FluentAssertions" Version="6.12.1" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\ReportingDashboard.Web\ReportingDashboard.Web.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="Fixtures\*.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Task Assignment
**Assigned To:** SoftwareEngineer
**Complexity:** Medium
**Branch:** `agent/softwareengineer/t1-project-foundation-scaffolding`

## Requirements
Closes #1987

# T1: Project Foundation & Scaffolding

## Summary

This PR establishes the complete .NET 8 Blazor Server solution skeleton for **ReportingDashboard** — a single-page executive reporting dashboard that renders a milestone Gantt timeline and monthly execution heatmap from a local `data.json` file. After this PR merges, `dotnet build` succeeds, `dotnet run` starts Kestrel on `http://127.0.0.1:5000`, and a GET to `/` returns HTTP 200 with a placeholder Dashboard page.

The PR creates the solution file, two project files (web + tests), all 10 immutable model records, stub service classes (DashboardDataProvider, MilestoneLayout, DateOnlyJsonConverter), all Razor component files as minimal stubs accepting their final parameter signatures, a complete fictional sample `data.json` exercising all 3 milestone types and all 4 heatmap rows across 4 months, empty section-commented `site.css`, and test-project scaffolding with fixture files. This is the W0 foundation task that unblocks T2–T11 for parallel execution in W1.

## Acceptance Criteria

- [ ] `.gitignore` at repo root excludes `bin/`, `obj/`, `*.user`, `.vs/`, `*.suo`, `.idea/`, `TestResults/`.
- [ ] `.editorconfig` at repo root sets C# defaults (UTF-8, LF or CRLF consistent, 4-space indent for `.cs`, 2-space for `.razor`/`.json`/`.css`).
- [ ] `ReportingDashboard.sln` at repo root references both projects with correct relative paths.
- [ ] `src/ReportingDashboard.Web/ReportingDashboard.Web.csproj` targets `net8.0`, `Sdk=Microsoft.NET.Sdk.Web`, has `<Nullable>enable</Nullable>`, `<ImplicitUsings>enable</ImplicitUsings>`, `<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.*" />`, and `<None Update="data.json"><CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory></None>`.
- [ ] `tests/ReportingDashboard.Tests/ReportingDashboard.Tests.csproj` targets `net8.0`, `IsPackable=false`, references xunit 2.9.x, xunit.runner.visualstudio, bunit 1.33.x, FluentAssertions 6.12.x, coverlet.collector 6.0.x, Microsoft.NET.Test.Sdk, and has `<ProjectReference>` to the Web project.
- [ ] `dotnet restore` at repo root completes with no errors.
- [ ] `dotnet build` at repo root completes with zero warnings and zero errors (treat warnings as errors is optional but preferred for `net8.0`).
- [ ] `dotnet run --project src/ReportingDashboard.Web` starts Kestrel bound to `http://127.0.0.1:5000` (verify via logs; confirm **not** bound to `0.0.0.0` or `localhost`).
- [ ] `curl http://127.0.0.1:5000/` returns HTTP 200 with `text/html` body containing the placeholder `<div>Dashboard</div>`.
- [ ] Navigating to `/error` returns a renderable stub page (not a YSOD).
- [ ] All 10 model types exist as `public sealed record` (or `public record` for those with inheritance needs) in `src/ReportingDashboard.Web/Models/` with namespace `ReportingDashboard.Web.Models`: `DashboardData`, `ProjectInfo`, `TimelineConfig`, `Swimlane`, `Milestone`, `MilestoneType` (enum: `Poc`, `Prod`, `Checkpoint`, `CheckpointMinor`), `LabelPosition` (enum: `Above`, `Below`), `HeatmapConfig`, `HeatmapRows`, `DashboardDataException : Exception`.
- [ ] `Services/DashboardDataProvider.cs` is a `public sealed class` wrapping `IOptionsMonitor<DashboardData>`, exposing `DashboardData Current`, `IReadOnlyList<string> Warnings`, `IDisposable OnChange(Action<DashboardData>)`, and a `Validate()` method — minimal implementation that compiles and returns current snapshot (T4 provides full validation).
- [ ] `Services/MilestoneLayout.cs` is a `public static class` with stubs for `DateToX`, `DateToClampedX`, `SwimlaneY`, `MonthBoundaries`, `MonthTicks` returning reasonable defaults (T3 provides full math).
- [ ] `Services/DateOnlyJsonConverter.cs` is a working `JsonConverter<DateOnly>` for `YYYY-MM-DD` round-trip.
- [ ] `Components/App.razor` emits `<html><head>...<link rel="stylesheet" href="site.css"><link rel="stylesheet" href="ReportingDashboard.Web.styles.css">...</head><body><Routes/></body></html>`.
- [ ] `Components/Routes.razor` uses `<Router AppAssembly="@typeof(Program).Assembly">` with `DefaultLayout="null"`.
- [ ] `Components/_Imports.razor` imports `Microsoft.AspNetCore.Components.*`, `ReportingDashboard.Web.Models`, `ReportingDashboard.Web.Services`, `ReportingDashboard.Web.Components.Shared`.
- [ ] `Components/Pages/Dashboard.razor` is a `@page "/"` stub rendering `<div>Dashboard</div>` (T8 replaces).
- [ ] `Components/Pages/Error.razor` is a `@page "/error"` stub rendering `<pre>Error</pre>` (T9 replaces).
- [ ] `Components/Shared/Header.razor`, `TimelineSvg.razor`, `HeatmapGrid.razor`, `HeatmapCell.razor` exist as minimal stubs declaring their final `[Parameter]` signatures (`ProjectInfo`, `TimelineConfig`, `HeatmapConfig`, and `IReadOnlyList<string> Items + string RowClass + bool IsCurrentMonth` respectively) and render placeholder markup so T5/T6/T7 can fill them in without altering parameter names.
- [ ] `wwwroot/site.css` exists as an empty file containing exactly four section comments: `/* Global */`, `/* Header */`, `/* Timeline */`, `/* Heatmap */` (T2 fills).
- [ ] `Program.cs` contains, in order: `UseUrls("http://127.0.0.1:5000")`; `AddJsonFile("data.json", optional:false, reloadOnChange:true)`; `Services.Configure<DashboardData>(builder.Configuration)`; `AddSingleton<DashboardDataProvider>()`; `AddRazorComponents()`; `app.UseExceptionHandler("/error")`; `app.UseStatusCodePagesWithReExecute("/error")`; `app.UseStaticFiles()`; `app.MapRazorComponents<App>()`. **No** `UseHttpsRedirection`, `UseAuthentication`, `UseAuthorization`. JSON options register `DateOnlyJsonConverter` and `JsonStringEnumConverter(JsonNamingPolicy.CamelCase)`.
- [ ] `appsettings.json` exists (can be minimal — just `{}` or default logging config).
- [ ] `Properties/launchSettings.json` has a single `http` profile with `applicationUrl: "http://127.0.0.1:5000"` (no `https`, no IIS Express profile, or if IIS Express profile exists it also uses `127.0.0.1:5000`).
- [ ] `src/ReportingDashboard.Web/data.json` is a complete fictional "Privacy Automation Release Roadmap" with:
  - `Project` block (Title, Subtitle, BacklogUrl, AsOfDate)
  - `Timeline` with StartDate `2026-01-01`, EndDate `2026-04-30`, NowDate `2026-04-19`, 3 swimlanes (M1 `#0078D4`, M2 `#00897B`, M3 `#546E7A`)
  - Milestones covering all 3 types: at least one `poc`, one `prod`, one `checkpoint` distributed across swimlanes
  - `Heatmap` with `Months: ["Jan","Feb","Mar","Apr"]`, `CurrentMonthIndex: 3`, and all 4 rows (Shipped, InProgress, Carryover, Blockers) each with exactly 4 arrays (one per month), with at least one non-empty cell per row.
  - Must deserialize cleanly into `DashboardData` with the stub provider.
- [ ] `tests/ReportingDashboard.Tests/Placeholder.cs` is an empty-body class so the test project compiles with no tests yet (T10 deletes it and adds real tests).
- [ ] `tests/ReportingDashboard.Tests/Fixtures/sample-data.json` is a copy of the shipped `data.json`.
- [ ] `tests/ReportingDashboard.Tests/Fixtures/malformed-data.json` contains intentionally broken JSON (e.g., trailing comma + missing brace) for T10 to use.
- [ ] `dotnet test` runs with 0 tests, 0 failures (placeholder project compiles).
- [ ] No `Components/Layout/*`, no `Pages/Counter.razor`, no `wwwroot/bootstrap/*`, no default Blazor template scaffolding other than what's explicitly listed above.

## Implementation Steps

### Step 1 — Repo-root scaffolding and solution file (commit: "T1.1 scaffolding: .gitignore, .editorconfig, .sln, project structure")

Create the bare repository skeleton and solution file so all subsequent steps build from a consistent starting point.

1. Create `.gitignore` at repo root with the standard Visual Studio / .NET ignores: `bin/`, `obj/`, `*.user`, `*.suo`, `.vs/`, `.idea/`, `TestResults/`, `*.received.*`, `publish/`, `artifacts/`.
2. Create `.editorconfig` at repo root with C#/.razor/.json/.css formatting rules (root=true, UTF-8, CRLF on Windows acceptable, 4-space C#, 2-space for the rest, trim trailing whitespace, final newline).
3. Create empty folder structure: `src/ReportingDashboard.Web/`, `src/ReportingDashboard.Web/Models/`, `src/ReportingDashboard.Web/Services/`, `src/ReportingDashboard.Web/Components/`, `src/ReportingDashboard.Web/Components/Pages/`, `src/ReportingDashboard.Web/Components/Shared/`, `src/ReportingDashboard.Web/Properties/`, `src/ReportingDashboard.Web/wwwroot/`, `tests/ReportingDashboard.Tests/`, `tests/ReportingDashboard.Tests/Fixtures/`.
4. Create `ReportingDashboard.sln` via `dotnet new sln -n ReportingDashboard` at repo root (or hand-author the .sln with the two project GUIDs). The .sln references will be added in Step 2 after the csproj files exist.

**Produces:** a committable repo skeleton with `.gitignore`, `.editorconfig`, empty directory tree, and an empty `.sln`.

### Step 2 — Project files, Program.cs, models, and services stubs (commit: "T1.2 projects: csprojs, Program.cs, models, service stubs")

Create both .csproj files, wire them into the solution, author Program.cs, and add all model records and service stubs. After this step, `dotnet build` succeeds (even without any Razor components yet — add one minimal `Dashboard.razor` stub to prevent `MapRazorComponents<App>()` from failing, but App.razor itself lands in Step 3; alternatively, do an inline minimal App here and enrich in Step 3).

1. Create `src/ReportingDashboard.Web/ReportingDashboard.Web.csproj` with `Sdk=Microsoft.NET.Sdk.Web`, `TargetFramework=net8.0`, `Nullable=enable`, `ImplicitUsings=enable`, `<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.*" />`, and `<ItemGroup><None Update="data.json"><CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory></None></ItemGroup>`.
2. Create `tests/ReportingDashboard.Tests/ReportingDashboard.Tests.csproj` with `Sdk=Microsoft.NET.Sdk`, `TargetFramework=net8.0`, `IsPackable=false`, PackageReferences for `Microsoft.NET.Test.Sdk`, `xunit 2.9.*`, `xunit.runner.visualstudio 2.8.*`, `bunit 1.33.*`, `FluentAssertions 6.12.*`, `coverlet.collector 6.0.*`, and `<ProjectReference Include="../../src/ReportingDashboard.Web/ReportingDashboard.Web.csproj" />`.
3. Add both projects to the .sln: `dotnet sln add src/ReportingDashboard.Web/ReportingDashboard.Web.csproj tests/ReportingDashboard.Tests/ReportingDashboard.Tests.csproj`.
4. Create `tests/ReportingDashboard.Tests/Placeholder.cs` with `namespace ReportingDashboard.Tests; internal class Placeholder {}`.
5. Create all 10 model files in `src/ReportingDashboard.Web/Models/` (namespace `ReportingDashboard.Web.Models`) as immutable records matching the architecture's Entity Diagram exactly:
   - `MilestoneType.cs` (enum `Poc | Prod | Checkpoint | CheckpointMinor`).
   - `LabelPosition.cs` (enum `Above | Below`).
   - `Milestone.cs` — `public sealed record Milestone(DateOnly Date, MilestoneType Type, string Label, LabelPosition? LabelPosition = null)`.
   - `Swimlane.cs` — `public sealed record Swimlane(string Id, string Label, string Color, IReadOnlyList<Milestone> Milestones)`.
   - `TimelineConfig.cs` — `public sealed record TimelineConfig(DateOnly StartDate, DateOnly EndDate, DateOnly NowDate, IReadOnlyList<Swimlane> Swimlanes, IReadOnlyList<string>? MonthLabels = null)`.
   - `ProjectInfo.cs` — `public sealed record ProjectInfo(string Title, string Subtitle, string? BacklogUrl, DateOnly AsOfDate)`.
   - `HeatmapRows.cs` — `public sealed record HeatmapRows(IReadOnlyList<IReadOnlyList<string>> Shipped, IReadOnlyList<IReadOnlyList<string>> InProgress, IReadOnlyList<IReadOnlyList<string>> Carryover, IReadOnlyList<IReadOnlyList<string>> Blockers)`.
   - `HeatmapConfig.cs` — `public sealed record HeatmapConfig(IReadOnlyList<string> Months, int CurrentMonthIndex, HeatmapRows Rows)`.
   - `DashboardData.cs` — `public sealed record DashboardData(ProjectInfo Project, TimelineConfig Timeline, HeatmapConfig Heatmap)`. Provide a parameterless constructor or a default instance factory if required by `IOptions` binding (use `record class` with init-only properties if binding struggles; preferred: `public sealed class DashboardData { public ProjectInfo Project { get; set; } = default!; ... }` to play nicely with `Configure<T>()`). **Document the binding choice** inline so T4 understands.
   - `DashboardDataException.cs` — `public sealed class DashboardDataException(string message) : Exception(message);`.
6. Create `src/ReportingDashboard.Web/Services/DateOnlyJsonConverter.cs` (namespace `ReportingDashboard.Web.Services`): working `JsonConverter<DateOnly>` parsing/writing `"yyyy-MM-dd"`.
7. Create `src/ReportingDashboard.Web/Services/MilestoneLayout.cs` as `public static class` with stub methods returning sensible placeholders:
   - `DateToX(DateOnly d, DateOnly s, DateOnly e, double w = 1560) => 0.0`
   - `DateToClampedX(...) => (0.0, false)`
   - `SwimlaneY(int i, int n, double top = 42, double bottom = 154) => (top + bottom) / 2`
   - `MonthBoundaries(DateOnly s, DateOnly e) => Enumerable.Empty<(string, double)>()`
   - `MonthTicks(DateOnly s, DateOnly e) => MonthBoundaries(s, e)`
   - Define public constants `SvgWidth = 1560`, `SvgHeight = 185`, `FirstLaneY = 42`, `LastLaneY = 154`.
8. Create `src/ReportingDashboard.Web/Services/DashboardDataProvider.cs` as `public sealed class` with constructor accepting `IOptionsMonitor<DashboardData>` and `ILogger<DashboardDataProvider>`, properties `DashboardData Current => _monitor.CurrentValue`, `IReadOnlyList<string> Warnings => Array.Empty<string>()`, method `IDisposable OnChange(Action<DashboardData> listener) => _monitor.OnChange(listener)!`, and `public void Validate() { /* T4 fills */ }`.
9. Create `src/ReportingDashboard.Web/Program.cs` exactly matching the architecture (UseUrls loopback, AddJsonFile data.json with optional:false/reloadOnChange:true, Configure<DashboardData>, AddSingleton<DashboardDataProvider>, AddRazorComponents — **no InteractiveServerComponents** — UseExceptionHandler, UseStatusCodePagesWithReExecute, UseStaticFiles, MapRazorComponents<App>). Register `JsonStringEnumConverter(JsonNamingPolicy.CamelCase)` and `DateOnlyJsonConverter` via `builder.Services.ConfigureHttpJsonOptions` or — more importantly for config binding — via `builder.Services.Configure<JsonOptions>` and pass the same converters to the JSON configuration provider (T4 will confirm hot-reload path).
10. Create `src/ReportingDashboard.Web/appsettings.json` with `{ "Logging": { "LogLevel": { "Default": "Information", "Microsoft.AspNetCore": "Warning" } } }`.
11. Create `src/ReportingDashboard.Web/Properties/launchSettings.json` with one `http` profile: `"applicationUrl": "http://127.0.0.1:5000"`, `"commandName": "Project"`, `"launchBrowser": false`, `"environmentVariables": { "ASPNETCORE_ENVIRONMENT": "Development" }`.

**Produces:** `dotnet restore && dotnet build` succeeds. `dotnet test` discovers zero tests and reports success.

### Step 3 — Razor components (App, Routes, _Imports, Pages, Shared stubs) and empty site.css (commit: "T1.3 components: App, Routes, stubs, site.css skeleton")

Create every Razor component declared in the architecture so that T2–T9 can each modify one file without blocking on component creation.

1. Create `src/ReportingDashboard.Web/Components/_Imports.razor` with `@using Microsoft.AspNetCore.Components`, `@using Microsoft.AspNetCore.Components.Web`, `@using Microsoft.AspNetCore.Components.Routing`, `@using ReportingDashboard.Web.Models`, `@using ReportingDashboard.Web.Services`, `@using ReportingDashboard.Web.Components.Shared`.
2. Create `src/ReportingDashboard.Web/Components/App.razor`: `<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"/><meta name="viewport" content="width=1920"/><base href="/"/><title>Reporting Dashboard</title><link rel="stylesheet" href="site.css"/><link rel="stylesheet" href="ReportingDashboard.Web.styles.css"/><HeadOutlet/></head><body><Routes/></body></html>`.
3. Create `src/ReportingDashboard.Web/Components/Routes.razor`: `<Router AppAssembly="@typeof(Program).Assembly"><Found Context="routeData"><RouteView RouteData="@routeData" DefaultLayout="null"/></Found></Router>`.
4. Create `src/ReportingDashboard.Web/Components/Pages/Dashboard.razor`: `@page "/"` + `<div>Dashboard</div>` (T8 replaces body).
5. Create `src/ReportingDashboard.Web/Components/Pages/Error.razor`: `@page "/error"` + `<pre>Error</pre>` (T9 replaces body).
6. Create `src/ReportingDashboard.Web/Components/Shared/Header.razor` with the final parameter shape so T5 only modifies the body:
   ```razor
   @* T5 will fill this body *@
   <div class="hdr">Header stub</div>
   @code { [Parameter] public ProjectInfo Project { get; set; } = default!; }
   ```
7. Create `src/ReportingDashboard.Web/Components/Shared/TimelineSvg.razor` with `[Parameter] public TimelineConfig Timeline { get; set; } = default!;` and body `<div class="tl-area">TimelineSvg stub</div>`.
8. Create `src/ReportingDashboard.Web/Components/Shared/HeatmapGrid.razor` with `[Parameter] public HeatmapConfig Heatmap { get; set; } = default!;` and body `<div class="hm-wrap">HeatmapGrid stub</div>`.
9. Create `src/ReportingDashboard.Web/Components/Shared/HeatmapCell.razor` with `[Parameter] public IReadOnlyList<string> Items { get; set; } = Array.Empty<string>();`, `[Parameter] public string RowClass { get; set; } = "";`, `[Parameter] public bool IsCurrentMonth { get; set; }`, and body `<div class="hm-cell">cell stub</div>`.
10. Create `src/ReportingDashboard.Web/wwwroot/site.css` with exactly:
    ```css
    /* Global */

    /* Header */

    /* Timeline */

    /* Heatmap */
    ```

**Produces:** `dotnet build` succeeds; `dotnet run --project src/ReportingDashboard.Web` starts Kestrel on `127.0.0.1:5000` and GET `/` returns 200 with the placeholder markup.

### Step 4 — Sample data.json and test fixtures (commit: "T1.4 data: ship sample data.json and test fixtures")

Author the content file that drives the dashboard and the fixtures the test suite will use in T10.

1. Create `src/ReportingDashboard.Web/data.json` — a complete fictional "Privacy Automation Release Roadmap" payload that deserializes cleanly into `DashboardData` and exercises every visual vocabulary element. Follow the architecture's JSON Schema example exactly, adjusted so `currentMonthIndex = 3` (April) against months `["Jan","Feb","Mar","Apr"]`. Include:
   - **Project:** Title "Privacy Automation Release Roadmap", Subtitle "Trusted Platform · Privacy Automation Workstream · April 2026", BacklogUrl "https://ado.example.com/backlog", AsOfDate "2026-04-19".
   - **Timeline:** StartDate "2026-01-01", EndDate "2026-04-30", NowDate "2026-04-19", 3 swimlanes (M1 `#0078D4`, M2 `#00897B`, M3 `#546E7A`), with across-the-swimlanes: at least one `poc`, one `prod`, one `checkpoint`, and one `checkpointMinor`.
   - **Heatmap:** 4 months × 4 rows, each row's outer array length is exactly 4, with at least one non-empty cell per row (e.g., Shipped in Jan, InProgress in Mar, Carryover in Feb, Blockers in Apr) and at least one multi-item cell to exercise Scenario 6.
   - Fictional content only — no real PII, no real customer names.
2. Copy the file byte-for-byte to `tests/ReportingDashboard.Tests/Fixtures/sample-data.json` (use a csproj `<ItemGroup><None Update="Fixtures/sample-data.json"><CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory></None></ItemGroup>` or copy via msbuild target).
3. Create `tests/ReportingDashboard.Tests/Fixtures/malformed-data.json` with deliberately broken JSON, e.g.:
   ```json
   { "Project": { "Title": "Broken", "Subtitle": "x", "AsOfDate": "2026-04-19" },
     "Timeline": { "StartDate": "2026-01-01", "EndDate": "2026-04-30",
   ```
   (unterminated object) — this file must fail `JsonSerializer.Deserialize<DashboardData>()` with a `JsonException` for T10.
4. Also mark this fixture file as `CopyToOutputDirectory=PreserveNewest`.

**Produces:** `dotnet run` loads the shipped `data.json` without exception; the stub Dashboard page still renders the placeholder (T8 wires the rendering).

### Step 5 — Verification and PR polish (commit: "T1.5 verify: build, run, smoke, lint")

Confirm every acceptance criterion locally before requesting review.

1. Run `dotnet restore && dotnet build -warnaserror` at repo root → zero warnings, zero errors.
2. Run `dotnet test` → zero tests, zero failures.
3. Run `dotnet run --project src/ReportingDashboard.Web` in one shell; in another, `curl -v http://127.0.0.1:5000/` → expect `HTTP/1.1 200 OK` and body containing `<div>Dashboard</div>`. Also `curl -v http://127.0.0.1:5000/error` → 200 with `<pre>Error</pre>`.
4. Temporarily rename `data.json` → restart the app → confirm startup fails fast with a clear "data.json not found" error in the log. Restore the file.
5. Temporarily replace `data.json` with the malformed fixture contents → restart → confirm the error page (or startup error) identifies JSON parse failure. Restore.
6. Confirm Kestrel log line says `Now listening on: http://127.0.0.1:5000` and **not** `http://localhost:5000` or `http://0.0.0.0:5000`.
7. Run `dotnet format --verify-no-changes` (optional if available) to confirm code style compliance.
8. Update the PR body with a screenshot of the placeholder page and a paste of the `curl -v /` output.

**Produces:** a green PR ready for review with all acceptance criteria demonstrably met.

## Testing

T1 itself ships **no behavioral tests** — test authoring is T10's deliverable, and T1 only creates the empty `Placeholder.cs` so the test project compiles. The tests that future tasks will layer on top of this scaffolding are:

1. **Compile-time verification (covered by this PR):**
   - `dotnet build -warnaserror` on both projects — confirms every stub compiles and nullable-reference contracts are satisfied.
   - `dotnet test` runs `ReportingDashboard.Tests` with zero discovered tests and exits successfully — confirms test project, fixtures, and ProjectReference are wired correctly.

2. **Manual smoke verification for this PR (checklist in Step 5):**
   - Kestrel binds to `127.0.0.1:5000` only (verify via log line; confirm `netstat -an | findstr :5000` shows LISTENING on `127.0.0.1:5000` and not `0.0.0.0:5000`).
   - GET `/` returns 200 with placeholder markup.
   - GET `/error` returns 200 with placeholder markup.
   - Missing `data.json` → fail-fast startup (documented in log).
   - Malformed `data.json` → error page identifies the file.
   - Edit `data.json` (change `Project.Title`), hit F5 → new value appears (verifies `reloadOnChange:true` and `IOptionsMonitor` wiring; even though the placeholder Dashboard doesn't render the title yet, instrumenting a quick `@inject DashboardDataProvider Data` + `<div>@Data.Current.Project.Title</div>` in the stub is acceptable for verification and can be reverted before merge or left in — T8 replaces the body anyway).

3. **Deferred to later tasks (not in scope for T1):**
   - **T3** → unit tests for `MilestoneLayout.DateToX`, `MonthBoundaries`, `SwimlaneY`.
   - **T4** → `DashboardDataProvider` validation tests against the malformed fixture.
   - **T10** → bUnit `Dashboard` render smoke, `SampleDataCoverageTests` that deserialize the shipped `data.json` and assert all 3 milestone types + all 4 heatmap rows are represented (this is the test that validates T1's sample-data acceptance criterion mechanically).

## Dependencies & Downstream Enablement

- **Dependencies:** NONE (W0 foundation).
- **Unblocks:** T2 (fills `site.css`), T3 (replaces `MilestoneLayout` stub), T4 (replaces `DashboardDataProvider` stub + `DateOnlyJsonConverter` hardening), T5/T6/T7 (fill Header/TimelineSvg/HeatmapGrid/HeatmapCell bodies using the parameter signatures frozen here), T9 (fills `Error.razor` + modifies `Program.cs`), T10 (adds tests + consumes fixtures), T11 (documents run/edit/screenshot). T8 integrates in W3 once T4/T5/T6/T7 are done.
- **Shared files explicitly declared:** `Program.cs` and `wwwroot/site.css` are touched again by T9 and T2 respectively; no other task should modify these in W1.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

## References
- Architecture: Architecture.md
- PM Spec: 

## Status
- [ ] Implementation
- [ ] Tests Written
- [ ] Ready for Review