### PR TITLE
SoftwareEngineer: Build Monthly Execution Heatmap Component

### DIFF
--- a/.agentsquad/build-monthly-execution-heatmap-component.task
+++ b/.agentsquad/build-monthly-execution-heatmap-component.task
@@ -1,0 +1,4 @@
+agent: SoftwareEngineer
+task: Build Monthly Execution Heatmap Component
+complexity: High
+status: in-progress

--- a/src/ReportingDashboard.Web/Components/Pages/Partials/Heatmap.razor
+++ b/src/ReportingDashboard.Web/Components/Pages/Partials/Heatmap.razor
@@ -1,6 +1,57 @@
-@* TODO(T8): render .hm-title + .hm-grid (5x5 CSS grid) from HeatmapViewModel. *@
-<div>Heatmap placeholder</div>
+@{
+    var model = Model ?? HeatmapViewModel.Empty;
+    var months = model.Months;
+    var current = model.CurrentMonthIndex;
+}
+<div class="hm-wrap">
+    <div class="hm-title">Monthly Execution Heatmap &mdash; Shipped &bull; In Progress &bull; Carryover &bull; Blockers</div>
+    <div class="hm-grid">
+        <div class="hm-corner">Status</div>
+        @for (var i = 0; i < months.Count; i++)
+        {
+            var isCurrent = i == current;
+            <div class="hm-col-hdr @(isCurrent ? "current-hdr" : "")">@months[i]</div>
+        }
+
+        @foreach (var row in model.Rows)
+        {
+            var cat = CategoryClass(row.Category);
+            <div class="hm-row-hdr @(cat)-hdr">@row.HeaderLabel</div>
+            @for (var i = 0; i < row.Cells.Count; i++)
+            {
+                var cell = row.Cells[i];
+                var isCurrent = i == current;
+                <div class="hm-cell @(cat)-cell @(isCurrent ? "current" : "")">
+                    @if (cell.IsEmpty)
+                    {
+                        <div class="it empty">-</div>
+                    }
+                    else
+                    {
+                        @foreach (var item in cell.Items)
+                        {
+                            <div class="it">@item</div>
+                        }
+                        @if (cell.OverflowCount > 0)
+                        {
+                            <div class="it overflow">@HeatmapLayout.FormatOverflow(cell.OverflowCount)</div>
+                        }
+                    }
+                </div>
+            }
+        }
+    </div>
+</div>
 
 @code {
     [Parameter] public HeatmapViewModel? Model { get; set; }
+
+    private static string CategoryClass(HeatmapCategory category) => category switch
+    {
+        HeatmapCategory.Shipped => "ship",
+        HeatmapCategory.InProgress => "prog",
+        HeatmapCategory.Carryover => "carry",
+        HeatmapCategory.Blockers => "block",
+        _ => "ship"
+    };
 }

--- a/src/ReportingDashboard.Web/Components/Pages/Partials/Heatmap.razor.css
+++ b/src/ReportingDashboard.Web/Components/Pages/Partials/Heatmap.razor.css
@@ -1,0 +1,173 @@
+.hm-wrap {
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    padding: 10px 44px 10px;
+}
+
+.hm-title {
+    font-size: 14px;
+    font-weight: 700;
+    color: #888;
+    letter-spacing: .5px;
+    text-transform: uppercase;
+    margin-bottom: 8px;
+    flex-shrink: 0;
+}
+
+.hm-grid {
+    flex: 1;
+    min-height: 0;
+    display: grid;
+    grid-template-columns: 160px repeat(4, 1fr);
+    grid-template-rows: 36px repeat(4, 1fr);
+    border: 1px solid #E0E0E0;
+}
+
+.hm-corner {
+    background: #F5F5F5;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 11px;
+    font-weight: 700;
+    color: #999;
+    text-transform: uppercase;
+    border-right: 1px solid #E0E0E0;
+    border-bottom: 2px solid #CCC;
+}
+
+.hm-col-hdr {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 16px;
+    font-weight: 700;
+    color: #111;
+    background: #F5F5F5;
+    border-right: 1px solid #E0E0E0;
+    border-bottom: 2px solid #CCC;
+}
+
+.hm-col-hdr.current-hdr {
+    background: #FFF0D0;
+    color: #C07700;
+}
+
+.hm-row-hdr {
+    display: flex;
+    align-items: center;
+    padding: 0 12px;
+    font-size: 11px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: .7px;
+    border-right: 2px solid #CCC;
+    border-bottom: 1px solid #E0E0E0;
+}
+
+.hm-cell {
+    padding: 8px 12px;
+    border-right: 1px solid #E0E0E0;
+    border-bottom: 1px solid #E0E0E0;
+    overflow: hidden;
+}
+
+.hm-cell .it {
+    font-size: 12px;
+    color: #333;
+    padding: 2px 0 2px 12px;
+    position: relative;
+    line-height: 1.35;
+}
+
+.hm-cell .it::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 7px;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+}
+
+.hm-cell .it.empty {
+    color: #AAA;
+}
+
+.hm-cell .it.empty::before {
+    background: transparent;
+}
+
+.ship-hdr {
+    color: #1B7A28;
+    background: #E8F5E9;
+    border-right: 2px solid #CCC;
+}
+
+.ship-cell {
+    background: #F0FBF0;
+}
+
+.ship-cell.current {
+    background: #D8F2DA;
+}
+
+.ship-cell .it::before {
+    background: #34A853;
+}
+
+.prog-hdr {
+    color: #1565C0;
+    background: #E3F2FD;
+    border-right: 2px solid #CCC;
+}
+
+.prog-cell {
+    background: #EEF4FE;
+}
+
+.prog-cell.current {
+    background: #DAE8FB;
+}
+
+.prog-cell .it::before {
+    background: #0078D4;
+}
+
+.carry-hdr {
+    color: #B45309;
+    background: #FFF8E1;
+    border-right: 2px solid #CCC;
+}
+
+.carry-cell {
+    background: #FFFDE7;
+}
+
+.carry-cell.current {
+    background: #FFF0B0;
+}
+
+.carry-cell .it::before {
+    background: #F4B400;
+}
+
+.block-hdr {
+    color: #991B1B;
+    background: #FEF2F2;
+    border-right: 2px solid #CCC;
+}
+
+.block-cell {
+    background: #FFF5F5;
+}
+
+.block-cell.current {
+    background: #FFE4E4;
+}
+
+.block-cell .it::before {
+    background: #EA4335;
+}

