### PR TITLE
SoftwareEngineer 3: GitHub Actions CI Pipeline

### DIFF
--- a/.agentsquad/github-actions-ci-pipeline.task
+++ b/.agentsquad/github-actions-ci-pipeline.task
@@ -1,0 +1,4 @@
+agent: SoftwareEngineer 3
+task: GitHub Actions CI Pipeline
+complexity: Medium
+status: in-progress

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,65 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+      - name: Restore
+        run: dotnet restore
+      - name: Build
+        run: dotnet build --no-restore -c Release
+      - name: Test
+        run: dotnet test --no-build -c Release --collect:"XPlat Code Coverage"
+
+  frontend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: src/ReportingDashboard.Client
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: src/ReportingDashboard.Client/package-lock.json
+      - name: Install dependencies
+        run: npm ci
+      - name: Type check
+        run: npx tsc --noEmit
+      - name: Lint
+        run: npm run lint
+      - name: Test
+        run: npm run test -- --reporter=verbose --coverage
+      - name: Build
+        run: npm run build
+
+  publish:
+    runs-on: windows-latest
+    needs: [backend, frontend]
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Publish self-contained EXE
+        run: dotnet publish src/ReportingDashboard.Api/ReportingDashboard.Api.csproj -c Release -r win-x64 --self-contained -p:PublishSingleFile=true -o publish
+      - name: Verify EXE size under 40MB
+        shell: pwsh
+        run: |
+          $size = (Get-Item publish/ReportingDashboard.Api.exe).Length / 1MB
+          if ($size -gt 40) { throw "EXE exceeds 40MB: $([math]::Round($size,1))MB" }
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ReportingDashboard-win-x64
+          path: publish/ReportingDashboard.Api.exe

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+## .NET
+bin/
+obj/
+*.user
+*.suo
+*.cache
+*.vs/
+
+## Node
+node_modules/
+dist/
+
+## IDE
+.idea/
+.vscode/
+*.swp

