### PR TITLE
SoftwareEngineer: Build Error Banner and Wire Dashboard Composition

### DIFF
--- a/.agentsquad/build-error-banner-and-wire-dashboard-composition.task
+++ b/.agentsquad/build-error-banner-and-wire-dashboard-composition.task
@@ -1,0 +1,4 @@
+agent: SoftwareEngineer
+task: Build Error Banner and Wire Dashboard Composition
+complexity: Medium
+status: in-progress

--- a/src/ReportingDashboard.Web/Components/Pages/Dashboard.razor
+++ b/src/ReportingDashboard.Web/Components/Pages/Dashboard.razor
@@ -1,50 +1,102 @@
 @page "/"
 @* Static SSR - intentionally NO @rendermode directive. *@
+@using System.Globalization
+@using ReportingDashboard.Web.Components.Pages.Partials
+@using ReportingDashboard.Web.Models
+@using ReportingDashboard.Web.Services
+@inject IDashboardDataService Data
 
 <PageTitle>Reporting Dashboard</PageTitle>
 
-<div class="hdr">
-    <div>
-        <h1>Reporting Dashboard</h1>
-        <div class="sub">Static SSR shell &bull; data binding lands in a later task</div>
-    </div>
-</div>
+@if (_error is not null)
+{
+    <ErrorBanner Error="_error" />
+}
 
-<div class="tl-area">
-    <div class="tl-svg-box"></div>
-</div>
+<DashboardHeader Project="_project" NowLabel="@_nowLabel" />
+<TimelineSvg Model="_timelineVm" />
+<Heatmap Model="_heatmapVm" />
 
-<div class="hm-wrap">
-    <div class="hm-title">Monthly Execution Heatmap &mdash; Shipped &middot; In Progress &middot; Carryover &middot; Blockers</div>
-    <div class="hm-grid">
-        <div class="hm-corner">Status</div>
-        <div class="hm-col-hdr">&nbsp;</div>
-        <div class="hm-col-hdr">&nbsp;</div>
-        <div class="hm-col-hdr">&nbsp;</div>
-        <div class="hm-col-hdr">&nbsp;</div>
+@code {
+    private DashboardLoadError? _error;
+    private Project _project = Project.Placeholder;
+    private string _nowLabel = "Now";
+    private TimelineViewModel _timelineVm = TimelineViewModel.Empty;
+    private HeatmapViewModel _heatmapVm = HeatmapViewModel.Empty;
 
-        <div class="hm-row-hdr ship-hdr">Shipped</div>
-        <div class="hm-cell ship-cell"></div>
-        <div class="hm-cell ship-cell"></div>
-        <div class="hm-cell ship-cell"></div>
-        <div class="hm-cell ship-cell"></div>
+    protected override void OnInitialized()
+    {
+        var today = DateOnly.FromDateTime(DateTime.Today);
+        _nowLabel = "Now (" + DateTime.Today.ToString("MMM yyyy", CultureInfo.InvariantCulture) + ")";
 
-        <div class="hm-row-hdr prog-hdr">In Progress</div>
-        <div class="hm-cell prog-cell"></div>
-        <div class="hm-cell prog-cell"></div>
-        <div class="hm-cell prog-cell"></div>
-        <div class="hm-cell prog-cell"></div>
+        var result = Data.GetCurrent();
+        _error = result.Error;
 
-        <div class="hm-row-hdr carry-hdr">Carryover</div>
-        <div class="hm-cell carry-cell"></div>
-        <div class="hm-cell carry-cell"></div>
-        <div class="hm-cell carry-cell"></div>
-        <div class="hm-cell carry-cell"></div>
+        if (result.Data is { } d)
+        {
+            _project = d.Project;
+            _timelineVm = BuildTimelineSafe(d.Timeline, today);
+            _heatmapVm = BuildHeatmapSafe(d.Heatmap, today);
+        }
+        else
+        {
+            _project = Project.Placeholder;
+            _timelineVm = TimelineViewModel.Empty;
+            _heatmapVm = HeatmapViewModel.Empty;
+        }
+    }
 
-        <div class="hm-row-hdr block-hdr">Blockers</div>
-        <div class="hm-cell block-cell"></div>
-        <div class="hm-cell block-cell"></div>
-        <div class="hm-cell block-cell"></div>
-        <div class="hm-cell block-cell"></div>
-    </div>
-</div>
+    private static TimelineViewModel BuildTimelineSafe(Timeline timeline, DateOnly today)
+    {
+        try
+        {
+            if (timeline is null || timeline.End <= timeline.Start)
+                return TimelineViewModel.Empty;
+
+            var gridlines = TimelineMath.MonthGridlines(timeline.Start, timeline.End, 1560);
+            var now = TimelineMath.NowX(today, timeline.Start, timeline.End, 1560);
+
+            var lanes = timeline.Lanes ?? Array.Empty<TimelineLane>();
+            var laneCount = Math.Max(lanes.Count, 1);
+            const int topPad = 20, bottomPad = 20;
+            var usable = 185 - topPad - bottomPad;
+
+            var laneVms = new List<LaneGeometry>(lanes.Count);
+            for (var i = 0; i < lanes.Count; i++)
+            {
+                var lane = lanes[i];
+                var y = topPad + (i + 0.5) * usable / laneCount;
+
+                var milestones = new List<MilestoneGeometry>();
+                foreach (var ms in lane.Milestones ?? Array.Empty<Milestone>())
+                {
+                    if (ms.Date < timeline.Start || ms.Date > timeline.End) continue;
+                    var x = TimelineMath.DateToX(ms.Date, timeline.Start, timeline.End, 1560);
+                    milestones.Add(new MilestoneGeometry(
+                        x, y, ms.Type, ms.Label,
+                        ms.CaptionPosition ?? CaptionPosition.Above));
+                }
+
+                laneVms.Add(new LaneGeometry(lane.Id, lane.Label, lane.Color, y, milestones));
+            }
+
+            return new TimelineViewModel(gridlines, laneVms, now);
+        }
+        catch
+        {
+            return TimelineViewModel.Empty;
+        }
+    }
+
+    private static HeatmapViewModel BuildHeatmapSafe(ReportingDashboard.Web.Models.Heatmap heatmap, DateOnly today)
+    {
+        try
+        {
+            return HeatmapLayout.Build(heatmap, today);
+        }
+        catch
+        {
+            return HeatmapViewModel.Empty;
+        }
+    }
+}

--- a/src/ReportingDashboard.Web/Components/Pages/Partials/ErrorBanner.razor
+++ b/src/ReportingDashboard.Web/Components/Pages/Partials/ErrorBanner.razor
@@ -1,6 +1,35 @@
-@* TODO(T9): render full-width red error banner with file path, line/col, kind, and message. *@
-<div class="error-banner" role="alert">Error placeholder</div>
+@using ReportingDashboard.Web.Models
+
+@if (Error is not null)
+{
+    <div class="error-banner" role="alert">
+        <strong>@Heading</strong>
+        <span class="error-kind">@KindLabel</span>
+        <span class="error-path">@Error.FilePath</span>
+        @if (Error.Line is { } line)
+        {
+            <span class="error-location">line @line@(Error.Column is { } col ? $", col {col}" : "")</span>
+        }
+        <span class="error-message">@Error.Message</span>
+    </div>
+}
 
 @code {
     [Parameter] public DashboardLoadError? Error { get; set; }
+
+    private string Heading => Error?.Kind switch
+    {
+        DashboardLoadErrorKind.NotFound => "data.json not found",
+        DashboardLoadErrorKind.ParseError => "Failed to parse data.json",
+        DashboardLoadErrorKind.ValidationError => "data.json failed validation",
+        _ => "Failed to load data.json"
+    };
+
+    private string KindLabel => Error?.Kind switch
+    {
+        DashboardLoadErrorKind.NotFound => "not found",
+        DashboardLoadErrorKind.ParseError => "parse error",
+        DashboardLoadErrorKind.ValidationError => "validation error",
+        _ => Error?.Kind ?? string.Empty
+    };
 }