--- a/src/ReportingDashboard.Web/Services/HeatmapLayout.cs
+++ b/src/ReportingDashboard.Web/Services/HeatmapLayout.cs
@@ -1,0 +1,110 @@
+using System.Globalization;
+using ReportingDashboard.Web.Models;
+
+namespace ReportingDashboard.Web.Services;
+
+/// <summary>
+/// Pure helper that projects a <see cref="Heatmap"/> model plus "today" into a
+/// render-ready <see cref="HeatmapViewModel"/>. Stateless and deterministic;
+/// distinct from <see cref="TimelineMath"/> but reuses its generic helpers
+/// (<see cref="TimelineMath.TruncateItems"/>, <see cref="TimelineMath.CurrentMonthIndex"/>).
+/// </summary>
+public static class HeatmapLayout
+{
+    public const int DefaultMaxItems = 4;
+
+    private static readonly HeatmapCategory[] RowOrder =
+    {
+        HeatmapCategory.Shipped,
+        HeatmapCategory.InProgress,
+        HeatmapCategory.Carryover,
+        HeatmapCategory.Blockers
+    };
+
+    /// <summary>
+    /// Builds a heatmap view model from raw data, enforcing the fixed row order
+    /// (Shipped / InProgress / Carryover / Blockers), resolving the current
+    /// month column, and truncating overflowing cells.
+    /// </summary>
+    public static HeatmapViewModel Build(
+        Heatmap heatmap,
+        DateOnly today,
+        int defaultMaxItems = DefaultMaxItems)
+    {
+        ArgumentNullException.ThrowIfNull(heatmap);
+        if (defaultMaxItems < 1)
+            throw new ArgumentOutOfRangeException(nameof(defaultMaxItems), "must be >= 1");
+
+        var months = heatmap.Months ?? Array.Empty<string>();
+        var monthCount = months.Count;
+
+        var currentIndex = ResolveCurrentMonthIndex(heatmap, today, months);
+        var maxItems = heatmap.MaxItemsPerCell > 0 ? heatmap.MaxItemsPerCell : defaultMaxItems;
+
+        var byCategory = new Dictionary<HeatmapCategory, HeatmapRow>();
+        foreach (var row in heatmap.Rows ?? Array.Empty<HeatmapRow>())
+        {
+            byCategory[row.Category] = row;
+        }
+
+        var rows = new List<HeatmapRowView>(RowOrder.Length);
+        foreach (var cat in RowOrder)
+        {
+            byCategory.TryGetValue(cat, out var row);
+            rows.Add(BuildRow(cat, row, monthCount, maxItems));
+        }
+
+        return new HeatmapViewModel(months, currentIndex, rows);
+    }
+
+    private static int ResolveCurrentMonthIndex(
+        Heatmap heatmap, DateOnly today, IReadOnlyList<string> months)
+    {
+        if (heatmap.CurrentMonthIndex is { } explicitIndex)
+        {
+            if (explicitIndex >= 0 && explicitIndex < months.Count)
+                return explicitIndex;
+            return -1;
+        }
+        return TimelineMath.CurrentMonthIndex(today, months);
+    }
+
+    private static HeatmapRowView BuildRow(
+        HeatmapCategory category, HeatmapRow? row, int monthCount, int maxItems)
+    {
+        var cells = new List<HeatmapCellView>(monthCount);
+        var sourceCells = row?.Cells;
+        for (var i = 0; i < monthCount; i++)
+        {
+            IReadOnlyList<string> items = sourceCells is not null && i < sourceCells.Count
+                ? sourceCells[i] ?? Array.Empty<string>()
+                : Array.Empty<string>();
+            cells.Add(BuildCell(items, maxItems));
+        }
+        return new HeatmapRowView(category, HeaderLabel(category), cells);
+    }
+
+    private static HeatmapCellView BuildCell(IReadOnlyList<string> items, int maxItems)
+    {
+        if (items.Count == 0)
+        {
+            return new HeatmapCellView(Array.Empty<string>(), 0, IsEmpty: true);
+        }
+        var (kept, overflow) = TimelineMath.TruncateItems(items, maxItems);
+        return new HeatmapCellView(kept, overflow, IsEmpty: false);
+    }
+
+    /// <summary>Uppercase display label for the category row header.</summary>
+    public static string HeaderLabel(HeatmapCategory category) => category switch
+    {
+        HeatmapCategory.Shipped => "Shipped",
+        HeatmapCategory.InProgress => "In Progress",
+        HeatmapCategory.Carryover => "Carryover",
+        HeatmapCategory.Blockers => "Blockers",
+        _ => category.ToString()
+    };
+
+    /// <summary>Formats the trailing "+K more" overflow label.</summary>
+    public static string FormatOverflow(int count) =>
+        "+" + count.ToString(CultureInfo.InvariantCulture) + " more";
+}