--- a/ReportingDashboard.sln
+++ b/ReportingDashboard.sln
@@ -1,0 +1,24 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.9.34728.123
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ReportingDashboard.Api", "src\ReportingDashboard.Api\ReportingDashboard.Api.csproj", "{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ReportingDashboard.Api.Tests", "src\ReportingDashboard.Api.Tests\ReportingDashboard.Api.Tests.csproj", "{B2C3D4E5-F6A7-8901-BCDE-F12345678901}"
+EndProject
+Global
+GlobalSection(SolutionConfigurationPlatforms) = preSolution
+Debug|Any CPU = Debug|Any CPU
+Release|Any CPU = Release|Any CPU
+EndGlobalSection
+GlobalSection(ProjectConfigurationPlatforms) = postSolution
+{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|Any CPU.Build.0 = Release|Any CPU
+{B2C3D4E5-F6A7-8901-BCDE-F12345678901}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{B2C3D4E5-F6A7-8901-BCDE-F12345678901}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{B2C3D4E5-F6A7-8901-BCDE-F12345678901}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{B2C3D4E5-F6A7-8901-BCDE-F12345678901}.Release|Any CPU.Build.0 = Release|Any CPU
+EndGlobalSection
+EndGlobal

--- a/src/ReportingDashboard.Api.Tests/PlaceholderTests.cs
+++ b/src/ReportingDashboard.Api.Tests/PlaceholderTests.cs
@@ -1,0 +1,9 @@
+using Xunit;
+
+namespace ReportingDashboard.Api.Tests;
+
+public class PlaceholderTests
+{
+    [Fact]
+    public void Placeholder_ReturnsTrue() => Assert.True(true);
+}

--- a/src/ReportingDashboard.Api.Tests/ReportingDashboard.Api.Tests.csproj
+++ b/src/ReportingDashboard.Api.Tests/ReportingDashboard.Api.Tests.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.7.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ReportingDashboard.Api\ReportingDashboard.Api.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/ReportingDashboard.Api/Program.cs
+++ b/src/ReportingDashboard.Api/Program.cs
@@ -1,0 +1,4 @@
+var builder = WebApplication.CreateBuilder(args);
+var app = builder.Build();
+app.MapGet("/", () => "ReportingDashboard API");
+app.Run();

--- a/src/ReportingDashboard.Api/ReportingDashboard.Api.csproj
+++ b/src/ReportingDashboard.Api/ReportingDashboard.Api.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
## Task Assignment
**Assigned To:** SoftwareEngineer 3
**Complexity:** Medium
**Branch:** `agent/28bed6fb/softwareengineer-3/t-3711-github-actions-ci-pipeline`

## Requirements
Closes #3711

# PR: Add GitHub Actions CI Pipeline

## Summary

Adds a GitHub Actions CI workflow (`.github/workflows/ci.yml`) that builds and tests both the .NET backend and TypeScript frontend on every push and pull request. The two jobs run in parallel to keep total CI time under 3 minutes. The pipeline fails fast on any build error, lint violation, or test failure.

## Acceptance Criteria

- [ ] Workflow triggers on both `push` and `pull_request` events
- [ ] Backend job runs on `ubuntu-latest` with .NET 8.0.x
- [ ] Backend job executes: `dotnet restore` → `dotnet build --no-restore -c Release` → `dotnet test --no-build -c Release --collect:"XPlat Code Coverage"`
- [ ] Frontend job runs on `ubuntu-latest` with Node.js 20
- [ ] Frontend job uses npm cache with `cache-dependency-path: src/ReportingDashboard.Client/package-lock.json`
- [ ] Frontend job executes: `npm ci` → `npx tsc --noEmit` → `npm run lint` → `npm run test -- --reporter=verbose --coverage` → `npm run build`
- [ ] Frontend job sets `working-directory: src/ReportingDashboard.Client` as a default for all `run` steps
- [ ] Backend and frontend jobs run in parallel (no `needs` dependency between them)
- [ ] Pipeline fails if any step in either job fails
- [ ] Total CI execution time is <3 minutes under normal conditions

## Implementation Steps

1. **Scaffold workflow directory and file**
   - Create `.github/workflows/` directory structure at repo root
   - Create `.github/workflows/ci.yml` with the workflow `name: CI` and trigger configuration (`on: [push, pull_request]`)
   - Commit: "chore: scaffold CI workflow file with triggers"

2. **Add backend job**
   - Define `backend` job targeting `ubuntu-latest`
   - Add `actions/checkout@v4` step
   - Add `actions/setup-dotnet@v4` with `dotnet-version: '8.0.x'`
   - Add sequential steps: `dotnet restore`, `dotnet build --no-restore -c Release`, `dotnet test --no-build -c Release --collect:"XPlat Code Coverage"`
   - Commit: "ci: add backend build and test job"

3. **Add frontend job**
   - Define `frontend` job targeting `ubuntu-latest`
   - Set `defaults.run.working-directory: src/ReportingDashboard.Client` at job level
   - Add `actions/checkout@v4` step
   - Add `actions/setup-node@v4` with `node-version: '20'`, `cache: 'npm'`, and `cache-dependency-path: src/ReportingDashboard.Client/package-lock.json`
   - Add sequential steps: `npm ci`, `npx tsc --noEmit`, `npm run lint`, `npm run test -- --reporter=verbose --coverage`, `npm run build`
   - Commit: "ci: add frontend lint, test, and build job"

4. **Validate workflow syntax and push**
   - Run `actionlint` or manually verify YAML syntax is valid
   - Confirm both jobs have no `needs` dependency (parallel execution)
   - Verify no secrets or environment variables are required for the base CI flow
   - Push branch and confirm GitHub Actions picks up the workflow on the PR event
   - Commit: "ci: finalize workflow validation"

## Testing

- **Workflow syntax**: Validate YAML parses correctly (use `actionlint` locally or GitHub's workflow editor)
- **Backend job**: Confirm `dotnet restore`, `build`, and `test` complete successfully; coverage report is generated
- **Frontend job**: Confirm `npm ci` installs cleanly, `tsc --noEmit` passes type-checking, `npm run lint` reports no errors, `npm run test` passes all specs with coverage output, `npm run build` produces `dist/` artifacts
- **Parallelism**: Verify in the Actions UI that backend and frontend jobs start simultaneously
- **Failure propagation**: Introduce a deliberate test failure on a scratch branch and confirm the workflow reports failure status on the PR
- **Timing**: Confirm total wall-clock time for both jobs is under 3 minutes on a typical run

## References
- Architecture: Architecture.md
- PM Spec: 

## Status
- [ ] Implementation
- [ ] Tests Written
- [ ] Ready for Review