--- a/src/ReportingDashboard.Web/Services/DashboardDataValidator.cs
+++ b/src/ReportingDashboard.Web/Services/DashboardDataValidator.cs
@@ -1,0 +1,163 @@
+using System.Text.RegularExpressions;
+using ReportingDashboard.Web.Models;
+
+namespace ReportingDashboard.Web.Services;
+
+/// <summary>
+/// Pure, stateless v1 validator for a deserialized <see cref="DashboardData"/>.
+/// Returns a list of human-readable error strings; empty means valid.
+/// </summary>
+public static class DashboardDataValidator
+{
+    private static readonly Regex HexColor = new("^#[0-9A-Fa-f]{6}$", RegexOptions.Compiled);
+
+    private static readonly HashSet<HeatmapCategory> RequiredCategories = new()
+    {
+        HeatmapCategory.Shipped,
+        HeatmapCategory.InProgress,
+        HeatmapCategory.Carryover,
+        HeatmapCategory.Blockers
+    };
+
+    public static IReadOnlyList<string> Validate(DashboardData? data)
+    {
+        var errors = new List<string>();
+        if (data is null)
+        {
+            errors.Add("data is null");
+            return errors;
+        }
+
+        ValidateProject(data.Project, errors);
+        ValidateTimeline(data.Timeline, errors);
+        ValidateHeatmap(data.Heatmap, errors);
+
+        return errors;
+    }
+
+    private static void ValidateProject(Project? project, List<string> errors)
+    {
+        if (project is null)
+        {
+            errors.Add("project is required");
+            return;
+        }
+        if (string.IsNullOrWhiteSpace(project.Title))
+        {
+            errors.Add("project.title must be non-empty");
+        }
+        if (!string.IsNullOrWhiteSpace(project.BacklogUrl) &&
+            !Uri.TryCreate(project.BacklogUrl, UriKind.Absolute, out _))
+        {
+            errors.Add($"project.backlogUrl is not a valid absolute URI: '{project.BacklogUrl}'");
+        }
+    }
+
+    private static void ValidateTimeline(Timeline? timeline, List<string> errors)
+    {
+        if (timeline is null)
+        {
+            errors.Add("timeline is required");
+            return;
+        }
+
+        if (timeline.Start >= timeline.End)
+        {
+            errors.Add($"timeline.start ({timeline.Start:yyyy-MM-dd}) must be before timeline.end ({timeline.End:yyyy-MM-dd})");
+        }
+
+        var lanes = timeline.Lanes ?? Array.Empty<TimelineLane>();
+        if (lanes.Count < 1 || lanes.Count > 6)
+        {
+            errors.Add($"timeline.lanes must have 1..6 entries (got {lanes.Count})");
+        }
+
+        var seenIds = new HashSet<string>(StringComparer.Ordinal);
+        for (var i = 0; i < lanes.Count; i++)
+        {
+            var lane = lanes[i];
+            var prefix = $"timeline.lanes[{i}]";
+            if (string.IsNullOrWhiteSpace(lane.Id))
+            {
+                errors.Add($"{prefix}.id must be non-empty");
+            }
+            else if (!seenIds.Add(lane.Id))
+            {
+                errors.Add($"{prefix}.id '{lane.Id}' is duplicated");
+            }
+
+            if (string.IsNullOrWhiteSpace(lane.Color) || !HexColor.IsMatch(lane.Color))
+            {
+                errors.Add($"{prefix}.color must match ^#[0-9A-Fa-f]{{6}}$ (got '{lane.Color}')");
+            }
+
+            var milestones = lane.Milestones ?? Array.Empty<Milestone>();
+            for (var m = 0; m < milestones.Count; m++)
+            {
+                var ms = milestones[m];
+                if (timeline.Start < timeline.End &&
+                    (ms.Date < timeline.Start || ms.Date > timeline.End))
+                {
+                    errors.Add(
+                        $"{prefix}.milestones[{m}].date ({ms.Date:yyyy-MM-dd}) is outside timeline range " +
+                        $"[{timeline.Start:yyyy-MM-dd}, {timeline.End:yyyy-MM-dd}]");
+                }
+            }
+        }
+    }
+
+    private static void ValidateHeatmap(Heatmap? heatmap, List<string> errors)
+    {
+        if (heatmap is null)
+        {
+            errors.Add("heatmap is required");
+            return;
+        }
+
+        var months = heatmap.Months ?? Array.Empty<string>();
+        if (months.Count == 0)
+        {
+            errors.Add("heatmap.months must have at least one entry");
+        }
+
+        var rows = heatmap.Rows ?? Array.Empty<HeatmapRow>();
+        var seenCats = new HashSet<HeatmapCategory>();
+        for (var i = 0; i < rows.Count; i++)
+        {
+            var row = rows[i];
+            if (!seenCats.Add(row.Category))
+            {
+                errors.Add($"heatmap.rows[{i}].category '{row.Category}' is duplicated");
+            }
+
+            var cells = row.Cells ?? Array.Empty<IReadOnlyList<string>>();
+            if (months.Count > 0 && cells.Count != months.Count)
+            {
+                errors.Add(
+                    $"heatmap.rows[{i}] ({row.Category}) has {cells.Count} cells but months.Length is {months.Count}");
+            }
+        }
+
+        foreach (var required in RequiredCategories)
+        {
+            if (!seenCats.Contains(required))
+            {
+                errors.Add($"heatmap.rows is missing required category '{required}'");
+            }
+        }
+
+        if (heatmap.CurrentMonthIndex is { } idx)
+        {
+            if (idx < 0 || idx >= months.Count)
+            {
+                errors.Add(
+                    $"heatmap.currentMonthIndex ({idx}) must be in [0, {months.Count}) or null");
+            }
+        }
+
+        if (heatmap.MaxItemsPerCell < 1)
+        {
+            errors.Add($"heatmap.maxItemsPerCell must be >= 1 (got {heatmap.MaxItemsPerCell})");
+        }
+    }
+}