--- a/tests/ReportingDashboard.Web.Tests/Components/HeatmapTests.cs
+++ b/tests/ReportingDashboard.Web.Tests/Components/HeatmapTests.cs
@@ -1,0 +1,148 @@
+using System.Collections.Generic;
+using System.Linq;
+using Bunit;
+using FluentAssertions;
+using ReportingDashboard.Web.Models;
+using ReportingDashboard.Web.Services;
+using Xunit;
+using HeatmapComponent = ReportingDashboard.Web.Components.Pages.Partials.Heatmap;
+
+namespace ReportingDashboard.Web.Tests.Components;
+
+[Trait("Category", "Unit")]
+public class HeatmapTests
+{
+    private static HeatmapViewModel BuildModel(
+        IReadOnlyList<string>? months = null,
+        int currentMonthIndex = -1,
+        IReadOnlyList<HeatmapRowView>? rows = null)
+    {
+        months ??= new[] { "Jan", "Feb", "Mar", "Apr" };
+        if (rows is null)
+        {
+            var emptyCells = Enumerable.Range(0, months.Count)
+                .Select(_ => new HeatmapCellView(System.Array.Empty<string>(), 0, IsEmpty: true))
+                .ToList();
+            rows = new[]
+            {
+                new HeatmapRowView(HeatmapCategory.Shipped, "SHIPPED", emptyCells),
+                new HeatmapRowView(HeatmapCategory.InProgress, "IN PROGRESS", emptyCells),
+                new HeatmapRowView(HeatmapCategory.Carryover, "CARRYOVER", emptyCells),
+                new HeatmapRowView(HeatmapCategory.Blockers, "BLOCKERS", emptyCells),
+            };
+        }
+        return new HeatmapViewModel(months, currentMonthIndex, rows);
+    }
+
+    [Fact]
+    public void Renders_FullShell_With25GridChildren()
+    {
+        using var ctx = new Bunit.TestContext();
+        var cut = ctx.RenderComponent<HeatmapComponent>(p => p.Add(x => x.Model, BuildModel()));
+
+        cut.Find(".hm-wrap").Should().NotBeNull();
+        cut.Find(".hm-title").TextContent.Should().Contain("Monthly Execution Heatmap");
+        cut.FindAll(".hm-grid > *").Count.Should().Be(25);
+    }
+
+    [Fact]
+    public void CurrentMonthIndex_AppliesCurrentHdrAndCurrentCellClasses()
+    {
+        using var ctx = new Bunit.TestContext();
+        var model = BuildModel(currentMonthIndex: 2);
+        var cut = ctx.RenderComponent<HeatmapComponent>(p => p.Add(x => x.Model, model));
+
+        var monthHdrs = cut.FindAll(".hm-col-hdr");
+        monthHdrs.Count.Should().Be(4);
+        monthHdrs[2].ClassList.Should().Contain("current-hdr");
+        monthHdrs.Where((_, i) => i != 2).All(h => !h.ClassList.Contains("current-hdr")).Should().BeTrue();
+
+        cut.FindAll(".hm-cell").Where((_, i) => i % 4 == 2)
+           .All(c => c.ClassList.Contains("current")).Should().BeTrue();
+    }
+
+    [Fact]
+    public void RowHeader_CssClasses_MapToCategories()
+    {
+        using var ctx = new Bunit.TestContext();
+        var cut = ctx.RenderComponent<HeatmapComponent>(p => p.Add(x => x.Model, BuildModel()));
+
+        var rowHdrs = cut.FindAll(".hm-row-hdr");
+        rowHdrs.Count.Should().Be(4);
+        rowHdrs[0].ClassList.Should().Contain("ship-hdr");
+        rowHdrs[1].ClassList.Should().Contain("prog-hdr");
+        rowHdrs[2].ClassList.Should().Contain("carry-hdr");
+        rowHdrs[3].ClassList.Should().Contain("block-hdr");
+    }
+
+    [Fact]
+    public void Cell_Items_RenderEmptyAndOverflowVariants()
+    {
+        using var ctx = new Bunit.TestContext();
+        var months = new[] { "Jan", "Feb", "Mar", "Apr" };
+        var cells = new List<HeatmapCellView>
+        {
+            new(new[] { "Alpha", "Beta" }, 0, IsEmpty: false),
+            new(System.Array.Empty<string>(), 0, IsEmpty: true),
+            new(new[] { "A", "B", "C" }, 5, IsEmpty: false),
+            new(System.Array.Empty<string>(), 0, IsEmpty: true),
+        };
+        var rows = new[]
+        {
+            new HeatmapRowView(HeatmapCategory.Shipped, "SHIPPED", cells),
+            new HeatmapRowView(HeatmapCategory.InProgress, "IN PROGRESS",
+                Enumerable.Range(0,4).Select(_ => new HeatmapCellView(System.Array.Empty<string>(),0,true)).ToList()),
+            new HeatmapRowView(HeatmapCategory.Carryover, "CARRYOVER",
+                Enumerable.Range(0,4).Select(_ => new HeatmapCellView(System.Array.Empty<string>(),0,true)).ToList()),
+            new HeatmapRowView(HeatmapCategory.Blockers, "BLOCKERS",
+                Enumerable.Range(0,4).Select(_ => new HeatmapCellView(System.Array.Empty<string>(),0,true)).ToList()),
+        };
+        var cut = ctx.RenderComponent<HeatmapComponent>(p => p.Add(x => x.Model, new HeatmapViewModel(months, -1, rows)));
+
+        var dataCells = cut.FindAll(".hm-cell");
+        var firstCellItems = dataCells[0].QuerySelectorAll(".it");
+        firstCellItems.Length.Should().Be(2);
+        firstCellItems[0].TextContent.Trim().Should().Be("Alpha");
+        firstCellItems[1].TextContent.Trim().Should().Be("Beta");
+
+        var emptyItems = dataCells[1].QuerySelectorAll(".it.empty");
+        emptyItems.Length.Should().Be(1);
+        emptyItems[0].TextContent.Trim().Should().Be("-");
+
+        var overflowCellItems = dataCells[2].QuerySelectorAll(".it");
+        overflowCellItems.Length.Should().Be(4);
+        var last = overflowCellItems[3];
+        last.ClassList.Should().Contain("overflow");
+        last.TextContent.Trim().Should().Be("+5 more");
+    }
+
+    [Fact]
+    public void ItemText_IsHtmlEncoded_PreventingXss()
+    {
+        using var ctx = new Bunit.TestContext();
+        var months = new[] { "Jan", "Feb", "Mar", "Apr" };
+        var payload = "<script>alert(1)</script>";
+        var firstRowCells = new List<HeatmapCellView>
+        {
+            new(new[] { payload }, 0, IsEmpty: false),
+            new(System.Array.Empty<string>(),0,true),
+            new(System.Array.Empty<string>(),0,true),
+            new(System.Array.Empty<string>(),0,true),
+        };
+        var rows = new[]
+        {
+            new HeatmapRowView(HeatmapCategory.Shipped, "SHIPPED", firstRowCells),
+            new HeatmapRowView(HeatmapCategory.InProgress, "IN PROGRESS",
+                Enumerable.Range(0,4).Select(_ => new HeatmapCellView(System.Array.Empty<string>(),0,true)).ToList()),
+            new HeatmapRowView(HeatmapCategory.Carryover, "CARRYOVER",
+                Enumerable.Range(0,4).Select(_ => new HeatmapCellView(System.Array.Empty<string>(),0,true)).ToList()),
+            new HeatmapRowView(HeatmapCategory.Blockers, "BLOCKERS",
+                Enumerable.Range(0,4).Select(_ => new HeatmapCellView(System.Array.Empty<string>(),0,true)).ToList()),
+        };
+        var cut = ctx.RenderComponent<HeatmapComponent>(p => p.Add(x => x.Model, new HeatmapViewModel(months, -1, rows)));
+
+        cut.FindAll(".hm-cell script").Count.Should().Be(0);
+        cut.Markup.Should().Contain("&lt;script&gt;");
+        cut.Markup.Should().NotContain("<script>alert(1)</script>");
+    }
+}

