### PR TITLE
SoftwareEngineer: Build Timeline SVG Component

### DIFF
--- a/.agentsquad/build-timeline-svg-component.task
+++ b/.agentsquad/build-timeline-svg-component.task
@@ -1,0 +1,4 @@
+agent: SoftwareEngineer
+task: Build Timeline SVG Component
+complexity: High
+status: in-progress

--- a/src/ReportingDashboard.Web/Components/Pages/Partials/TimelineSvg.razor
+++ b/src/ReportingDashboard.Web/Components/Pages/Partials/TimelineSvg.razor
@@ -1,6 +1,98 @@
-@* TODO(T7): render 230px lane-label column + 1560x185 SVG timeline. *@
-<div>TimelineSvg placeholder</div>
+@using System.Globalization
+@using System.Net
+@using Microsoft.AspNetCore.Components
+@using ReportingDashboard.Web.Models
+
+<div class="tl-area">
+    <div class="tl-labels">
+        @foreach (var lane in Model.Lanes)
+        {
+            <div class="tl-lane-label" style="color:@lane.Color;">
+                @lane.Id<br />
+                <span class="tl-lane-sub">@lane.Label</span>
+            </div>
+        }
+    </div>
+    <div class="tl-svg-box">
+        <svg xmlns="http://www.w3.org/2000/svg" width="@SvgWidth" height="@SvgHeight"
+             style="overflow:visible;display:block">
+            <defs>
+                <filter id="sh">
+                    <feDropShadow dx="0" dy="1" stdDeviation="1.5" flood-opacity="0.3" />
+                </filter>
+            </defs>
+
+            @foreach (var g in Model.Gridlines)
+            {
+                <line x1="@N(g.X)" y1="0" x2="@N(g.X)" y2="@SvgHeight"
+                      stroke="#bbb" stroke-opacity="0.4" stroke-width="1" />
+                @MonthLabel(g)
+            }
+
+            @foreach (var lane in Model.Lanes)
+            {
+                <line x1="0" y1="@N(lane.Y)" x2="@SvgWidth" y2="@N(lane.Y)"
+                      stroke="@lane.Color" stroke-width="3" />
+
+                @foreach (var m in lane.Milestones)
+                {
+                    var captionY = m.CaptionPosition == CaptionPosition.Below
+                        ? lane.Y + 24
+                        : lane.Y - 16;
+
+                    switch (m.Type)
+                    {
+                        case MilestoneType.Poc:
+                            <polygon points="@DiamondPoints(m.X, lane.Y)"
+                                     fill="#F4B400" filter="url(#sh)" />
+                            break;
+                        case MilestoneType.Prod:
+                            <polygon points="@DiamondPoints(m.X, lane.Y)"
+                                     fill="#34A853" filter="url(#sh)" />
+                            break;
+                        case MilestoneType.Checkpoint:
+                            <circle cx="@N(m.X)" cy="@N(lane.Y)" r="7"
+                                    fill="white" stroke="@lane.Color" stroke-width="2.5" />
+                            break;
+                    }
+
+                    if (!string.IsNullOrEmpty(m.Caption))
+                    {
+                        @CaptionLabel(m.X, captionY, m.Caption)
+                    }
+                }
+            }
+
+            @if (Model.Now.InRange)
+            {
+                <line x1="@N(Model.Now.X)" y1="0" x2="@N(Model.Now.X)" y2="@SvgHeight"
+                      stroke="#EA4335" stroke-width="2" stroke-dasharray="5,3" />
+                @NowLabel(Model.Now.X)
+            }
+        </svg>
+    </div>
+</div>
 
 @code {
-    [Parameter] public TimelineViewModel? Model { get; set; }
+    private const int SvgWidth = 1560;
+    private const int SvgHeight = 185;
+
+    [Parameter] public TimelineViewModel Model { get; set; } = TimelineViewModel.Empty;
+
+    private static string N(double v) => v.ToString("0.###", CultureInfo.InvariantCulture);
+
+    private static string DiamondPoints(double x, double y)
+    {
+        return string.Create(CultureInfo.InvariantCulture,
+            $"{x},{y - 11} {x + 11},{y} {x},{y + 11} {x - 11},{y}");
+    }
+
+    private static MarkupString MonthLabel(MonthGridline g) => (MarkupString)
+        $"<text x=\"{N(g.X + 5)}\" y=\"14\" fill=\"#666\" font-size=\"11\" font-weight=\"600\" font-family=\"Segoe UI,Arial\">{WebUtility.HtmlEncode(g.Label)}</text>";
+
+    private static MarkupString CaptionLabel(double x, double y, string caption) => (MarkupString)
+        $"<text x=\"{N(x)}\" y=\"{N(y)}\" text-anchor=\"middle\" fill=\"#666\" font-size=\"10\" font-family=\"Segoe UI,Arial\">{WebUtility.HtmlEncode(caption)}</text>";
+
+    private static MarkupString NowLabel(double x) => (MarkupString)
+        $"<text x=\"{N(x + 4)}\" y=\"14\" fill=\"#EA4335\" font-size=\"10\" font-weight=\"700\" font-family=\"Segoe UI,Arial\">NOW</text>";
 }

