### PR TITLE
SoftwareEngineer: Author README with Getting Started, Schema, and Screenshot Workflow

### DIFF
--- a/.agentsquad/author-readme-with-getting-started-schema-and-screenshot-workflow.task
+++ b/.agentsquad/author-readme-with-getting-started-schema-and-screenshot-workflow.task
@@ -1,0 +1,4 @@
+agent: SoftwareEngineer
+task: Author README with Getting Started, Schema, and Screenshot Workflow
+complexity: Medium
+status: in-progress

--- a/README.md
+++ b/README.md
@@ -1,0 +1,216 @@
+# My Project - Reporting Dashboard
+
+A minimal, local-only Blazor Server (.NET 8) app that renders a fixed **1920x1080** executive
+status dashboard (header + legend, milestone timeline, monthly execution heatmap) from a
+single hand-edited `data.json`. The page exists to be **screenshotted into a PowerPoint slide** -
+no BI tool, no auth, no cloud, no interactivity.
+
+Canonical visual reference: [`OriginalDesignConcept.html`](OriginalDesignConcept.html) and
+[`docs/design-screenshots/OriginalDesignConcept.png`](docs/design-screenshots/OriginalDesignConcept.png).
+
+---
+
+## Getting Started
+
+```bash
+git clone <repo-url>
+cd src/ReportingDashboard.Web
+dotnet run
+# open http://localhost:5080
+```
+
+> Requires the [.NET 8 SDK](https://dotnet.microsoft.com/download/dotnet/8.0) (8.0.x). No other
+> prerequisites - Kestrel binds only to `http://localhost:5080` (loopback, no HTTPS).
+
+---
+
+## Editing `data.json`
+
+### Path
+
+The dashboard reads **one** file:
+
+```
+src/ReportingDashboard.Web/wwwroot/data.json
+```
+
+You can also view the currently-served file in a browser at
+[`http://localhost:5080/data.json`](http://localhost:5080/data.json) to sanity-check what
+the app is actually parsing.
+
+### Hot-reload behavior
+
+- A `FileSystemWatcher` watches `wwwroot/data.json` and debounces change events by ~250ms.
+- On save, the in-memory cache is invalidated - **no process restart required**.
+- The browser does **not** auto-refresh (there is no SignalR circuit in static SSR).
+  Workflow: **save the file**, then **refresh the browser** (F5). Your edits appear
+  immediately.
+- If the file is missing, malformed JSON, or fails schema validation, the page renders a
+  red error banner at the top (with file path, line/column if available, and the parse
+  message) instead of crashing. Fix the file, save, refresh - the banner goes away.
+
+### Annotated schema
+
+```jsonc
+{
+  // ----- Project: header band content -----
+  "project": {
+    "title":           "Privacy Automation Release Roadmap",        // h1, 24px bold
+    "subtitle":        "Trusted Platform \u2022 Privacy Automation Workstream \u2022 April 2026",
+                                                                    // 12px muted grey under title
+    "backlogUrl":      "https://dev.azure.com/contoso/privacy/_backlogs/backlog/",
+                                                                    // optional; must be http/https
+                                                                    //   or it is rendered as plain text
+    "backlogLinkText": "\u2192 ADO Backlog"                         // optional; default "\u2192 ADO Backlog"
+  },
+
+  // ----- Timeline: 196px-tall Gantt-style SVG with lanes + milestones + NOW line -----
+  "timeline": {
+    "start": "2026-01-01",                                          // ISO date (yyyy-MM-dd), inclusive
+    "end":   "2026-06-30",                                          // ISO date, must be > start
+    "lanes": [                                                      // 1..6 lanes
+      {
+        "id":    "M1",                                              // short code shown in the left label column
+        "label": "Chatbot & MS Role",                               // longer sub-label
+        "color": "#0078D4",                                         // lane track + id color; #RRGGBB only
+        "milestones": [
+          {
+            "date":  "2026-01-12",                                  // must be within [timeline.start, timeline.end]
+            "type":  "checkpoint",                                  // "checkpoint" | "poc" | "prod"
+                                                                    //   checkpoint -> grey circle / outlined dot
+                                                                    //   poc        -> amber diamond (#F4B400)
+                                                                    //   prod       -> green diamond (#34A853)
+            "label": "Jan 12 Kickoff",                              // caption rendered next to the marker
+            "captionPosition": "above"                              // optional: "above" | "below"
+                                                                    //   (auto-alternates when omitted)
+          },
+          { "date": "2026-03-26", "type": "poc",  "label": "Mar 26 PoC",     "captionPosition": "below" },
+          { "date": "2026-04-30", "type": "prod", "label": "Apr Prod (TBD)", "captionPosition": "above" }
+        ]
+      },
+      { "id": "M2", "label": "PDS & Data Inventory", "color": "#00897B", "milestones": [ /* ... */ ] },
+      { "id": "M3", "label": "Auto Review DFD",      "color": "#546E7A", "milestones": [ /* ... */ ] }
+    ]
+  },
+
+  // ----- Heatmap: 4x4 grid of monthly execution items -----
+  "heatmap": {
+    "months": ["Jan", "Feb", "Mar", "Apr"],                         // column headers; length must equal
+                                                                    //   each row's cells.length (default 4)
+    "currentMonthIndex": null,                                      // 0-based index of the "current" column
+                                                                    //   (amber header + darker cell tint);
+                                                                    //   null => auto from today's month
+                                                                    //   (matched by abbreviation against months[])
+    "maxItemsPerCell": 4,                                           // truncate at N; overflow becomes "+K more"
+    "rows": [                                                       // exactly 4 rows, in the order below
+      {
+        "category": "shipped",                                      // "shipped"    -> green  dot #34A853
+        "cells": [                                                  //   one array per month (length == months.length)
+          ["Chatbot v0.9 dev build", "DFD schema v1"],              //   each string is an item line in that cell
+          ["PDS inventory baseline", "Role registry export"],
+          ["Chatbot PoC demo", "Auto Review rules v1"],
+          ["Privacy banner rollout", "Consent API v1.2"]
+        ]
+      },
+      { "category": "inProgress", "cells": [ /* ... */ ] },         // "inProgress" -> blue   dot #0078D4
+      { "category": "carryover",  "cells": [ /* ... */ ] },         // "carryover"  -> amber  dot #F4B400
+      { "category": "blockers",   "cells": [ /* ... */ ] }          // "blockers"   -> red    dot #EA4335
+                                                                    // Empty cell ([]) renders a muted "-".
+    ]
+  },
+
+  // ----- Theme: reserved for future re-skinning; unused in v1 -----
+  "theme": { "font": "Segoe UI" }
+}
+```
+
+**Validation rules enforced at load time:**
+
+- `project.title` non-empty; `backlogUrl` must be an absolute `http`/`https` URL (else the link
+  degrades to plain text).
+- `timeline.start < timeline.end`; 1..6 lanes; each lane `id` unique; `color` matches
+  `#RRGGBB`.
+- Every `milestone.date` lies within `[start, end]`; `type`  { `checkpoint`, `poc`, `prod` };
+  `captionPosition`  { `above`, `below` } when present.
+- `heatmap.months.length == rows[i].cells.length` (default 4).
+- Exactly 4 rows with categories `shipped`, `inProgress`, `carryover`, `blockers`
+  (case-insensitive).
+- `currentMonthIndex` is either `null` or in `[0, months.length)`.
+- `maxItemsPerCell` is an integer `>= 1` (default `4`).
+
+A complete working sample ships in the repo at
+[`src/ReportingDashboard.Web/wwwroot/data.json`](src/ReportingDashboard.Web/wwwroot/data.json) -
+use it as your starting point.
+
+---
+
+## Screenshot Workflow
+
+The page is intentionally a fixed **1920x1080** artifact with no scrollbars, no spinners,
+and no chrome. To produce a deck-ready screenshot:
+
+1. **Use Windows + Edge or Chrome.** Segoe UI is the canonical font; other OSes fall back to
+   similar sans-serif fonts and text metrics will shift slightly.
+2. **Get a 1920-wide viewport.** Either:
+   - Plug into an external monitor at 1920+ px wide and maximize the browser, **or**
+   - Open DevTools (`F12`) -> **Toggle device toolbar** (`Ctrl+Shift+M`) -> set the viewport
+     to `1920 x 1080` -> reload.
+3. **Capture the viewport.** `Win+Shift+S` (Snipping Tool) -> **Window** or **Rectangular**
+   capture covering the full 1920x1080 frame.
+4. **Paste into a 16:9 PowerPoint slide.** No cropping or resizing needed.
+
+> Laptop screens narrower than 1920px will horizontally clip the body. Browser zoom
+> (e.g. 75%) lets you *preview* the dashboard at reduced size, but screenshots taken at
+> reduced zoom are **not** deck-ready - always capture at 100% zoom, 1920-wide viewport.
+
+---
+
+## Project Layout
+
+```
+ReportingDashboard.sln
+ src/ReportingDashboard.Web/        # Blazor Server app (static SSR)
+    wwwroot/data.json              # <-- the only data source; edit this
+    Components/Pages/               # Dashboard + partials (Heatmap, ...)
+    Models/                         # DashboardData, Timeline, Heatmap, ...
+    Services/                       # DashboardDataService (+ validator, load result)
+    Layout/                         # HeatmapLayoutEngine, view models
+    Program.cs                      # minimal host, binds http://localhost:5080
+ tests/                              # xUnit + bUnit
+ docs/design-screenshots/           # canonical PNG reference
+ OriginalDesignConcept.html          # canonical HTML/CSS reference
+```
+
+## Build & Test
+
+```bash
+dotnet restore ReportingDashboard.sln
+dotnet build   ReportingDashboard.sln -c Release
+dotnet test    ReportingDashboard.sln -c Release
+```
+
+## Optional: self-contained publish
+
+Produce a double-clickable `.exe` (plus an editable `wwwroot/data.json` alongside):
+
+```bash
+dotnet publish src/ReportingDashboard.Web `
+    -c Release -r win-x64 --self-contained true `
+    -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true `
+    -o publish/win-x64
+```
+
+Run `publish/win-x64/ReportingDashboard.Web.exe` and open
+<http://localhost:5080>.
+
+---
+
+## Design Principles
+
+- **Static SSR only.** No `@rendermode InteractiveServer` / `InteractiveWebAssembly`, no
+  SignalR circuit, no reconnect UI - nothing that could land in a screenshot.
+- **Single source of truth.** Every rendered string, date, color, and coordinate flows from
+  `data.json`. Nothing is hardcoded in Razor.
+- **Fail-safe rendering.** Bad data produces an in-page banner, never a YSOD.
+- **Local only.** No auth, no HTTPS, no cloud. Do **not** place PII or secrets in `data.json`
+  and do **not** deploy this to a shared server without revisiting the security model.


### PR DESCRIPTION
## Task Assignment
**Assigned To:** SoftwareEngineer
**Complexity:** Medium
**Branch:** `agent/softwareengineer/t9-author-readme-with-getting-started-schema-and-screenshot-workflow`

## Requirements
Closes #2158

# Author README with Getting Started, Schema, and Screenshot Workflow

## Summary

This PR adds the repository-root `README.md` for the ReportingDashboard project. The README is the primary onboarding artifact for both developers and PMs: it explains how to clone and run the app locally, documents the `wwwroot/data.json` schema (the single source of truth for dashboard content) with a fully annotated example, describes hot-reload behavior, covers the screenshot workflow for pasting into a 16:9 PowerPoint deck, documents the error-banner states, and lists explicit "do not" constraints (no auth, no HTTPS, no interactive render modes). The file is a documentation-only change — no code, no tests, no build impact.

This task depends on #2150 (scaffolding) so that referenced paths (`ReportingDashboard.sln`, `src/ReportingDashboard.Web/`, `wwwroot/data.json`) exist and are correct.

## Acceptance Criteria

- [ ] `README.md` exists at repo root (`/README.md`), UTF-8, LF line endings.
- [ ] Top of file: project title + one-paragraph purpose statement ("local-only, screenshot-optimized executive dashboard; 1920x1080 Blazor Server static SSR").
- [ ] **Getting Started** section is ≤5 command lines and shows: `git clone`, `cd src/ReportingDashboard.Web`, `dotnet run`, open `http://localhost:5080`. Prerequisite line mentions .NET 8 SDK (8.0.400+).
- [ ] **Editing `data.json`** section documents:
  - [ ] Exact path: `src/ReportingDashboard.Web/wwwroot/data.json`.
  - [ ] Hot-reload behavior: save file → `FileSystemWatcher` (250ms debounce) invalidates cache → browser F5 shows updates with no restart/rebuild.
  - [ ] Network drives / WSL mounts are unsupported for hot-reload.
- [ ] **Schema** section contains a full annotated `data.json` example (fenced ```jsonc``` block) covering every field:
  - [ ] `project`: `title`, `subtitle`, `backlogUrl`, `backlogLinkText`.
  - [ ] `timeline`: `start`, `end` (ISO `YYYY-MM-DD`), `lanes[]` with `id`, `label`, `color` (`#RRGGBB`), `milestones[]` with `date`, `type` (`poc` | `prod` | `checkpoint`), `label`, optional `captionPosition` (`Above` | `Below`).
  - [ ] `heatmap`: `months` (array of 4 strings), `currentMonthIndex` (int or null = auto), `maxItemsPerCell` (default 4), `rows[]` with `category` (`shipped` | `inProgress` | `carryover` | `blockers`) and `cells` (array of 4 arrays of strings).
  - [ ] Each field has an inline `//` comment explaining meaning, required/optional status, and constraints.
- [ ] **Validation rules** summary table lists the constraints the `DashboardDataValidator` enforces (title non-empty, `start < end`, lane count 1..6, color regex `^#[0-9A-Fa-f]{6}$`, milestone date in range, enum whitelists, exactly 4 heatmap rows, etc.).
- [ ] **Error banner** section describes the three banner kinds (`NotFound`, `ParseError`, `ValidationError`) and that malformed data never crashes the process.
- [ ] **Screenshot workflow** section describes: open in Edge/Chrome at 1920-wide window OR DevTools device toolbar at 1920x1080; `Win+Shift+S` to capture; paste into 16:9 PPT slide; notes laptop-zoom fallback is preview-only.
- [ ] **Optional self-contained publish** section shows the `dotnet publish -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true` command and notes `data.json` stays external/editable alongside the exe.
- [ ] **Configuration** section documents `appsettings.json` keys (`Kestrel:Endpoints:Http:Url`, `Dashboard:DataFilePath`, `Dashboard:HotReloadDebounceMs`) and `ASPNETCORE_URLS` override for port collisions.
- [ ] **Do NOT** section explicitly forbids: adding `@rendermode InteractiveServer`/`InteractiveWebAssembly`, `AddInteractiveServerComponents()`, `UseHttpsRedirection()`, `UseAuthentication()`, putting PII/secrets in `data.json`, binding Kestrel to `0.0.0.0`.
- [ ] **Project structure** section shows the tree: `ReportingDashboard.sln`, `src/ReportingDashboard.Web/`, `tests/ReportingDashboard.Web.Tests/`, `docs/OriginalDesignConcept.html`.
- [ ] All commands copy-pasteable and verified (paths correct for Windows and POSIX shells; `dotnet` commands use forward slashes which work in both).
- [ ] Markdown lints cleanly (no broken headings, fenced blocks closed, relative links resolve).

## Implementation Steps

1. **Scaffold `README.md` skeleton at repo root.** Create `/README.md` with the top-level title `# ReportingDashboard`, a 2–3 sentence purpose paragraph, and empty H2 section headers in order: `## Getting Started`, `## Project Structure`, `## Editing data.json`, `## Schema Reference`, `## Validation Rules`, `## Error States`, `## Screenshot Workflow`, `## Configuration`, `## Optional: Self-Contained Publish`, `## Do NOT`, `## Troubleshooting`. No content yet. Commit: `docs: scaffold README with section headers`.

2. **Write Getting Started + Project Structure sections.** Fill `## Getting Started` with a ≤5-line fenced ```bash``` block (`git clone …`, `cd src/ReportingDashboard.Web`, `dotnet run`, then "open http://localhost:5080" as a prose line), preceded by a one-line prerequisite ("Requires .NET 8 SDK (8.0.400+)"). Fill `## Project Structure` with an ASCII tree showing `ReportingDashboard.sln` at root, `src/ReportingDashboard.Web/{Components,Models,Services,wwwroot}`, `tests/ReportingDashboard.Web.Tests/`, `docs/OriginalDesignConcept.html`, `docs/design-screenshots/OriginalDesignConcept.png`. Commit: `docs: add Getting Started and Project Structure`.

3. **Write data.json schema sections (the core of the README).** Fill `## Editing data.json` with the path `src/ReportingDashboard.Web/wwwroot/data.json`, the hot-reload paragraph (250ms debounce, browser refresh required, no SignalR push), and the network-drives caveat. Fill `## Schema Reference` with a single ```jsonc``` fenced block containing the canonical example from the architecture doc, with `//` comments on every field explaining meaning, required/optional, allowed values, and defaults. Fill `## Validation Rules` with a markdown table summarizing the `DashboardDataValidator` rules. Commit: `docs: document data.json schema and validation rules`.

4. **Write operational sections: error states, screenshot workflow, configuration, publish.** Fill `## Error States` listing the three banner kinds (`NotFound`, `ParseError`, `ValidationError`) with example banner text and the "process never crashes" guarantee. Fill `## Screenshot Workflow` with the 1920-wide-window guidance, DevTools device-toolbar tip, `Win+Shift+S` step, 16:9 PPT paste step, and laptop-zoom-is-preview-only note. Fill `## Configuration` with a ```json``` block showing `appsettings.json` keys and a prose note about `ASPNETCORE_URLS=http://localhost:5081` for port collisions. Fill `## Optional: Self-Contained Publish` with the `dotnet publish` command and the "data.json stays alongside exe" note. Commit: `docs: add error states, screenshot, config, and publish sections`.

5. **Write Do NOT + Troubleshooting; final review.** Fill `## Do NOT` as a bulleted list of forbidden changes (interactive render modes, HTTPS redirect, auth, PII in data.json, 0.0.0.0 binding) with one-line rationale each. Fill `## Troubleshooting` with 3–5 common issues (hot-reload not working, port in use, blank page, wrong font on Linux/macOS, error banner shown). Proofread full document, run `markdownlint` locally if available, verify all relative paths resolve, verify all fenced blocks have language tags, ensure no trailing whitespace. Commit: `docs: add Do NOT and Troubleshooting; polish README`.

## Testing

This is a documentation-only change with no automated test coverage required. Verification is manual:

- **Render check:** Preview `README.md` on GitHub (or with `grip`/VS Code preview) and confirm all headings, tables, and fenced code blocks render correctly; no broken anchors.
- **Copy-paste check:** Execute every command in `## Getting Started` from a clean clone on Windows PowerShell and bash; confirm `dotnet run` succeeds and `http://localhost:5080` serves the dashboard.
- **Schema round-trip check:** Copy the annotated `## Schema Reference` example into `wwwroot/data.json` (stripping `//` comments, which `System.Text.Json` tolerates with `ReadCommentHandling = Skip` but a strict JSON tool would not) and confirm the dashboard renders without an error banner.
- **Link check:** Click every relative link (`docs/OriginalDesignConcept.html`, `src/ReportingDashboard.Web/`, etc.) in the rendered README and confirm each resolves.
- **Validation-rules accuracy check:** Cross-reference the `## Validation Rules` table against `DashboardDataValidator.cs` (or its spec in the architecture doc) to ensure no rule is missing or misstated.
- **Lint:** Run `markdownlint README.md` (if the project adds it) or `npx markdownlint-cli README.md` ad-hoc; fix any warnings.
- **CI:** No new CI steps required; existing `dotnet build`/`dotnet test`/`dotnet format` workflow is unaffected by documentation changes.

## References
- Architecture: Architecture.md
- PM Spec: 

## Status
- [ ] Implementation
- [ ] Tests Written
- [ ] Ready for Review