--- a/tests/ReportingDashboard.Web.Tests/ReportingDashboard.Web.Tests.csproj
+++ b/tests/ReportingDashboard.Web.Tests/ReportingDashboard.Web.Tests.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
@@ -8,7 +7,6 @@
     <IsTestProject>true</IsTestProject>
     <RootNamespace>ReportingDashboard.Web.Tests</RootNamespace>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="xunit" Version="2.9.2" />
@@ -18,9 +16,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.11" />
     <PackageReference Include="coverlet.collector" Version="6.0.2" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\src\ReportingDashboard.Web\ReportingDashboard.Web.csproj" />
   </ItemGroup>
-
 </Project>

--- a/tests/ReportingDashboard.Web.Tests/Services/HeatmapLayoutTests.cs
+++ b/tests/ReportingDashboard.Web.Tests/Services/HeatmapLayoutTests.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using FluentAssertions;
+using ReportingDashboard.Web.Models;
+using ReportingDashboard.Web.Services;
+using Xunit;
+
+namespace ReportingDashboard.Web.Tests.Services;
+
+[Trait("Category", "Unit")]
+public class HeatmapLayoutTests
+{
+    private static Heatmap MakeHeatmap(
+        IReadOnlyList<string>? months = null,
+        int? currentMonthIndex = null,
+        int maxItemsPerCell = 0,
+        IReadOnlyList<HeatmapRow>? rows = null)
+    {
+        return new Heatmap
+        {
+            Months = months ?? new[] { "Jan", "Feb", "Mar", "Apr" },
+            CurrentMonthIndex = currentMonthIndex,
+            MaxItemsPerCell = maxItemsPerCell,
+            Rows = rows ?? Array.Empty<HeatmapRow>()
+        };
+    }
+
+    [Fact]
+    public void Build_EnforcesCanonicalRowOrder_AndFillsMissingCategories()
+    {
+        var rows = new[]
+        {
+            new HeatmapRow { Category = HeatmapCategory.Blockers, Cells = new List<IReadOnlyList<string>> { new[] { "b1" }, Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>() } },
+            new HeatmapRow { Category = HeatmapCategory.Shipped, Cells = new List<IReadOnlyList<string>> { new[] { "s1" }, Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>() } },
+        };
+        var hm = MakeHeatmap(rows: rows);
+
+        var vm = HeatmapLayout.Build(hm, new DateOnly(2026, 4, 10));
+
+        vm.Rows.Select(r => r.Category).Should().ContainInOrder(
+            HeatmapCategory.Shipped, HeatmapCategory.InProgress,
+            HeatmapCategory.Carryover, HeatmapCategory.Blockers);
+
+        vm.Rows[1].Cells.All(c => c.IsEmpty).Should().BeTrue();
+        vm.Rows[2].Cells.All(c => c.IsEmpty).Should().BeTrue();
+        vm.Rows[0].Cells[0].Items.Should().ContainSingle().Which.Should().Be("s1");
+    }
+
+    [Fact]
+    public void Build_HonorsExplicitCurrentMonthIndex()
+    {
+        var hm = MakeHeatmap(currentMonthIndex: 1);
+        var vm = HeatmapLayout.Build(hm, new DateOnly(2026, 3, 15));
+        vm.CurrentMonthIndex.Should().Be(1);
+    }
+
+    [Fact]
+    public void Build_MaxItemsPerCellZero_FallsBackToDefault()
+    {
+        var manyItems = Enumerable.Range(0, 10).Select(i => $"x{i}").ToArray();
+        var rows = new[]
+        {
+            new HeatmapRow { Category = HeatmapCategory.Shipped, Cells = new List<IReadOnlyList<string>> { manyItems, Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>() } }
+        };
+        var hm = MakeHeatmap(maxItemsPerCell: 0, rows: rows);
+
+        var vm = HeatmapLayout.Build(hm, new DateOnly(2026, 4, 10), defaultMaxItems: 4);
+
+        var cell = vm.Rows[0].Cells[0];
+        cell.IsEmpty.Should().BeFalse();
+        cell.OverflowCount.Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public void Build_ProducesFourCanonicalRows_FromEmptyHeatmap()
+    {
+        var hm = MakeHeatmap(rows: Array.Empty<HeatmapRow>());
+        var vm = HeatmapLayout.Build(hm, new DateOnly(2026, 4, 10));
+        vm.Rows.Should().HaveCount(4);
+        vm.Rows.SelectMany(r => r.Cells).All(c => c.IsEmpty).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Build_UnderInvariantCultureTrap_StillResolvesMonth()
+    {
+        var originalCulture = Thread.CurrentThread.CurrentCulture;
+        try
+        {
+            Thread.CurrentThread.CurrentCulture = new CultureInfo("tr-TR");
+            var hm = MakeHeatmap(months: new[] { "Jan", "Feb", "Mar", "Apr" });
+            var vm = HeatmapLayout.Build(hm, new DateOnly(2026, 1, 5));
+            vm.CurrentMonthIndex.Should().BeInRange(-1, 3);
+        }
+        finally
+        {
+            Thread.CurrentThread.CurrentCulture = originalCulture;
+        }
+    }
+}

--- a/tests/ReportingDashboard.Web.UITests/HeatmapUiTests.cs
+++ b/tests/ReportingDashboard.Web.UITests/HeatmapUiTests.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Playwright;
+using Xunit;
+
+namespace ReportingDashboard.Web.UITests;
+
+[Trait("Category", "UI")]
+[Collection("Playwright")]
+public class HeatmapUiTests : IClassFixture<PlaywrightFixture>
+{
+    private readonly PlaywrightFixture _fx;
+
+    public HeatmapUiTests(PlaywrightFixture fx)
+    {
+        _fx = fx;
+    }
+
+    [Fact]
+    public async Task Heatmap_WrapAndTitle_AreVisible()
+    {
+        var page = await _fx.NewPageAsync();
+        (await page.Locator(".hm-wrap").CountAsync()).Should().Be(1);
+        var titleText = await page.Locator(".hm-title").InnerTextAsync();
+        titleText.Should().Contain("Monthly Execution Heatmap");
+        titleText.Should().Contain("Shipped");
+        titleText.Should().Contain("In Progress");
+        titleText.Should().Contain("Carryover");
+        titleText.Should().Contain("Blockers");
+    }
+
+    [Fact]
+    public async Task HmGrid_Has25DirectChildren()
+    {
+        var page = await _fx.NewPageAsync();
+        var count = await page.Locator(".hm-grid > *").CountAsync();
+        count.Should().Be(25);
+    }
+
+    [Fact]
+    public async Task HeaderRow_HasCornerAndFourMonthHeaders()
+    {
+        var page = await _fx.NewPageAsync();
+        (await page.Locator(".hm-grid .hm-corner").CountAsync()).Should().Be(1);
+        (await page.Locator(".hm-grid .hm-col-hdr").CountAsync()).Should().Be(4);
+        (await page.Locator(".hm-corner").InnerTextAsync()).Trim().Should().Be("Status");
+    }
+
+    [Fact]
+    public async Task AllFourCategoryRowHeaders_RenderInCanonicalOrder()
+    {
+        var page = await _fx.NewPageAsync();
+        var rowHdrs = page.Locator(".hm-row-hdr");
+        (await rowHdrs.CountAsync()).Should().Be(4);
+        (await rowHdrs.Nth(0).GetAttributeAsync("class"))!.Should().Contain("ship-hdr");
+        (await rowHdrs.Nth(1).GetAttributeAsync("class"))!.Should().Contain("prog-hdr");
+        (await rowHdrs.Nth(2).GetAttributeAsync("class"))!.Should().Contain("carry-hdr");
+        (await rowHdrs.Nth(3).GetAttributeAsync("class"))!.Should().Contain("block-hdr");
+    }
+
+    [Fact]
+    public async Task NoInteractiveArtifacts_InHeatmap()
+    {
+        var page = await _fx.NewPageAsync();
+        (await page.Locator(".hm-wrap script").CountAsync()).Should().Be(0);
+        (await page.Locator(".hm-wrap button").CountAsync()).Should().Be(0);
+        var html = await page.ContentAsync();
+        html.Should().NotContain("blazor.server.js");
+    }
+}

--- a/tests/ReportingDashboard.Web.UITests/PlaywrightFixture.cs
+++ b/tests/ReportingDashboard.Web.UITests/PlaywrightFixture.cs
@@ -1,17 +1,16 @@
+using System;
+using System.Threading.Tasks;
 using Microsoft.Playwright;
 using Xunit;
 
 namespace ReportingDashboard.Web.UITests;
-
-[CollectionDefinition("Playwright")]
-public class PlaywrightCollection : ICollectionFixture<PlaywrightFixture> { }
 
 public class PlaywrightFixture : IAsyncLifetime
 {
     public IPlaywright Playwright { get; private set; } = default!;
     public IBrowser Browser { get; private set; } = default!;
 
-    public string BaseUrl =>
+    public string BaseUrl { get; } =
         Environment.GetEnvironmentVariable("BASE_URL") ?? "http://localhost:5080";
 
     public async Task InitializeAsync()
@@ -23,9 +22,15 @@ public class PlaywrightFixture : IAsyncLifetime
 
     public async Task<IPage> NewPageAsync()
     {
-        var context = await Browser.NewContextAsync();
-        context.SetDefaultTimeout(60000);
-        return await context.NewPageAsync();
+        var ctx = await Browser.NewContextAsync(new BrowserNewContextOptions
+        {
+            ViewportSize = new ViewportSize { Width = 1920, Height = 1080 }
+        });
+        var page = await ctx.NewPageAsync();
+        page.SetDefaultTimeout(60000);
+        await page.GotoAsync(BaseUrl);
+        await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+        return page;
     }
 
     public async Task DisposeAsync()
@@ -34,3 +39,6 @@ public class PlaywrightFixture : IAsyncLifetime
         Playwright?.Dispose();
     }
 }
+
+[CollectionDefinition("Playwright")]
+public class PlaywrightCollection : ICollectionFixture<PlaywrightFixture> { }


### PR DESCRIPTION
## Task Assignment
**Assigned To:** SoftwareEngineer
**Complexity:** High
**Branch:** `agent/softwareengineer/t8-build-monthly-execution-heatmap-component`

## Requirements
Closes #2066

# PR: Build Monthly Execution Heatmap Component (T8)

## Summary

Fleshes out `Heatmap.razor` (T1 stub) into the full `.hm-wrap` section: a 14px uppercase section title (`"Monthly Execution Heatmap · Shipped • In Progress • Carryover • Blockers"`) followed by a `.hm-grid` 5×5 CSS Grid (`grid-template-columns:160px repeat(4,1fr); grid-template-rows:36px repeat(4,1fr)`). Row 0 is `.hm-corner` + four `.hm-col-hdr` month headers (current month adds `.current-hdr`). Rows 1–4 render in a **fixed, enforced order** — Shipped, InProgress, Carryover, Blockers — using `.ship-hdr`/`.ship-cell`, `.prog-*`, `.carry-*`, `.block-*`; the current-month column cell on every data row additionally gets `.current`. Each cell renders its `Items` as `<div class="it">` (with a category-colored `::before` dot via scoped CSS); if `IsEmpty`, a single `<div class="it empty">-</div>` renders in `#AAA`; if `OverflowCount > 0`, a trailing `<div class="it overflow">+K more</div>` is appended.

Adds a new `HeatmapLayout` static helper under `Services/` (distinct from `TimelineMath`) that builds a `HeatmapViewModel` from `Heatmap` + today's date. Truncation is encapsulated in `TruncateItems(items, maxItems)` which returns `(kept, overflowCount)` per the architecture spec's rule: when `items.Count > maxItems`, keep the first `maxItems - 1` items and surface `K = items.Count - (maxItems - 1)` as overflow; when `items.Count <= maxItems`, no truncation. `CurrentMonthIndex` resolves from `Heatmap.CurrentMonthIndex` if set, otherwise by matching `DateTime.Today`'s month abbreviation against `Heatmap.Months` (case-insensitive, invariant culture), returning `-1` on no match (which disables all `.current`/`.current-hdr` application).

Static SSR only: no `@rendermode`, no event handlers, no JS interop, no tooltips. Scoped CSS additions live in `Heatmap.razor.css`; rules already ported to `Dashboard.razor.css` in T5 are not duplicated — this PR's `.razor.css` is limited to component-local selectors (the `.it::before` dot positioning and any `.it.empty` / `.it.overflow` tuning that doesn't already exist globally).