--- a/src/ReportingDashboard.Web/Components/Pages/Partials/TimelineSvg.razor.css
+++ b/src/ReportingDashboard.Web/Components/Pages/Partials/TimelineSvg.razor.css
@@ -1,0 +1,36 @@
+.tl-area {
+    display: flex;
+    align-items: stretch;
+    padding: 6px 44px 0;
+    flex-shrink: 0;
+    height: 196px;
+    border-bottom: 2px solid #E8E8E8;
+    background: #FAFAFA;
+}
+
+.tl-labels {
+    width: 230px;
+    flex-shrink: 0;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-around;
+    padding: 16px 12px 16px 0;
+    border-right: 1px solid #E0E0E0;
+}
+
+.tl-lane-label {
+    font-size: 12px;
+    font-weight: 600;
+    line-height: 1.4;
+}
+
+.tl-lane-sub {
+    font-weight: 400;
+    color: #444;
+}
+
+.tl-svg-box {
+    flex: 1;
+    padding-left: 12px;
+    padding-top: 6px;
+}

--- a/tests/ReportingDashboard.Web.Tests/Components/TimelineSvgTests.cs
+++ b/tests/ReportingDashboard.Web.Tests/Components/TimelineSvgTests.cs
@@ -1,0 +1,140 @@
+using Bunit;
+using ReportingDashboard.Web.Components.Pages.Partials;
+using ReportingDashboard.Web.Models;
+using ReportingDashboard.Web.Services;
+
+namespace ReportingDashboard.Web.Tests.Components;
+
+public class TimelineSvgTests : TestContext
+{
+    private static TimelineViewModel BuildModel(
+        NowMarker? now = null,
+        IReadOnlyList<LaneGeometry>? lanes = null,
+        IReadOnlyList<MonthGridline>? gridlines = null)
+    {
+        return new TimelineViewModel(
+            gridlines ?? new[] { new MonthGridline(0, "Jan"), new MonthGridline(260, "Feb") },
+            lanes ?? Array.Empty<LaneGeometry>(),
+            now ?? new NowMarker(0, false));
+    }
+
+    [Fact]
+    public void Renders_Empty_Model_Without_Throwing()
+    {
+        var cut = RenderComponent<TimelineSvg>(p => p.Add(x => x.Model, TimelineViewModel.Empty));
+
+        cut.Find("svg").Should().NotBeNull();
+        cut.Find("filter#sh").Should().NotBeNull();
+        cut.Find("feDropShadow").Should().NotBeNull();
+        cut.FindAll("line").Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Renders_Month_Gridlines_And_Labels()
+    {
+        var cut = RenderComponent<TimelineSvg>(p => p.Add(x => x.Model, BuildModel()));
+
+        var texts = cut.FindAll("text");
+        texts.Select(t => t.TextContent).Should().Contain(new[] { "Jan", "Feb" });
+
+        var gridLines = cut.FindAll("line").Where(l =>
+            l.GetAttribute("stroke") == "#bbb").ToList();
+        gridLines.Should().HaveCount(2);
+        gridLines[0].GetAttribute("stroke-opacity").Should().Be("0.4");
+    }
+
+    [Fact]
+    public void Renders_Lane_Tracks_And_Labels()
+    {
+        var lane = new LaneGeometry(
+            "M1", "Chatbot", "#0078D4", 42,
+            Array.Empty<MilestoneGeometry>());
+
+        var cut = RenderComponent<TimelineSvg>(p => p.Add(x => x.Model, BuildModel(lanes: new[] { lane })));
+
+        cut.Markup.Should().Contain("M1");
+        cut.Markup.Should().Contain("Chatbot");
+
+        var track = cut.FindAll("line").First(l => l.GetAttribute("stroke") == "#0078D4");
+        track.GetAttribute("stroke-width").Should().Be("3");
+        track.GetAttribute("y1").Should().Be("42");
+    }
+
+    [Fact]
+    public void Renders_Poc_As_Amber_Diamond_With_Shadow()
+    {
+        var lane = new LaneGeometry("M1", "L", "#0078D4", 42, new[]
+        {
+            new MilestoneGeometry(745, 42, MilestoneType.Poc, "Mar 26 PoC", CaptionPosition.Below)
+        });
+        var cut = RenderComponent<TimelineSvg>(p => p.Add(x => x.Model, BuildModel(lanes: new[] { lane })));
+
+        var poly = cut.Find("polygon");
+        poly.GetAttribute("fill").Should().Be("#F4B400");
+        poly.GetAttribute("filter").Should().Be("url(#sh)");
+        poly.GetAttribute("points").Should().Contain("745");
+    }
+
+    [Fact]
+    public void Renders_Prod_As_Green_Diamond()
+    {
+        var lane = new LaneGeometry("M1", "L", "#0078D4", 42, new[]
+        {
+            new MilestoneGeometry(1040, 42, MilestoneType.Prod, "Apr Prod", CaptionPosition.Above)
+        });
+        var cut = RenderComponent<TimelineSvg>(p => p.Add(x => x.Model, BuildModel(lanes: new[] { lane })));
+
+        var poly = cut.Find("polygon");
+        poly.GetAttribute("fill").Should().Be("#34A853");
+        poly.GetAttribute("filter").Should().Be("url(#sh)");
+    }
+
+    [Fact]
+    public void Renders_Checkpoint_As_Stroked_White_Circle()
+    {
+        var lane = new LaneGeometry("M1", "L", "#0078D4", 42, new[]
+        {
+            new MilestoneGeometry(104, 42, MilestoneType.Checkpoint, "Jan 12", CaptionPosition.Above)
+        });
+        var cut = RenderComponent<TimelineSvg>(p => p.Add(x => x.Model, BuildModel(lanes: new[] { lane })));
+
+        var circle = cut.Find("circle");
+        circle.GetAttribute("fill").Should().Be("white");
+        circle.GetAttribute("stroke").Should().Be("#0078D4");
+        circle.GetAttribute("cx").Should().Be("104");
+    }
+
+    [Fact]
+    public void Renders_Now_Line_Only_When_InRange()
+    {
+        var inRange = RenderComponent<TimelineSvg>(p =>
+            p.Add(x => x.Model, BuildModel(now: new NowMarker(823, true))));
+        var nowLine = inRange.FindAll("line").First(l => l.GetAttribute("stroke") == "#EA4335");
+        nowLine.GetAttribute("stroke-dasharray").Should().Be("5,3");
+        inRange.Markup.Should().Contain(">NOW<");
+
+        var outOfRange = RenderComponent<TimelineSvg>(p =>
+            p.Add(x => x.Model, BuildModel(now: new NowMarker(0, false))));
+        outOfRange.FindAll("line").Any(l => l.GetAttribute("stroke") == "#EA4335").Should().BeFalse();
+        outOfRange.Markup.Should().NotContain(">NOW<");
+    }
+
+    [Fact]
+    public void Caption_Position_Above_And_Below_Offsets_From_Lane_Y()
+    {
+        var lane = new LaneGeometry("M1", "L", "#0078D4", 100, new[]
+        {
+            new MilestoneGeometry(200, 100, MilestoneType.Poc, "Above", CaptionPosition.Above),
+            new MilestoneGeometry(400, 100, MilestoneType.Poc, "Below", CaptionPosition.Below)
+        });
+        var cut = RenderComponent<TimelineSvg>(p => p.Add(x => x.Model, BuildModel(lanes: new[] { lane })));
+
+        var above = cut.FindAll("text").First(t => t.TextContent == "Above");
+        var below = cut.FindAll("text").First(t => t.TextContent == "Below");
+
+        double.Parse(above.GetAttribute("y")!, System.Globalization.CultureInfo.InvariantCulture)
+            .Should().BeLessThan(100);
+        double.Parse(below.GetAttribute("y")!, System.Globalization.CultureInfo.InvariantCulture)
+            .Should().BeGreaterThan(100);
+    }
+}

--- a/tests/ReportingDashboard.Web.Tests/Unit/TimelineSvgComponentTests.cs
+++ b/tests/ReportingDashboard.Web.Tests/Unit/TimelineSvgComponentTests.cs
@@ -1,0 +1,94 @@
+using System.Globalization;
+using System.Threading;
+using Bunit;
+using FluentAssertions;
+using ReportingDashboard.Web.Models;
+using ReportingDashboard.Web.Services;
+using Xunit;
+using TC = Bunit.TestContext;
+
+namespace ReportingDashboard.Web.Tests.Unit;
+
+[Trait("Category", "Unit")]
+public class TimelineSvgComponentTests
+{
+    private static Type TimelineSvgType =>
+        typeof(ReportingDashboard.Web.Models.DashboardData).Assembly
+            .GetType("ReportingDashboard.Web.Components.Pages.Partials.TimelineSvg", throwOnError: true)!;
+
+    private static IRenderedComponent<Microsoft.AspNetCore.Components.DynamicComponent> RenderWithModel(
+        TC ctx, object model)
+    {
+        return ctx.RenderComponent<Microsoft.AspNetCore.Components.DynamicComponent>(p => p
+            .Add(x => x.Type, TimelineSvgType)
+            .Add(x => x.Parameters, new Dictionary<string, object?> { ["Model"] = model }));
+    }
+
+    [Fact]
+    public void Renders_empty_shell_with_svg_filter_and_defs()
+    {
+        using var ctx = new TC();
+        var cut = RenderWithModel(ctx, TimelineViewModel.Empty);
+
+        var markup = cut.Markup;
+        markup.Should().Contain("class=\"tl-area\"");
+        markup.Should().Contain("width=\"1560\"");
+        markup.Should().Contain("height=\"185\"");
+        markup.Should().Contain("id=\"sh\"");
+        markup.Should().Contain("feDropShadow");
+    }
+
+    [Fact]
+    public void Empty_model_does_not_emit_now_line()
+    {
+        using var ctx = new TC();
+        var cut = RenderWithModel(ctx, TimelineViewModel.Empty);
+
+        var markup = cut.Markup;
+        markup.Should().NotContain("stroke-dasharray=\"5,3\"");
+        markup.Should().NotContain(">NOW<");
+    }
+
+    [Fact]
+    public void No_interactive_blazor_artifacts_in_output()
+    {
+        using var ctx = new TC();
+        var cut = RenderWithModel(ctx, TimelineViewModel.Empty);
+
+        var markup = cut.Markup;
+        markup.Should().NotContain("@onclick");
+        markup.Should().NotContain("<script");
+        markup.Should().NotContain("blazor.server.js");
+        markup.Should().NotContain("_framework/blazor.");
+    }
+
+    [Fact]
+    public void Svg_canvas_has_expected_dimensions_and_inline_style()
+    {
+        using var ctx = new TC();
+        var cut = RenderWithModel(ctx, TimelineViewModel.Empty);
+
+        var svg = cut.Find("svg");
+        svg.GetAttribute("width").Should().Be("1560");
+        svg.GetAttribute("height").Should().Be("185");
+        (svg.GetAttribute("style") ?? string.Empty).Should().Contain("overflow:visible");
+    }
+
+    [Fact]
+    public void Renders_without_exception_under_non_invariant_culture()
+    {
+        var prev = Thread.CurrentThread.CurrentCulture;
+        try
+        {
+            Thread.CurrentThread.CurrentCulture = new CultureInfo("de-DE");
+            using var ctx = new TC();
+            var cut = RenderWithModel(ctx, TimelineViewModel.Empty);
+
+            cut.Markup.Should().Contain("class=\"tl-area\"");
+        }
+        finally
+        {
+            Thread.CurrentThread.CurrentCulture = prev;
+        }
+    }
+}

--- a/tests/ReportingDashboard.Web.UITests/PlaywrightFixture.cs
+++ b/tests/ReportingDashboard.Web.UITests/PlaywrightFixture.cs
@@ -1,44 +1,36 @@
-using System;
-using System.Threading.Tasks;
 using Microsoft.Playwright;
 using Xunit;
 
 namespace ReportingDashboard.Web.UITests;
 
+[CollectionDefinition("Playwright")]
+public class PlaywrightCollection : ICollectionFixture<PlaywrightFixture> { }
+
 public class PlaywrightFixture : IAsyncLifetime
 {
     public IPlaywright Playwright { get; private set; } = default!;
     public IBrowser Browser { get; private set; } = default!;
-    public string BaseUrl { get; } =
+
+    public string BaseUrl =>
         Environment.GetEnvironmentVariable("BASE_URL") ?? "http://localhost:5080";
 
     public async Task InitializeAsync()
     {
         Microsoft.Playwright.Program.Main(new[] { "install", "chromium" });
         Playwright = await Microsoft.Playwright.Playwright.CreateAsync();
-        Browser = await Playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions
-        {
-            Headless = true
-        });
+        Browser = await Playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions { Headless = true });
     }
 
     public async Task<IPage> NewPageAsync()
     {
-        var context = await Browser.NewContextAsync(new BrowserNewContextOptions
-        {
-            ViewportSize = new ViewportSize { Width = 1920, Height = 1080 }
-        });
-        var page = await context.NewPageAsync();
-        page.SetDefaultTimeout(60000);
-        return page;
+        var context = await Browser.NewContextAsync();
+        context.SetDefaultTimeout(60000);
+        return await context.NewPageAsync();
     }
 
     public async Task DisposeAsync()
     {
-        if (Browser != null) await Browser.DisposeAsync();
+        if (Browser is not null) await Browser.CloseAsync();
         Playwright?.Dispose();
     }
 }