--- a/tests/ReportingDashboard.Web.Tests/Components/DashboardRenderTests.cs
+++ b/tests/ReportingDashboard.Web.Tests/Components/DashboardRenderTests.cs
@@ -1,0 +1,85 @@
+using Bunit;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using ReportingDashboard.Web.Models;
+using ReportingDashboard.Web.Services;
+using Xunit;
+
+namespace ReportingDashboard.Web.Tests.Components;
+
+[Trait("Category", "Unit")]
+public class DashboardRenderTests
+{
+    [Fact]
+    public void Dashboard_WithValidData_RendersHeaderTimelineAndHeatmap()
+    {
+        using var ctx = new Bunit.TestContext();
+        ctx.Services.AddSingleton<IDashboardDataService>(FakeDashboardDataService.WithSample());
+
+        var cut = ctx.RenderComponent<ReportingDashboard.Web.Components.Pages.Dashboard>();
+
+        cut.Find("header.hdr").Should().NotBeNull();
+        cut.Find(".tl-area").Should().NotBeNull();
+        cut.Find(".hm-grid").Should().NotBeNull();
+        cut.Find(".hdr h1").TextContent.Should().Contain("Sample Project");
+        cut.FindAll(".error-banner").Should().BeEmpty();
+        cut.FindAll("div.hm-grid > div").Count.Should().Be(25);
+    }
+
+    [Fact]
+    public void Dashboard_WithError_RendersErrorBanner_AndPlaceholderLayout()
+    {
+        var err = new DashboardLoadError(
+            FilePath: "wwwroot/data.json",
+            Message: "Unexpected end of JSON input",
+            Line: 42, Column: 3,
+            Kind: DashboardLoadErrorKind.ParseError);
+
+        using var ctx = new Bunit.TestContext();
+        ctx.Services.AddSingleton<IDashboardDataService>(FakeDashboardDataService.WithError(err));
+
+        var cut = ctx.RenderComponent<ReportingDashboard.Web.Components.Pages.Dashboard>();
+
+        var banner = cut.Find(".error-banner");
+        banner.GetAttribute("role").Should().Be("alert");
+        banner.TextContent.Should().Contain("wwwroot/data.json");
+        banner.TextContent.Should().Contain("parse error");
+        banner.TextContent.Should().Contain("line 42");
+        banner.TextContent.Should().Contain("Unexpected end of JSON input");
+
+        // Layout bands still present so page preserves 1920x1080.
+        cut.Find("header.hdr").Should().NotBeNull();
+        cut.Find(".tl-area").Should().NotBeNull();
+        cut.Find(".hm-grid").Should().NotBeNull();
+        cut.Find(".hdr h1").TextContent.Should().Contain("(data.json error)");
+    }
+
+    [Fact]
+    public void Dashboard_WithNotFoundError_RendersNotFoundKind()
+    {
+        var err = new DashboardLoadError(
+            FilePath: "wwwroot/data.json",
+            Message: "data.json not found at wwwroot/data.json.",
+            Line: null, Column: null,
+            Kind: DashboardLoadErrorKind.NotFound);
+
+        using var ctx = new Bunit.TestContext();
+        ctx.Services.AddSingleton<IDashboardDataService>(FakeDashboardDataService.WithError(err));
+
+        var cut = ctx.RenderComponent<ReportingDashboard.Web.Components.Pages.Dashboard>();
+        var banner = cut.Find(".error-banner");
+        banner.TextContent.Should().Contain("not found");
+        cut.FindAll(".error-location").Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Dashboard_HasNoInteractiveArtifacts()
+    {
+        using var ctx = new Bunit.TestContext();
+        ctx.Services.AddSingleton<IDashboardDataService>(FakeDashboardDataService.WithSample());
+
+        var cut = ctx.RenderComponent<ReportingDashboard.Web.Components.Pages.Dashboard>();
+        cut.Markup.Should().NotContain("blazor.server.js");
+        cut.Markup.Should().NotContain("render-mode=");
+    }
+}

--- a/tests/ReportingDashboard.Web.Tests/Components/ErrorBannerTests.cs
+++ b/tests/ReportingDashboard.Web.Tests/Components/ErrorBannerTests.cs
@@ -1,0 +1,80 @@
+using Bunit;
+using FluentAssertions;
+using ReportingDashboard.Web.Models;
+using Xunit;
+
+namespace ReportingDashboard.Web.Tests.Components;
+
+[Trait("Category", "Unit")]
+public class ErrorBannerTests : IDisposable
+{
+    private readonly Bunit.TestContext _ctx = new();
+
+    public void Dispose() => _ctx.Dispose();
+
+    [Fact]
+    public void RendersNothing_WhenErrorIsNull()
+    {
+        var cut = _ctx.RenderComponent<ReportingDashboard.Web.Components.Pages.Partials.ErrorBanner>(p => p
+            .Add(x => x.Error, null));
+
+        cut.FindAll("div.error-banner").Should().BeEmpty();
+        cut.Markup.Trim().Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData(DashboardLoadErrorKind.NotFound, "data.json not found", "not found")]
+    [InlineData(DashboardLoadErrorKind.ParseError, "Failed to parse data.json", "parse error")]
+    [InlineData(DashboardLoadErrorKind.ValidationError, "data.json failed validation", "validation error")]
+    public void RendersHeadingAndKindLabel_ForEachKind(string kind, string expectedHeading, string expectedKindLabel)
+    {
+        var err = new DashboardLoadError(
+            FilePath: "C:/x/data.json",
+            Message: "some message",
+            Line: null,
+            Column: null,
+            Kind: kind);
+
+        var cut = _ctx.RenderComponent<ReportingDashboard.Web.Components.Pages.Partials.ErrorBanner>(p => p
+            .Add(x => x.Error, err));
+
+        var root = cut.Find("div.error-banner");
+        root.GetAttribute("role").Should().Be("alert");
+        cut.Find("div.error-banner strong").TextContent.Should().Be(expectedHeading);
+        cut.Find(".error-kind").TextContent.Should().Be(expectedKindLabel);
+        cut.Find(".error-path").TextContent.Should().Be("C:/x/data.json");
+        cut.Find(".error-message").TextContent.Should().Be("some message");
+        cut.FindAll(".error-location").Should().BeEmpty();
+    }
+
+    [Fact]
+    public void RendersLocation_OnlyWhenLineIsProvided()
+    {
+        var err = new DashboardLoadError("data.json", "parse failed", Line: 12, Column: 5, Kind: DashboardLoadErrorKind.ParseError);
+
+        var cut = _ctx.RenderComponent<ReportingDashboard.Web.Components.Pages.Partials.ErrorBanner>(p => p
+            .Add(x => x.Error, err));
+
+        var loc = cut.Find(".error-location").TextContent;
+        loc.Should().Contain("line 12");
+        loc.Should().Contain("col 5");
+    }
+
+    [Fact]
+    public void HtmlEncodes_HostileMessageAndPath()
+    {
+        var err = new DashboardLoadError(
+            FilePath: "<path>",
+            Message: "<script>alert(1)</script>",
+            Line: null,
+            Column: null,
+            Kind: DashboardLoadErrorKind.ValidationError);
+
+        var cut = _ctx.RenderComponent<ReportingDashboard.Web.Components.Pages.Partials.ErrorBanner>(p => p
+            .Add(x => x.Error, err));
+
+        cut.Markup.Should().NotContain("<script>alert(1)</script>");
+        cut.Markup.Should().Contain("&lt;script&gt;");
+        cut.Markup.Should().Contain("&lt;path&gt;");
+    }
+}

--- a/tests/ReportingDashboard.Web.Tests/FakeDashboardDataService.cs
+++ b/tests/ReportingDashboard.Web.Tests/FakeDashboardDataService.cs
@@ -1,0 +1,58 @@
+using System.Collections.Generic;
+using ReportingDashboard.Web.Models;
+using ReportingDashboard.Web.Services;
+
+namespace ReportingDashboard.Web.Tests;
+
+internal sealed class FakeDashboardDataService : IDashboardDataService
+{
+    private readonly DashboardLoadResult _result;
+    public FakeDashboardDataService(DashboardLoadResult result) => _result = result;
+    public DashboardLoadResult GetCurrent() => _result;
+    public event EventHandler? DataChanged { add { } remove { } }
+
+    public static DashboardData SampleData() => new()
+    {
+        Project = new Project
+        {
+            Title = "Sample Project",
+            Subtitle = "Org - Workstream - Apr 2026",
+            BacklogUrl = "https://example.com/backlog"
+        },
+        Timeline = new Timeline
+        {
+            Start = new DateOnly(2026, 1, 1),
+            End = new DateOnly(2026, 6, 30),
+            Lanes = new List<TimelineLane>
+            {
+                new() { Id = "M1", Label = "Lane One", Color = "#0078D4", Milestones = Array.Empty<Milestone>() },
+                new() { Id = "M2", Label = "Lane Two", Color = "#00897B", Milestones = Array.Empty<Milestone>() },
+                new() { Id = "M3", Label = "Lane Three", Color = "#546E7A", Milestones = Array.Empty<Milestone>() }
+            }
+        },
+        Heatmap = new Heatmap
+        {
+            Months = new[] { "Jan", "Feb", "Mar", "Apr" },
+            CurrentMonthIndex = null,
+            MaxItemsPerCell = 4,
+            Rows = new List<HeatmapRow>
+            {
+                new() { Category = HeatmapCategory.Shipped,    Cells = Empty4() },
+                new() { Category = HeatmapCategory.InProgress, Cells = Empty4() },
+                new() { Category = HeatmapCategory.Carryover,  Cells = Empty4() },
+                new() { Category = HeatmapCategory.Blockers,   Cells = Empty4() }
+            }
+        }
+    };
+
+    private static IReadOnlyList<IReadOnlyList<string>> Empty4() => new IReadOnlyList<string>[]
+    {
+        Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>()
+    };
+
+    public static FakeDashboardDataService WithSample() => new(new DashboardLoadResult(
+        SampleData(), Error: null, LoadedAt: DateTimeOffset.UtcNow));
+
+    public static FakeDashboardDataService WithError(DashboardLoadError error) => new(new DashboardLoadResult(
+        Data: null, Error: error, LoadedAt: DateTimeOffset.UtcNow));
+}

--- a/tests/ReportingDashboard.Web.Tests/Integration/DashboardErrorBannerIntegrationTests.cs
+++ b/tests/ReportingDashboard.Web.Tests/Integration/DashboardErrorBannerIntegrationTests.cs
@@ -1,0 +1,40 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace ReportingDashboard.Web.Tests.Integration;
+
+[Trait("Category", "Integration")]
+public class DashboardErrorBannerIntegrationTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly WebApplicationFactory<Program> _factory;
+
+    public DashboardErrorBannerIntegrationTests(WebApplicationFactory<Program> factory) => _factory = factory;
+
+    [Fact]
+    public async Task Root_ReturnsHtmlAnd200_WithBodyAnd1920x1080Constraints()
+    {
+        var client = _factory.CreateClient();
+        var resp = await client.GetAsync("/");
+        resp.IsSuccessStatusCode.Should().BeTrue();
+
+        var html = await resp.Content.ReadAsStringAsync();
+        html.Should().NotContain("blazor.server.js");
+        html.Should().NotContain("blazor.web.js");
+        html.Should().Contain("<body");
+    }
+
+    [Fact]
+    public async Task Root_DoesNotCrash_OnAnyDataJsonState()
+    {
+        var client = _factory.CreateClient();
+        var resp = await client.GetAsync("/");
+        resp.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
+
+        var html = await resp.Content.ReadAsStringAsync();
+        // Either happy path (no banner) or error path (banner with role=alert) must render.
+        var hasBanner = html.Contains("error-banner") && html.Contains("role=\"alert\"");
+        var hasHeader = html.Contains("class=\"hdr\"") || html.Contains("header class=\"hdr\"");
+        (hasBanner || hasHeader).Should().BeTrue("page must always render either the error banner or the header");
+    }
+}