## Acceptance Criteria

- [ ] `Heatmap.razor` declares `[Parameter] public required HeatmapViewModel Model { get; set; }` and contains no `@rendermode`, no `@onclick`, no `@inject`.
- [ ] Root is `<div class="hm-wrap">` containing exactly two children: `<div class="hm-title">` and `<div class="hm-grid">`.
- [ ] `.hm-title` renders the literal text `"Monthly Execution Heatmap · Shipped • In Progress • Carryover • Blockers"` (uses `·` U+00B7 and `•` U+2022; all encoded as `@("...")` or plain Razor text — never `MarkupString`).
- [ ] `.hm-grid` contains exactly **25 direct child** cells in DOM order: row 0 = `.hm-corner` + 4× `.hm-col-hdr`; rows 1–4 = `.hm-row-hdr` + 4× `.hm-cell` (5 cells × 5 rows = 25).
- [ ] `.hm-corner` cell renders the literal text `"Status"`.
- [ ] Month header cells: for `i` in `[0..3]`, render `<div class="hm-col-hdr @(i == Model.CurrentMonthIndex ? "current-hdr" : null)">@Model.Months[i]</div>`. When `CurrentMonthIndex == -1`, **no** cell gets `.current-hdr`.
- [ ] Data rows render in **enforced fixed order** regardless of `Model.Rows[]` input order: Shipped → InProgress → Carryover → Blockers. The component looks up each category from `Model.Rows` by `Category`; missing categories render as an all-empty row (4 cells of `-`) rather than throwing.
- [ ] Row-header CSS class mapping: `HeatmapCategory.Shipped` → `hm-row-hdr ship-hdr`; `InProgress` → `hm-row-hdr prog-hdr`; `Carryover` → `hm-row-hdr carry-hdr`; `Blockers` → `hm-row-hdr block-hdr`. Row-header text comes from `row.HeaderLabel` (already uppercase per layout engine).
- [ ] Data-cell CSS class mapping: `Shipped` → `hm-cell ship-cell`; `InProgress` → `hm-cell prog-cell`; `Carryover` → `hm-cell carry-cell`; `Blockers` → `hm-cell block-cell`. Current-month cells additionally get `current` appended (space-separated, not comma).
- [ ] Cell content rendering rules (in DOM order):
  - If `cell.IsEmpty`: exactly one `<div class="it empty">-</div>`, no dot (CSS suppresses `::before`).
  - Else: one `<div class="it">@item</div>` per string in `cell.Items`, in order.
  - If `cell.OverflowCount > 0`: append one final `<div class="it overflow">+@cell.OverflowCount more</div>`.