-
-[CollectionDefinition("Playwright")]
-public class PlaywrightCollection : ICollectionFixture<PlaywrightFixture> { }

--- a/tests/ReportingDashboard.Web.UITests/TimelineSvgUiTests.cs
+++ b/tests/ReportingDashboard.Web.UITests/TimelineSvgUiTests.cs
@@ -1,0 +1,68 @@
+using FluentAssertions;
+using Microsoft.Playwright;
+using Xunit;
+
+namespace ReportingDashboard.Web.UITests;
+
+[Trait("Category", "UI")]
+[Collection("Playwright")]
+public class TimelineSvgUiTests : IClassFixture<PlaywrightFixture>
+{
+    private readonly PlaywrightFixture _fx;
+    public TimelineSvgUiTests(PlaywrightFixture fx) => _fx = fx;
+
+    [Fact]
+    public async Task Timeline_area_is_rendered_with_svg_canvas()
+    {
+        var page = await _fx.NewPageAsync();
+        await page.GotoAsync(_fx.BaseUrl);
+        await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        var tlArea = page.Locator(".tl-area");
+        (await tlArea.CountAsync()).Should().BeGreaterThan(0);
+
+        var svg = page.Locator(".tl-svg-box svg").First;
+        await svg.WaitForAsync(new LocatorWaitForOptions { Timeout = 60000 });
+        (await svg.GetAttributeAsync("width")).Should().Be("1560");
+        (await svg.GetAttributeAsync("height")).Should().Be("185");
+    }
+
+    [Fact]
+    public async Task Timeline_defs_contains_dropshadow_filter()
+    {
+        var page = await _fx.NewPageAsync();
+        await page.GotoAsync(_fx.BaseUrl);
+        await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        var filter = page.Locator(".tl-svg-box svg defs filter#sh");
+        (await filter.CountAsync()).Should().BeGreaterThan(0);
+        var drop = page.Locator(".tl-svg-box svg defs filter#sh feDropShadow");
+        (await drop.CountAsync()).Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public async Task Timeline_lane_labels_column_is_present()
+    {
+        var page = await _fx.NewPageAsync();
+        await page.GotoAsync(_fx.BaseUrl);
+        await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        var labels = page.Locator(".tl-area .tl-labels");
+        (await labels.CountAsync()).Should().BeGreaterThan(0);
+
+        var laneDivs = page.Locator(".tl-area .tl-labels .tl-lane-label");
+        (await laneDivs.CountAsync()).Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public async Task Timeline_has_no_blazor_interactive_script_markers()
+    {
+        var page = await _fx.NewPageAsync();
+        await page.GotoAsync(_fx.BaseUrl);
+        await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        var html = await page.ContentAsync();
+        html.Should().NotContain("blazor.server.js");
+        html.Should().NotContain("_framework/blazor.");
+    }
+}


### PR DESCRIPTION
## Task Assignment
**Assigned To:** SoftwareEngineer
**Complexity:** High
**Branch:** `agent/softwareengineer/t7-build-timeline-svg-component`

## Requirements
Closes #2065

# PR: Build Timeline SVG Component (T7)

## Summary

Fleshes out `TimelineSvg.razor` (currently a stub from T1) into the full `.tl-area` rendering: a fixed 230px lane-label flex column on the left and a 1560x185 inline `<svg>` canvas on the right. The SVG draws month gridlines, per-lane horizontal tracks, milestone markers (amber PoC diamonds, green Prod diamonds, stroked-white or filled-grey Checkpoint circles) with `feDropShadow` filter, 10px date/label captions positioned above or below to avoid overlap, and a dashed red "NOW" vertical line (conditionally rendered only when `Now.InRange`). The component is a pure view-binder over a `TimelineViewModel` produced upstream by `TimelineMath` helpers (issue #2061); it performs no coordinate math itself. Static SSR only — no `@rendermode`, no event handlers, no JS interop, no tooltips. CSS mostly lives in the page-scoped `Dashboard.razor.css` (per T5); this PR's scoped `.razor.css` is limited to component-local selectors (lane label typography, SVG box spacing) that don't conflict with the page shell.

## Acceptance Criteria

- [ ] `TimelineSvg.razor` declares `[Parameter] public required TimelineViewModel Model { get; set; }` and contains no `@rendermode`, no `@onclick`, no `@inject` of runtime services.
- [ ] Root wrapper has class `tl-area` (styled by `Dashboard.razor.css`) and contains two children: `.tl-labels` (230px left column) and `.tl-svg-box` (flex:1 right wrapper holding the `<svg>`).
- [ ] Lane-label column renders one `<div>` per `Model.Lanes[]` entry with inline `style="color:{lane.Color}; font-size:12px; font-weight:600; line-height:1.4;"`, content `{lane.Id}<br/><span style="font-weight:400;color:#444;">{lane.Label}</span>`. Flex column with `justify-content:space-around`.
- [ ] Inline `<svg xmlns="http://www.w3.org/2000/svg" width="1560" height="185" style="overflow:visible;display:block">` is emitted.
- [ ] `<defs>` contains `<filter id="sh"><feDropShadow dx="0" dy="1" stdDeviation="1.5" flood-opacity="0.3"/></filter>`.
- [ ] For each `MonthGridline g` in `Model.Gridlines`: one `<line x1="{g.X}" y1="0" x2="{g.X}" y2="185" stroke="#bbb" stroke-opacity="0.4" stroke-width="1"/>` and one `<text x="{g.X+5}" y="14" fill="#666" font-size="11" font-weight="600">{g.Label}</text>`.
- [ ] For each `LaneGeometry l` in `Model.Lanes`: one `<line x1="0" y1="{l.Y}" x2="1560" y2="{l.Y}" stroke="{l.Color}" stroke-width="3"/>`.
- [ ] For each `MilestoneGeometry m` on a lane, render:
  - `Poc` → `<polygon>` 12px-per-side diamond (4 points computed around `(m.X, m.Y)`) with `fill="#F4B400"` and `filter="url(#sh)"`.
  - `Prod` → same diamond shape with `fill="#34A853"` and `filter="url(#sh)"`.
  - `Checkpoint` → `<circle cx="{m.X}" cy="{m.Y}" r="5" fill="white" stroke="{lane.Color}" stroke-width="2.5"/>` (or `r="4" fill="#999"` variant — pick one and use consistently).
- [ ] Each milestone caption: `<text x="{m.X}" y="{captionY}" text-anchor="middle" fill="#666" font-size="10">{m.Caption}</text>`, where `captionY = m.Y - 14` for `CaptionPosition.Above` and `m.Y + 18` for `CaptionPosition.Below`.
- [ ] NOW indicator renders **only** when `Model.Now.InRange == true`: `<line x1="{Now.X}" y1="0" x2="{Now.X}" y2="185" stroke="#EA4335" stroke-width="2" stroke-dasharray="5,3"/>` plus `<text x="{Now.X+4}" y="14" fill="#EA4335" font-size="10" font-weight="700">NOW</text>`.
- [ ] Empty lanes array → gridlines + (optional) NOW line render; no exceptions.
- [ ] `Model` null or with null collections → component renders a stable empty SVG shell (no NRE). Use `Model ?? TimelineViewModel.Empty` guard at the top of the markup block.
- [ ] Component produces zero `@onclick`, zero `<title>` tooltip children, zero `<script>` tags. No Blazor interactive directives.
- [ ] Rendered output contains the literal strings `filter="url(#sh)"`, `stroke-dasharray="5,3"` (when NOW in range), and `stroke-opacity="0.4"`.

## Implementation Steps

1. **Scaffold files and stabilize build.**
   - Confirm/create `src/ReportingDashboard.Web/Components/Pages/Partials/TimelineSvg.razor` (already a T1 stub — keep existing `@namespace`/`@using` directives, clear body to a minimal root `<div class="tl-area"></div>` that compiles against `TimelineViewModel`).
   - Create empty `src/ReportingDashboard.Web/Components/Pages/Partials/TimelineSvg.razor.css`.
   - Create `tests/ReportingDashboard.Web.Tests/Components/TimelineSvgTests.cs` with a placeholder xUnit `[Fact] public void Placeholder() { }` under namespace `ReportingDashboard.Web.Tests.Components`, referencing bUnit + the Web project.
   - Verify `dotnet build ReportingDashboard.sln` and `dotnet test` pass. Commit.

2. **Implement lane-label column and SVG shell.**
   - In `TimelineSvg.razor`, add `@using ReportingDashboard.Web.Services` + `@using ReportingDashboard.Web.Models` + `[Parameter] public required TimelineViewModel Model { get; set; }` in `@code`.
   - Render `<div class="tl-area"><div class="tl-labels">@foreach lane...</div><div class="tl-svg-box"><svg ...><defs><filter id="sh">...</filter></defs></svg></div></div>`.
   - Emit lane label `<div>` per `Model.Lanes` as specified; tolerate null `Model` by substituting `TimelineViewModel.Empty`.
   - Commit.

3. **Render month gridlines and lane tracks inside the SVG.**
   - Inside the `<svg>` (after `<defs>`), emit `@foreach (var g in Model.Gridlines)` → gridline `<line>` + month label `<text>`.
   - Then `@foreach (var l in Model.Lanes)` → track `<line>` spanning `x1=0..x2=1560` at `y=l.Y` in `l.Color` at stroke-width 3.
   - Commit.

4. **Render milestone markers and captions.**
   - Add a nested `@foreach (var m in l.Milestones)` inside the lane loop (after emitting the track line, or in a separate pass so markers render above tracks).
   - Compute diamond points as the 4-vertex string `"{m.X},{m.Y-6} {m.X+6},{m.Y} {m.X},{m.Y+6} {m.X-6},{m.Y}"` (using `ToString("0.##", CultureInfo.InvariantCulture)` in a small `@code` helper `Pts(...)` to guarantee locale-stable output).
   - Switch on `m.Type`: Poc → amber polygon + filter; Prod → green polygon + filter; Checkpoint → stroked-white circle (r=5) with lane-color stroke.
   - Emit caption `<text>` with `captionY` derived from `m.CaptionPosition`.
   - Commit.

5. **Render the dashed NOW line (conditional) and scoped CSS.**
   - After the lane loop but still inside `<svg>`, emit `@if (Model.Now.InRange) { ... }` block with the red dashed `<line>` and bold red `NOW` `<text>`.
   - In `TimelineSvg.razor.css`, add only component-local rules that are not already provided by the page-scoped `Dashboard.razor.css` (e.g., any fine-tuning of `.tl-labels div { line-height:1.4; }` if needed). Keep this file minimal or empty if all rules are already covered by T5's port.
   - Verify manual render against sample `data.json` by running `dotnet run` and visual-diffing against `docs/OriginalDesignConcept.png` at 1920x1080.
   - Commit.

6. **Tests (bUnit + assertions).**
   - In `TimelineSvgTests.cs` (xUnit + bUnit + FluentAssertions 6.12.x), add tests enumerated in the Testing section below. Use a shared `BuildModel(...)` helper that constructs a deterministic `TimelineViewModel` (avoid calling `TimelineMath` — tests should decouple from its internals).
   - Ensure `dotnet test` is green on Windows CI and `dotnet format --verify-no-changes` passes.
   - Commit.

## Testing

All tests in `tests/ReportingDashboard.Web.Tests/Components/TimelineSvgTests.cs` using bUnit's `TestContext` and FluentAssertions 6.12.x:

- **Renders empty shell** — passing `TimelineViewModel.Empty` produces `<div class="tl-area">` with a 1560x185 `<svg>` and a `<filter id="sh">` child; no exceptions thrown.
- **Lane-label column** — given 3 lanes (M1 blue, M2 teal, M3 slate), `.tl-labels` contains 3 `<div>` children, each with the lane color in its `style` attribute and the lane id + label text.
- **Lane-label column tolerates empty lanes** — `Lanes = []` renders `.tl-labels` with zero child `<div>`s, no NRE.
- **Month gridlines** — with 6 gridlines (Jan..Jun), the SVG contains 6 `<line stroke="#bbb" stroke-opacity="0.4">` gridline elements and 6 `<text>` elements with the month labels at `font-size="11"`.
- **Lane tracks** — each lane produces exactly one `<line x1="0" x2="1560" stroke-width="3">` at the expected `stroke="{lane.Color}"`.
- **Milestone markers — PoC** — a PoC milestone produces a `<polygon fill="#F4B400" filter="url(#sh)">` with 4 points around `(m.X, m.Y)`.
- **Milestone markers — Prod** — analogous assertion with `fill="#34A853"`.
- **Milestone markers — Checkpoint** — a Checkpoint milestone produces a `<circle ... fill="white" stroke="{lane.Color}">`, not a polygon.
- **Caption positioning** — an `Above` caption renders `<text>` with `y < m.Y`; a `Below` caption renders with `y > m.Y`; both have `text-anchor="middle"` and `font-size="10"`.
- **NOW line present when in range** — `Now.InRange = true, X = 974` produces a `<line stroke="#EA4335" stroke-width="2" stroke-dasharray="5,3">` at `x1="974"` and a `<text>` with content `NOW` at `font-weight="700"`.
- **NOW line absent when out of range** — `Now.InRange = false` → rendered markup contains zero occurrences of the literal `stroke-dasharray="5,3"` and zero `<text>` nodes whose content is exactly `NOW`.
- **No interactive/blazor artifacts** — rendered markup contains zero `@onclick`, zero `<script`, and no occurrence of `blazor.server.js` or `_framework/blazor.`.
- **Culture-invariant X coordinates** — render under `CultureInfo("de-DE")` via `Thread.CurrentThread.CurrentCulture`; assert emitted `x` attributes use `.` (period) as decimal separator, not `,`. Guards against the classic `ToString` locale bug that breaks SVG in non-US cultures.
- **Static SSR snapshot (optional but recommended)** — one `Verify.Xunit` snapshot test pinning the full rendered SVG string for a fixed 3-lane, 4-milestone, `Now.InRange=true` fixture. Windows-only; gate with `[SkippableFact]` on non-Windows CI if needed.

Coverage target for this component: ≥80% line coverage on the Razor file's generated class.

## References
- Architecture: Architecture.md
- PM Spec: 

## Status
- [ ] Implementation
- [ ] Tests Written
- [ ] Ready for Review