--- a/tests/ReportingDashboard.Web.Tests/Services/DashboardDataValidatorEdgeCaseTests.cs
+++ b/tests/ReportingDashboard.Web.Tests/Services/DashboardDataValidatorEdgeCaseTests.cs
@@ -1,0 +1,125 @@
+using FluentAssertions;
+using ReportingDashboard.Web.Models;
+using ReportingDashboard.Web.Services;
+using Xunit;
+
+namespace ReportingDashboard.Web.Tests.Services;
+
+[Trait("Category", "Unit")]
+public class DashboardDataValidatorEdgeCaseTests
+{
+    private static Project MakeProject(string? backlogUrl = "https://example.com/b") => new()
+    {
+        Title = "T",
+        Subtitle = "S",
+        BacklogUrl = backlogUrl,
+        BacklogLinkText = "ADO Backlog"
+    };
+
+    private static List<IReadOnlyList<string>> EmptyCells() => new()
+    {
+        new List<string>(), new List<string>(), new List<string>(), new List<string>()
+    };
+
+    private static Timeline MakeTimeline(IReadOnlyList<TimelineLane>? lanes = null) => new()
+    {
+        Start = new DateOnly(2026, 1, 1),
+        End = new DateOnly(2026, 6, 30),
+        Lanes = lanes ?? new List<TimelineLane>
+        {
+            new() { Id = "M1", Label = "L1", Color = "#0078D4", Milestones = new List<Milestone>() }
+        }
+    };
+
+    private static Heatmap MakeHeatmap(int? currentMonthIndex = null) => new()
+    {
+        Months = new List<string> { "Jan", "Feb", "Mar", "Apr" },
+        CurrentMonthIndex = currentMonthIndex,
+        MaxItemsPerCell = 4,
+        Rows = new List<HeatmapRow>
+        {
+            new() { Category = HeatmapCategory.Shipped,    Cells = EmptyCells() },
+            new() { Category = HeatmapCategory.InProgress, Cells = EmptyCells() },
+            new() { Category = HeatmapCategory.Carryover,  Cells = EmptyCells() },
+            new() { Category = HeatmapCategory.Blockers,   Cells = EmptyCells() }
+        }
+    };
+
+    private static DashboardData ValidBaseline() => new()
+    {
+        Project = MakeProject(),
+        Timeline = MakeTimeline(),
+        Heatmap = MakeHeatmap()
+    };
+
+    [Fact]
+    public void Validate_Null_ReturnsDataIsNullError()
+    {
+        var errs = DashboardDataValidator.Validate(null);
+        errs.Should().ContainSingle(e => e.Contains("data is null"));
+    }
+
+    [Fact]
+    public void Validate_ValidBaseline_ReturnsEmpty()
+    {
+        DashboardDataValidator.Validate(ValidBaseline()).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Validate_NonHttpBacklogUrl_ReportsError()
+    {
+        var d = new DashboardData
+        {
+            Project = MakeProject("not-a-url"),
+            Timeline = MakeTimeline(),
+            Heatmap = MakeHeatmap()
+        };
+        var errs = DashboardDataValidator.Validate(d);
+        errs.Should().Contain(e => e.Contains("backlogUrl"));
+    }
+
+    [Fact]
+    public void Validate_DuplicateLaneIds_ReportsError()
+    {
+        var lanes = new List<TimelineLane>
+        {
+            new() { Id = "M1", Label = "L1", Color = "#111111", Milestones = new List<Milestone>() },
+            new() { Id = "M1", Label = "L2", Color = "#222222", Milestones = new List<Milestone>() }
+        };
+        var d = new DashboardData
+        {
+            Project = MakeProject(),
+            Timeline = MakeTimeline(lanes),
+            Heatmap = MakeHeatmap()
+        };
+        var errs = DashboardDataValidator.Validate(d);
+        errs.Should().Contain(e => e.Contains("duplicated"));
+    }
+
+    [Fact]
+    public void Validate_MilestoneOutsideRange_AndBadHex_AndCurrentMonthIndexOutOfBounds()
+    {
+        var lanes = new List<TimelineLane>
+        {
+            new()
+            {
+                Id = "M1", Label = "L1", Color = "#ZZZZZZ",
+                Milestones = new List<Milestone>
+                {
+                    new() { Date = new DateOnly(2025, 12, 31), Type = MilestoneType.Poc, Label = "early" }
+                }
+            }
+        };
+        var d = new DashboardData
+        {
+            Project = MakeProject(),
+            Timeline = MakeTimeline(lanes),
+            Heatmap = MakeHeatmap(currentMonthIndex: 99)
+        };
+
+        var errs = DashboardDataValidator.Validate(d);
+        errs.Should().Contain(e => e.Contains("color"));
+        errs.Should().Contain(e => e.Contains("outside timeline range"));
+        errs.Should().Contain(e => e.Contains("currentMonthIndex"));
+    }
+}

--- a/tests/ReportingDashboard.Web.Tests/Services/DashboardDataValidatorTests.cs
+++ b/tests/ReportingDashboard.Web.Tests/Services/DashboardDataValidatorTests.cs
@@ -1,0 +1,234 @@
+using System.Collections.Generic;
+using FluentAssertions;
+using ReportingDashboard.Web.Models;
+using ReportingDashboard.Web.Services;
+using Xunit;
+
+namespace ReportingDashboard.Web.Tests.Services;
+
+[Trait("Category", "Unit")]
+public class DashboardDataValidatorTests
+{
+    private static DashboardData ValidData() => FakeDashboardDataService.SampleData();
+
+    private static IReadOnlyList<IReadOnlyList<string>> Empty4() => new IReadOnlyList<string>[]
+    {
+        System.Array.Empty<string>(), System.Array.Empty<string>(),
+        System.Array.Empty<string>(), System.Array.Empty<string>()
+    };
+
+    [Fact]
+    public void Validate_OnValidData_ReturnsEmpty()
+    {
+        var errors = DashboardDataValidator.Validate(ValidData());
+        errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Validate_NullData_ReturnsError()
+    {
+        DashboardDataValidator.Validate(null).Should().NotBeEmpty();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Validate_BlankTitle_IsError(string title)
+    {
+        var d = ValidData();
+        var bad = new DashboardData
+        {
+            Project = new Project { Title = title, Subtitle = d.Project.Subtitle },
+            Timeline = d.Timeline,
+            Heatmap = d.Heatmap
+        };
+        DashboardDataValidator.Validate(bad).Should().Contain(e => e.Contains("project.title"));
+    }
+
+    [Fact]
+    public void Validate_InvalidBacklogUrl_IsError()
+    {
+        var d = ValidData();
+        var bad = new DashboardData
+        {
+            Project = new Project { Title = "T", Subtitle = "S", BacklogUrl = "not a url" },
+            Timeline = d.Timeline,
+            Heatmap = d.Heatmap
+        };
+        DashboardDataValidator.Validate(bad).Should().Contain(e => e.Contains("backlogUrl"));
+    }
+
+    [Fact]
+    public void Validate_TimelineStartAfterEnd_IsError()
+    {
+        var d = ValidData();
+        var bad = new DashboardData
+        {
+            Project = d.Project,
+            Timeline = new Timeline
+            {
+                Start = new DateOnly(2026, 6, 30),
+                End = new DateOnly(2026, 1, 1),
+                Lanes = d.Timeline.Lanes
+            },
+            Heatmap = d.Heatmap
+        };
+        DashboardDataValidator.Validate(bad).Should().Contain(e => e.Contains("timeline.start"));
+    }
+
+    [Theory]
+    [InlineData("blue")]
+    [InlineData("#FFF")]
+    [InlineData("#12345G")]
+    [InlineData("")]
+    public void Validate_BadLaneColor_IsError(string color)
+    {
+        var d = ValidData();
+        var bad = new DashboardData
+        {
+            Project = d.Project,
+            Timeline = new Timeline
+            {
+                Start = d.Timeline.Start,
+                End = d.Timeline.End,
+                Lanes = new[]
+                {
+                    new TimelineLane { Id = "M1", Label = "L", Color = color, Milestones = System.Array.Empty<Milestone>() }
+                }
+            },
+            Heatmap = d.Heatmap
+        };
+        DashboardDataValidator.Validate(bad).Should().Contain(e => e.Contains(".color"));
+    }
+
+    [Fact]
+    public void Validate_DuplicateLaneIds_IsError()
+    {
+        var d = ValidData();
+        var bad = new DashboardData
+        {
+            Project = d.Project,
+            Timeline = new Timeline
+            {
+                Start = d.Timeline.Start,
+                End = d.Timeline.End,
+                Lanes = new[]
+                {
+                    new TimelineLane { Id = "X", Label = "A", Color = "#0078D4", Milestones = System.Array.Empty<Milestone>() },
+                    new TimelineLane { Id = "X", Label = "B", Color = "#0078D4", Milestones = System.Array.Empty<Milestone>() }
+                }
+            },
+            Heatmap = d.Heatmap
+        };
+        DashboardDataValidator.Validate(bad).Should().Contain(e => e.Contains("duplicated"));
+    }
+
+    [Fact]
+    public void Validate_MilestoneOutsideRange_IsError()
+    {
+        var d = ValidData();
+        var bad = new DashboardData
+        {
+            Project = d.Project,
+            Timeline = new Timeline
+            {
+                Start = new DateOnly(2026, 1, 1),
+                End = new DateOnly(2026, 6, 30),
+                Lanes = new[]
+                {
+                    new TimelineLane
+                    {
+                        Id = "M1", Label = "L", Color = "#0078D4",
+                        Milestones = new[]
+                        {
+                            new Milestone { Date = new DateOnly(2025, 12, 1), Type = MilestoneType.Poc, Label = "early" }
+                        }
+                    }
+                }
+            },
+            Heatmap = d.Heatmap
+        };
+        DashboardDataValidator.Validate(bad).Should().Contain(e => e.Contains("outside timeline range"));
+    }
+
+    [Fact]
+    public void Validate_LaneCountOutOfRange_IsError()
+    {
+        var d = ValidData();
+        var bad = new DashboardData
+        {
+            Project = d.Project,
+            Timeline = new Timeline
+            {
+                Start = d.Timeline.Start,
+                End = d.Timeline.End,
+                Lanes = System.Array.Empty<TimelineLane>()
+            },
+            Heatmap = d.Heatmap
+        };
+        DashboardDataValidator.Validate(bad).Should().Contain(e => e.Contains("1..6"));
+    }
+
+    [Fact]
+    public void Validate_CurrentMonthIndexOutOfRange_IsError()
+    {
+        var d = ValidData();
+        var bad = new DashboardData
+        {
+            Project = d.Project,
+            Timeline = d.Timeline,
+            Heatmap = new Heatmap
+            {
+                Months = new[] { "Jan", "Feb", "Mar", "Apr" },
+                CurrentMonthIndex = 9,
+                Rows = d.Heatmap.Rows
+            }
+        };
+        DashboardDataValidator.Validate(bad).Should().Contain(e => e.Contains("currentMonthIndex"));
+    }
+
+    [Fact]
+    public void Validate_MissingCategory_IsError()
+    {
+        var d = ValidData();
+        var bad = new DashboardData
+        {
+            Project = d.Project,
+            Timeline = d.Timeline,
+            Heatmap = new Heatmap
+            {
+                Months = new[] { "Jan", "Feb", "Mar", "Apr" },
+                Rows = new[]
+                {
+                    new HeatmapRow { Category = HeatmapCategory.Shipped,    Cells = Empty4() },
+                    new HeatmapRow { Category = HeatmapCategory.InProgress, Cells = Empty4() },
+                    new HeatmapRow { Category = HeatmapCategory.Carryover,  Cells = Empty4() }
+                }
+            }
+        };
+        DashboardDataValidator.Validate(bad).Should().Contain(e => e.Contains("Blockers"));
+    }
+
+    [Fact]
+    public void Validate_CellCountMismatch_IsError()
+    {
+        var d = ValidData();
+        var bad = new DashboardData
+        {
+            Project = d.Project,
+            Timeline = d.Timeline,
+            Heatmap = new Heatmap
+            {
+                Months = new[] { "Jan", "Feb", "Mar", "Apr" },
+                Rows = new[]
+                {
+                    new HeatmapRow { Category = HeatmapCategory.Shipped,    Cells = new IReadOnlyList<string>[] { System.Array.Empty<string>() } },
+                    new HeatmapRow { Category = HeatmapCategory.InProgress, Cells = Empty4() },
+                    new HeatmapRow { Category = HeatmapCategory.Carryover,  Cells = Empty4() },
+                    new HeatmapRow { Category = HeatmapCategory.Blockers,   Cells = Empty4() }
+                }
+            }
+        };
+        DashboardDataValidator.Validate(bad).Should().Contain(e => e.Contains("cells"));
+    }
+}

--- a/tests/ReportingDashboard.Web.Tests/Unit/DashboardShellAdditionalTests.cs
+++ b/tests/ReportingDashboard.Web.Tests/Unit/DashboardShellAdditionalTests.cs
@@ -1,5 +1,7 @@
 using Bunit;
 using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using ReportingDashboard.Web.Services;
 using Xunit;
 
 namespace ReportingDashboard.Web.Tests.Unit;
@@ -7,20 +9,27 @@ namespace ReportingDashboard.Web.Tests.Unit;
 [Trait("Category", "Unit")]
 public class DashboardShellAdditionalTests
 {
+    private static Bunit.TestContext NewCtx()
+    {
+        var ctx = new Bunit.TestContext();
+        ctx.Services.AddSingleton<IDashboardDataService>(FakeDashboardDataService.WithSample());
+        return ctx;
+    }
+
     [Fact]
     public void Dashboard_RendersHeaderH1AndSubtitle()
     {
-        using var ctx = new Bunit.TestContext();
+        using var ctx = NewCtx();
         var cut = ctx.RenderComponent<ReportingDashboard.Web.Components.Pages.Dashboard>();
 
-        cut.Find("div.hdr h1").TextContent.Should().Be("Reporting Dashboard");
-        cut.Find("div.sub").TextContent.Should().Contain("Static SSR shell");
+        cut.Find("header.hdr h1").TextContent.Should().Contain("Sample Project");
+        cut.Find(".sub").TextContent.Should().Contain("Org - Workstream - Apr 2026");
     }
 
     [Fact]
     public void Dashboard_HasSingleTlSvgBoxInsideTlArea()
     {
-        using var ctx = new Bunit.TestContext();
+        using var ctx = NewCtx();
         var cut = ctx.RenderComponent<ReportingDashboard.Web.Components.Pages.Dashboard>();
 
         cut.FindAll("div.tl-area div.tl-svg-box").Count.Should().Be(1);
@@ -29,7 +38,7 @@ public class DashboardShellAdditionalTests
     [Fact]
     public void Dashboard_HasCornerCellWithStatusText()
     {
-        using var ctx = new Bunit.TestContext();
+        using var ctx = NewCtx();
         var cut = ctx.RenderComponent<ReportingDashboard.Web.Components.Pages.Dashboard>();
 
         var corners = cut.FindAll("div.hm-corner");
@@ -40,7 +49,7 @@ public class DashboardShellAdditionalTests
     [Fact]
     public void Dashboard_TotalHeatmapGridChildren_Equals25()
     {
-        using var ctx = new Bunit.TestContext();
+        using var ctx = NewCtx();
         var cut = ctx.RenderComponent<ReportingDashboard.Web.Components.Pages.Dashboard>();
 
         // 1 corner + 4 col-hdr + (1 row-hdr + 4 cells) * 4 rows = 25
@@ -50,7 +59,7 @@ public class DashboardShellAdditionalTests
     [Fact]
     public void Dashboard_DoesNotContainAprLegacyClass()
     {
-        using var ctx = new Bunit.TestContext();
+        using var ctx = NewCtx();
         var cut = ctx.RenderComponent<ReportingDashboard.Web.Components.Pages.Dashboard>();
 
         cut.Markup.Should().NotContain("apr-hdr");

--- a/tests/ReportingDashboard.Web.Tests/Unit/DashboardShellTests.cs
+++ b/tests/ReportingDashboard.Web.Tests/Unit/DashboardShellTests.cs
@@ -1,5 +1,7 @@
 using Bunit;
 using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using ReportingDashboard.Web.Services;
 using Xunit;
 
 namespace ReportingDashboard.Web.Tests.Unit;
@@ -7,10 +9,17 @@ namespace ReportingDashboard.Web.Tests.Unit;
 [Trait("Category", "Unit")]
 public class DashboardShellTests
 {
+    private static Bunit.TestContext NewCtx()
+    {
+        var ctx = new Bunit.TestContext();
+        ctx.Services.AddSingleton<IDashboardDataService>(FakeDashboardDataService.WithSample());
+        return ctx;
+    }
+
     [Fact]
     public void Dashboard_Renders_AllLayoutBands()
     {
-        using var ctx = new Bunit.TestContext();
+        using var ctx = NewCtx();
         var cut = ctx.RenderComponent<ReportingDashboard.Web.Components.Pages.Dashboard>();
 
         cut.Markup.Should().Contain("class=\"hdr\"");
@@ -22,7 +31,7 @@ public class DashboardShellTests
     [Fact]
     public void Dashboard_Renders_ExactlyOneHmTitle_WithLiteralText()
     {
-        using var ctx = new Bunit.TestContext();
+        using var ctx = NewCtx();
         var cut = ctx.RenderComponent<ReportingDashboard.Web.Components.Pages.Dashboard>();
 
         var titles = cut.FindAll("div.hm-title");
@@ -37,7 +46,7 @@ public class DashboardShellTests
     [Fact]
     public void Dashboard_HasNo_InteractiveBlazorArtifacts()
     {
-        using var ctx = new Bunit.TestContext();
+        using var ctx = NewCtx();
         var cut = ctx.RenderComponent<ReportingDashboard.Web.Components.Pages.Dashboard>();
 
         cut.Markup.Should().NotContain("blazor.server.js");
@@ -50,7 +59,7 @@ public class DashboardShellTests
     [Fact]
     public void Dashboard_Heatmap_RendersExpectedCategoryCells()
     {
-        using var ctx = new Bunit.TestContext();
+        using var ctx = NewCtx();
         var cut = ctx.RenderComponent<ReportingDashboard.Web.Components.Pages.Dashboard>();
 
         cut.FindAll("div.hm-cell.ship-cell").Count.Should().Be(4);
@@ -63,7 +72,7 @@ public class DashboardShellTests
     [Fact]
     public void Dashboard_RowHeaders_AllFourCategoriesPresent()
     {
-        using var ctx = new Bunit.TestContext();
+        using var ctx = NewCtx();
         var cut = ctx.RenderComponent<ReportingDashboard.Web.Components.Pages.Dashboard>();
 
         cut.Find("div.hm-row-hdr.ship-hdr").TextContent.Should().Be("Shipped");

--- a/tests/ReportingDashboard.Web.UITests/ErrorBannerUiTests.cs
+++ b/tests/ReportingDashboard.Web.UITests/ErrorBannerUiTests.cs
@@ -1,0 +1,50 @@
+using FluentAssertions;
+using Microsoft.Playwright;
+using Xunit;
+
+namespace ReportingDashboard.Web.UITests;
+
+[Trait("Category", "UI")]
+[Collection("Playwright")]
+public class ErrorBannerUiTests
+{
+    private readonly PlaywrightFixture _fx;
+
+    public ErrorBannerUiTests(PlaywrightFixture fx) => _fx = fx;
+
+    private static string BaseUrl =>
+        Environment.GetEnvironmentVariable("BASE_URL") ?? "http://localhost:5080";
+
+    [Fact]
+    public async Task Dashboard_AlwaysRendersHeaderOrErrorBanner_NeverBlank()
+    {
+        var page = await _fx.Browser.NewPageAsync();
+        await page.GotoAsync(BaseUrl);
+        await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        var headerCount = await page.Locator("div.hdr, header.hdr").CountAsync();
+        var bannerCount = await page.Locator("div.error-banner[role='alert']").CountAsync();
+
+        (headerCount + bannerCount).Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public async Task Dashboard_IfErrorBannerPresent_HasStrongHeadingAndPathSpan()
+    {
+        var page = await _fx.Browser.NewPageAsync();
+        await page.GotoAsync(BaseUrl);
+        await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        var banner = page.Locator("div.error-banner[role='alert']");
+        if (await banner.CountAsync() == 0)
+        {
+            return; // happy path: no banner expected
+        }
+
+        (await banner.Locator("strong").CountAsync()).Should().Be(1);
+        (await banner.Locator(".error-path").CountAsync()).Should().Be(1);
+        (await banner.Locator(".error-message").CountAsync()).Should().Be(1);
+        var headingText = await banner.Locator("strong").First.TextContentAsync();
+        headingText.Should().NotBeNullOrWhiteSpace();
+    }
+}


### PR DESCRIPTION
## Task Assignment
**Assigned To:** SoftwareEngineer
**Complexity:** Medium
**Branch:** `agent/softwareengineer/t9-build-error-banner-and-wire-dashboard-composition`

## Requirements
Closes #2067

# PR: Build Error Banner and Wire Dashboard Composition (T9)

## Summary

This PR completes the end-to-end render pipeline for the ReportingDashboard by wiring the root `Dashboard.razor` page to the `IDashboardDataService`, fleshing out the `ErrorBanner.razor` partial, and adding a new `DashboardDataValidator` that enforces v1 schema rules before data reaches any render path.

When `data.json` loads successfully, the page composes `DashboardHeader` + `TimelineSvg` + `Heatmap` against view models built by `TimelineMath` (a.k.a. `TimelineLayoutEngine`) and `HeatmapLayout` (a.k.a. `HeatmapLayoutEngine`) using `DateOnly.FromDateTime(DateTime.Today)` as "now." When `data.json` is missing, malformed, or fails validation, the service returns a `DashboardLoadResult` with `Error` populated; the page renders a red `.error-banner` at the top of `<body>` and falls back to `Project.Placeholder` + empty view models so the 1920x1080 layout is preserved for screenshot evidence (PM spec Story 6, Scenarios 11-12). The process never crashes on bad input.

`DashboardDataValidator` enforces v1 rules (title non-empty, `timeline.start < timeline.end`, lane color regex `^#[0-9A-Fa-f]{6}$`, milestone dates within range, milestone type in enum, heatmap has 4 rows with required categories, `months.Length` matches each row's `cells.Length`, `currentMonthIndex` in bounds or null, `maxItemsPerCell >= 1`, `backlogUrl` parseable as absolute http/https Uri or null). Results flow back through the service as `DashboardLoadError { Kind = "ValidationError" }`.

## Acceptance Criteria

- [ ] `Dashboard.razor` has `@page "/"`, no `@rendermode` directive, and injects `IDashboardDataService`.
- [ ] On `OnInitialized`, the page calls `GetCurrent()` exactly once, then (when `Data != null`) calls `TimelineLayoutEngine.Build(data.Timeline, today)` and `HeatmapLayoutEngine.Build(data.Heatmap, today)`.
- [ ] `NowLabel` is computed as `$"Now ({DateTime.Today:MMM yyyy})"` and passed to `DashboardHeader`.
- [ ] Happy path renders: `DashboardHeader`  `TimelineSvg`  `Heatmap` (in DOM order), no `ErrorBanner` present.
- [ ] Error path (`result.Error != null`) renders: `ErrorBanner`  `DashboardHeader (Project.Placeholder)`  `TimelineSvg (Empty)`  `Heatmap (Empty)`; `<body>` dimensions remain 1920x1080 with `overflow:hidden`.
- [ ] `ErrorBanner.razor` renders `<div class="error-banner" role="alert">` containing: a `<strong>` heading whose text depends on `Error.Kind` (`"NotFound"`  "data.json not found", `"ParseError"`  "Failed to parse data.json", `"ValidationError"`  "data.json failed validation"); `.error-path` span with `Error.FilePath`; `.error-location` span with `line {L}, col {C}` only when `Error.Line` is non-null; `.error-message` span with `Error.Message`.
- [ ] `DashboardDataValidator.Validate(DashboardData)` returns `IReadOnlyList<string>` of human-readable errors, empty when valid. Rules implemented:
  - `project.title` non-empty/non-whitespace.
  - `project.backlogUrl`, if present, parses via `Uri.TryCreate(..., Absolute)` with scheme `http` or `https`.
  - `timeline.start < timeline.end`.
  - `timeline.lanes.Count` in `[1, 6]`; each lane `Id` non-empty; `Id`s unique; `Color` matches `^#[0-9A-Fa-f]{6}$`.
  - Each `milestone.date` in `[timeline.start, timeline.end]`.
  - `heatmap.rows.Count == 4` and covers `{Shipped, InProgress, Carryover, Blockers}` exactly once.
  - `heatmap.months.Count >= 1`; every row's `cells.Count == months.Count`.
  - `heatmap.currentMonthIndex` is null OR in `[0, months.Count)`.
  - `heatmap.maxItemsPerCell >= 1`.
- [ ] `DashboardDataService` invokes `DashboardDataValidator.Validate(...)` after successful deserialization; when the validator returns errors, the service caches a `DashboardLoadResult` with `Data=null, Error=new DashboardLoadError(path, joinedMessage, Line=null, Column=null, Kind="ValidationError")` - it does not throw.
- [ ] No interactive render mode is introduced; rendered HTML does not contain `_framework/blazor.server.js` references emitted by interactive Blazor.
- [ ] All strings from `data.json` are auto-encoded by Razor (`@value`, never `@((MarkupString)value)`).
- [ ] Tests in `DashboardDataValidatorTests` and `DashboardRenderTests` pass in CI on `windows-latest`.

## Implementation Steps

1. **Scaffold validator + test classes (boilerplate only).**
   - Create `src/ReportingDashboard.Web/Services/DashboardDataValidator.cs` with namespace `ReportingDashboard.Web.Services`, public static class, and signature `public static IReadOnlyList<string> Validate(DashboardData data)` returning `Array.Empty<string>()`.
   - Create `tests/ReportingDashboard.Web.Tests/Services/DashboardDataValidatorTests.cs` (namespace `ReportingDashboard.Web.Tests.Services`) and `tests/ReportingDashboard.Web.Tests/Components/DashboardRenderTests.cs` (namespace `ReportingDashboard.Web.Tests.Components`) as empty xUnit classes with `using Xunit; using FluentAssertions; using Bunit;` imports and one `[Fact] public void Placeholder() { }` so the test project builds.
   - Verify `dotnet build ReportingDashboard.sln -c Release` is green before proceeding.

2. **Implement `DashboardDataValidator` rules.**
   - Implement all v1 rules listed in Acceptance Criteria. Use a local `List<string> errors = new()`, append one human-readable message per violation (e.g., `"timeline.lanes[2].color '#ZZZ' is not a valid #RRGGBB hex."`), return `errors`.
   - Use a compiled `Regex` for hex color (`^#[0-9A-Fa-f]{6}$`).
   - Use `HashSet<string>(StringComparer.Ordinal)` for lane `Id` uniqueness.
   - For backlog URL: `string.IsNullOrWhiteSpace` is OK (null-equivalent); otherwise must parse absolute + scheme http/https.
   - For heatmap categories: require the set of `row.Category` values to equal `{Shipped, InProgress, Carryover, Blockers}` (all four present, no duplicates).
   - No I/O, no logging, no exceptions for control flow.

3. **Wire validator into `DashboardDataService` (minimal surgical edit).**
   - In the existing `DashboardDataService` load path, after successful `JsonSerializer.Deserialize<DashboardData>(...)`, call `DashboardDataValidator.Validate(data)`; if the list is non-empty, construct `new DashboardLoadError(filePath, string.Join("; ", errors), Line:null, Column:null, Kind:"ValidationError")` and cache a `DashboardLoadResult(Data:null, Error:error, LoadedAt:DateTimeOffset.UtcNow)`.
   - Log validation failures at `LogLevel.Warning` with the joined message (no field values, only rule names/paths).
   - Leave existing `NotFound`/`ParseError` branches untouched.

4. **Flesh out `ErrorBanner.razor`.**
   - Replace stub with:
     ```razor
     @namespace ReportingDashboard.Web.Components.Pages.Partials
     @using ReportingDashboard.Web.Services
     <div class="error-banner" role="alert">
       <strong>@HeadingFor(Error.Kind)</strong>
       <span class="error-kind">@Error.Kind</span>
       <span class="error-path">@Error.FilePath</span>
       @if (Error.Line is int l)
       {
         <span class="error-location">line @l, col @(Error.Column ?? 0)</span>
       }
       <span class="error-message">@Error.Message</span>
     </div>
     @code {
       [Parameter, EditorRequired] public required DashboardLoadError Error { get; set; }
       private static string HeadingFor(string kind) => kind switch
       {
         "NotFound"        => "data.json not found",
         "ParseError"      => "Failed to parse data.json",
         "ValidationError" => "data.json failed validation",
         _                 => "Failed to load data.json"
       };
     }
     ```
   - Do NOT add inline `<style>`; rely on `.error-banner` rules already in `Dashboard.razor.css` (architecture C12/Section 5).

5. **Wire `Dashboard.razor` composition.**
   - Add `@inject IDashboardDataService Data`. Do NOT add `@rendermode`.
   - In `@code`:
     ```csharp
     private DashboardLoadResult _result = default!;
     private string _nowLabel = string.Empty;
     private TimelineViewModel _timelineVm = TimelineViewModel.Empty;
     private HeatmapViewModel _heatmapVm  = HeatmapViewModel.Empty;

     protected override void OnInitialized()
     {
       _result   = Data.GetCurrent();
       var today = DateOnly.FromDateTime(DateTime.Today);
       _nowLabel = $"Now ({DateTime.Today:MMM yyyy})";
       if (_result.Data is { } d)
       {
         _timelineVm = TimelineLayoutEngine.Build(d.Timeline, today);
         _heatmapVm  = HeatmapLayoutEngine.Build(d.Heatmap,  today);
       }
     }
     ```
   - Render order inside `<body>`:
     ```razor
     @if (_result.Error is not null) { <ErrorBanner Error="_result.Error" /> }
     <DashboardHeader Project="@(_result.Data?.Project ?? Project.Placeholder)" NowLabel="@_nowLabel" />
     <TimelineSvg Model="_timelineVm" />
     <Heatmap     Model="_heatmapVm"  />
     ```
   - Ensure `TimelineViewModel.Empty` and `HeatmapViewModel.Empty` exist (add if missing in those records as static readonly defaults with empty lists and `CurrentMonthIndex = -1` / `Now.InRange = false`).

6. **Author tests.**
   - `DashboardDataValidatorTests`: one `[Fact]` per rule with a valid baseline `DashboardData` factory helper; positive case asserts `Validate(valid).Should().BeEmpty()`; negative cases mutate one field (empty title, start>=end, 0 or 7 lanes, duplicate lane IDs, bad hex color, milestone before start / after end, wrong milestone enum via invalid JSON round-trip, missing category, duplicate categories, `cells.Length != months.Length`, `currentMonthIndex = -1` and `= months.Length`, `maxItemsPerCell = 0`, non-http URL). Each negative asserts `.Should().ContainSingle(msg => msg.Contains("<expected token>"))`.
   - `DashboardRenderTests` (bUnit): (a) happy path - stub `IDashboardDataService` returns a valid `DashboardLoadResult`; render `<Dashboard/>`; assert `.hdr h1` text, `.tl-area svg`, `.hm-grid` presence, and absence of `.error-banner`. (b) error path - stub returns `Error.Kind="NotFound"`; assert `.error-banner[role=alert]` present, heading is "data.json not found", `DashboardHeader` renders `Project.Placeholder.Title`, timeline/heatmap render empty shells (no `<polygon>`, no `.it`).
   - Run `dotnet test ReportingDashboard.sln -c Release`; all tests green.

## Testing

- **Unit - `DashboardDataValidatorTests`**: per-rule positive/negative coverage (~15 facts). Factory helper produces a known-valid `DashboardData`; each negative mutates a single field to isolate the rule under test. Assert message content so rules can't silently drop.
- **Component - `DashboardRenderTests` (bUnit)**: happy path renders all three sections with no banner; error path renders banner with correct heading for each of `NotFound` / `ParseError` / `ValidationError` (three theory rows) and placeholder header. Assert `cut.Markup` does NOT contain `blazor.server.js` (guard against R1 - accidental interactive mode).
- **Regression**: existing `DashboardDataServiceTests` should be extended (or a new test added) to verify that invalid-but-parseable JSON now yields `Error.Kind == "ValidationError"` rather than `Data != null`.
- **Manual smoke**: `dotnet run`, browse `http://localhost:5080/`  full dashboard. Then corrupt `wwwroot/data.json` (remove a closing brace)  banner appears with `ParseError` heading; rename file  `NotFound`; set `timeline.end` before `timeline.start`  `ValidationError`. In all three cases page remains 1920x1080, no scrollbars, process still serving.
- **CI**: `dotnet build` + `dotnet test` on `windows-latest` (canonical OS per architecture). `dotnet format --verify-no-changes` stays clean.

## References
- Architecture: Architecture.md
- PM Spec: 

## Status
- [ ] Implementation
- [ ] Tests Written
- [ ] Ready for Review