- [ ] All item text is rendered via Razor auto-encoding (`@item`), never `MarkupString` — malicious `<script>` content in `data.json` must not execute.
- [ ] `HeatmapLayout.Build(Heatmap heatmap, DateOnly today, int defaultMaxItems = 4)` returns a `HeatmapViewModel` with:
  - `Months` equal to `heatmap.Months` (same order, same content).
  - `CurrentMonthIndex` = `heatmap.CurrentMonthIndex ?? AutoResolve(today, heatmap.Months)`; `AutoResolve` matches `today.ToString("MMM", CultureInfo.InvariantCulture)` against `Months` with `StringComparison.OrdinalIgnoreCase`, returning `-1` on no match.
  - `Rows` contains exactly 4 entries in the canonical order Shipped, InProgress, Carryover, Blockers, sourced by lookup from `heatmap.Rows`; missing rows default to 4 empty cells.
  - Each cell's `(Items, OverflowCount, IsEmpty)` produced by `TruncateItems(source, effectiveMax)` where `effectiveMax = heatmap.MaxItemsPerCell > 0 ? heatmap.MaxItemsPerCell : defaultMaxItems`.
- [ ] `HeatmapLayout.TruncateItems(IReadOnlyList<string> items, int maxItems)` contract:
  - `items.Count == 0` → `(Items: [], OverflowCount: 0, IsEmpty: true)`.
  - `items.Count <= maxItems` → `(items, 0, false)` (no overflow row).
  - `items.Count > maxItems` → `Items` = first `maxItems - 1` items, `OverflowCount = items.Count - (maxItems - 1)`, `IsEmpty = false`.
  - `maxItems < 1` → treated as 1 (defensive; logs nothing, returns overflow-only behavior consistent with above).
- [ ] `HeatmapViewModel.Empty` static exists and renders a valid 4-row × 4-column shell with all cells `IsEmpty = true`, `Months = ["","","",""]`, `CurrentMonthIndex = -1`.
- [ ] `Heatmap.razor.css` defines only component-local rules: `.it::before` dot sizing/positioning (6×6px, `border-radius:50%`, `left:0; top:7px;`), per-category `.ship-cell .it::before { background:#34A853 } ` etc., and `.it.empty::before { background:transparent }` / `.it.overflow { color:#666; font-style:italic }` (or similar). Does NOT redefine `.hm-grid`/`.hm-wrap` if already in `Dashboard.razor.css`.
- [ ] Rendered HTML contains zero `@onclick`, zero `<script>`, zero `<button>`, and no occurrence of `blazor.server.js`.

## Implementation Steps

1. **Scaffold files and stabilize build.**
   - Reduce `src/ReportingDashboard.Web/Components/Pages/Partials/Heatmap.razor` to a minimal compiling shell: `@namespace`/`@using` directives, `[Parameter] public required HeatmapViewModel Model { get; set; }` in `@code`, and a body of `<div class="hm-wrap"></div>`.
   - Create empty `src/ReportingDashboard.Web/Components/Pages/Partials/Heatmap.razor.css`.
   - Create `src/ReportingDashboard.Web/Services/HeatmapLayout.cs` with `namespace ReportingDashboard.Web.Services;` and a `public static class HeatmapLayout { public static HeatmapViewModel Build(Heatmap h, DateOnly today, int defaultMaxItems = 4) => throw new NotImplementedException(); public static (IReadOnlyList<string> Items, int OverflowCount, bool IsEmpty) TruncateItems(IReadOnlyList<string> items, int maxItems) => throw new NotImplementedException(); }`.
   - Create `tests/ReportingDashboard.Web.Tests/Services/HeatmapLayoutTests.cs` and `tests/ReportingDashboard.Web.Tests/Components/HeatmapTests.cs` with placeholder `[Fact] public void Placeholder() { }`.
   - Verify `dotnet build ReportingDashboard.sln` + `dotnet test` pass. Commit.

2. **Implement `HeatmapLayout.TruncateItems` + unit tests.**
   - Implement the truncation contract exactly as specified (0 → empty; ≤N → passthrough; >N → first N-1 + overflow count).
   - Flesh out `HeatmapLayoutTests` truncation cases first (TDD): items=0, 1, N-1, N, N+1, N+5, N=1 edge, N=0 clamps to 1.
   - Commit.

3. **Implement `HeatmapLayout.Build` + auto-resolution of `CurrentMonthIndex` + canonical row ordering + tests.**
   - Implement `AutoResolve(DateOnly today, IReadOnlyList<string> months)` using `today.ToString("MMM", CultureInfo.InvariantCulture)` and `OrdinalIgnoreCase` match.
   - Implement row reordering: build a dictionary from `heatmap.Rows` keyed by `Category`, then emit a 4-row sequence in the canonical enum order; fill gaps with an all-empty row.
   - Apply `TruncateItems` per cell using `effectiveMax`; assemble the `HeatmapRowView` with `HeaderLabel` = uppercased category display name (e.g., `InProgress` → `"IN PROGRESS"`).
   - Add `HeatmapViewModel.Empty` static.
   - Extend `HeatmapLayoutTests` to cover: explicit `CurrentMonthIndex` honored, null → auto-resolve hit, null → no match returns `-1`, out-of-order input rows are reordered, missing categories filled empty, `MaxItemsPerCell=0` falls back to `defaultMaxItems`.
   - Commit.

4. **Build the Razor markup: title + grid header row + 4 data rows.**
   - In `Heatmap.razor`, render `.hm-title` with the literal section title string.
   - Render `.hm-grid` with a `@foreach`/indexed loop for the header row (corner + 4 month headers, conditional `.current-hdr`).
   - Render the 4 data rows by iterating the canonical category order, looking up the row from `Model.Rows`, and emitting the row header + 4 cells per row. Use a small `@code` helper `CellClasses(category, isCurrent)` and `RowHdrClass(category)` returning the appropriate class strings.
   - Inside each cell, branch on `IsEmpty` / `OverflowCount` and emit `.it` / `.it.empty` / `.it.overflow` divs.
   - Commit.

5. **Component-local scoped CSS (`Heatmap.razor.css`) and visual verification.**
   - Add `.it` / `.it::before` dot rules keyed by parent category class (`.ship-cell .it::before { background:#34A853; }`, `.prog-cell .it::before { background:#0078D4; }`, `.carry-cell .it::before { background:#F4B400; }`, `.block-cell .it::before { background:#EA4335; }`), plus `.it.empty { color:#AAA; }` and `.it.empty::before { background:transparent; }`, and `.it.overflow { color:#666; font-style:italic; }`.
   - Do NOT redeclare rules owned by `Dashboard.razor.css` from T5. If there is overlap, remove the duplicate from `Heatmap.razor.css` and note it in the PR description.
   - Run `dotnet run` against the sample `data.json` and visually diff against `docs/design-screenshots/OriginalDesignConcept.png` at 1920×1080. Capture a screenshot in the PR.
   - Commit.

6. **bUnit component tests for `Heatmap.razor`.**
   - In `HeatmapTests.cs` add tests enumerated in the Testing section. Use a shared `BuildModel(...)` helper constructing `HeatmapViewModel` instances deterministically (do not go through `HeatmapLayout` — keep component tests decoupled from service logic).
   - Ensure `dotnet test` is green and `dotnet format --verify-no-changes` passes.
   - Commit.

## Testing

**`HeatmapLayoutTests` (xUnit, pure):**

- **Truncation — empty** → `(items=[], overflow=0, isEmpty=true)`.
- **Truncation — at limit** → `items.Count == maxItems` returns passthrough, `overflow=0`.
- **Truncation — one under limit** → passthrough, `overflow=0`.
- **Truncation — one over limit** → returns first `maxItems-1`, `overflow = 2` (when count = maxItems+1, because (maxItems+1) - (maxItems-1) = 2).
- **Truncation — many over limit** → `items.Count=10, maxItems=4` returns first 3, overflow=7.
- **Truncation — `maxItems < 1` clamped to 1** → no crash, consistent overflow behavior.
- **AutoResolve — exact match** → `Months=["Jan","Feb","Mar","Apr"]`, `today=2026-03-15` → `CurrentMonthIndex=2`.
- **AutoResolve — case insensitive** → `Months=["jan","feb","mar","apr"]` still matches.
- **AutoResolve — no match** → `Months=["Q1","Q2","Q3","Q4"]`, any `today` → `-1`.
- **AutoResolve — invariant culture** → run under `CultureInfo("tr-TR")` (famous "İ"/"i" trap); matching `"Jan"` still works because we pin `CultureInfo.InvariantCulture`.
- **Explicit `CurrentMonthIndex` honored** → `heatmap.CurrentMonthIndex=1` overrides auto-resolution even when today would map to index 3.
- **Row reordering** → `heatmap.Rows` supplied as `[Blockers, Carryover, InProgress, Shipped]` yields `Rows[0].Category=Shipped, Rows[1]=InProgress, Rows[2]=Carryover, Rows[3]=Blockers`.
- **Missing category filled empty** → `heatmap.Rows` omits `Carryover`; result has a Carryover row with 4 cells, all `IsEmpty=true`.
- **`MaxItemsPerCell == 0`** → falls back to `defaultMaxItems` (4 by default).
- **Cell items preserved verbatim** → non-truncating case does not mutate item strings (whitespace, unicode, HTML-looking strings all pass through).

**`HeatmapTests` (bUnit):**

- **Renders empty shell without throw** → `HeatmapViewModel.Empty` yields `.hm-wrap > .hm-title + .hm-grid`; grid has exactly 25 direct children; no exceptions.
- **Title text** → `.hm-title` contains the exact literal including `·` and `•` (assert via `TextContent`).
- **Header row structure** → first 5 grid children are `.hm-corner, .hm-col-hdr, .hm-col-hdr, .hm-col-hdr, .hm-col-hdr` in order.
- **Current-month header class** → with `CurrentMonthIndex=2`, exactly the 3rd `.hm-col-hdr` element has class `current-hdr`; the other three do not.
- **No current class when index is -1** → `CurrentMonthIndex=-1` → zero `.current-hdr` elements, zero `.current` on data cells.
- **Canonical row order enforced in DOM** → given `Model.Rows` in reverse order, rendered row-headers still appear in DOM as Shipped, InProgress, Carryover, Blockers. (Relies on component enforcement, not just layout engine.)
- **Row-header classes** → each `.hm-row-hdr` has the correct category class (`ship-hdr`, `prog-hdr`, `carry-hdr`, `block-hdr`).
- **Data-cell classes** → in a row with `CurrentMonthIndex=1`, the 2nd data cell has classes `hm-cell prog-cell current` (or equivalent for each row); other cells lack `current`.
- **Cell items rendering** → a cell with `Items=["Alpha","Beta"], OverflowCount=0, IsEmpty=false` produces exactly 2 `.it` children with text "Alpha" and "Beta".
- **Empty cell** → `IsEmpty=true` produces exactly one `.it.empty` child with text `-`.
- **Overflow cell** → `Items=["A","B","C"], OverflowCount=5, IsEmpty=false` produces 4 `.it` children where the last has class `overflow` and text `+5 more`.
- **XSS safety** → `Items=["<script>alert(1)</script>"]` renders as encoded text; querying for a `<script>` element inside `.hm-cell` returns zero nodes.
- **No interactive artifacts** → rendered markup contains zero `@onclick`, zero `<script`, zero `<button`, and no `blazor.server.js` reference.
- **Missing-category tolerance** → `Model` where `Rows` has only Shipped + Blockers still renders 4 data rows (InProgress + Carryover filled with 4 empty cells each).

Coverage target: ≥80% line coverage on `HeatmapLayout.cs`; ≥70% on the `Heatmap.razor` generated class.

## References
- Architecture: Architecture.md
- PM Spec: 

## Status
- [ ] Implementation
- [ ] Tests Written
- [ ] Ready for Review