### PR TITLE
SoftwareEngineer 3: Frontend API Client & Data Hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,59 @@
+## Build results
+[Dd]ebug/
+[Rr]elease/
+x64/
+x86/
+[Ww][Ii][Nn]32/
+[Aa][Rr][Mm]/
+[Aa][Rr][Mm]64/
+bld/
+[Bb]in/
+[Oo]bj/
+[Ll]og/
+[Ll]ogs/
+
+## NuGet
+*.nupkg
+*.snupkg
+**/[Pp]ackages/*
+!**/[Pp]ackages/build/
+
+## Visual Studio
+.vs/
+*.suo
+*.user
+*.userosscache
+*.sln.docstates
+*.csproj.user
+
+## Rider
+.idea/
+
+## User-specific
+*.rsuser
+*.DotSettings.user
+launchSettings.json
+
+## Build output
+publish/
+[Pp]ublish/
+**/wwwroot/dist/
+
+## Node
+node_modules/
+npm-debug.log*
+
+## OS
+.DS_Store
+Thumbs.db
+desktop.ini
+
+## Environment
+.env
+.env.*
+appsettings.Development.json
+appsettings.Local.json
+
+## Playwright
+playwright-report/
+test-results/

--- a/ReportingDashboard.sln
+++ b/ReportingDashboard.sln
@@ -1,0 +1,15 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ReportingDashboard", "src\ReportingDashboard\ReportingDashboard.csproj", "{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}"
+EndProject
+Global
+GlobalSection(SolutionConfigurationPlatforms) = preSolution
+Debug|Any CPU = Debug|Any CPU
+Release|Any CPU = Release|Any CPU
+EndGlobalSection
+GlobalSection(ProjectConfigurationPlatforms) = postSolution
+{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|Any CPU.Build.0 = Release|Any CPU
+EndGlobalSection
+EndGlobal

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,0 +1,111 @@
+// TODO: Remove this temporary verification view once real dashboard components are wired up.
+// It renders every hook's output to confirm data loads from all 7 endpoints.
+
+import React, { useState } from 'react';
+import {
+  useProjectSummary,
+  useProjectItems,
+  useSprintMetrics,
+  useRisks,
+  useTeamActivity,
+  useRoadmap,
+  useReportDetail,
+} from './hooks/useProjectData';
+import type { AsyncState } from './types';
+
+// Error boundary to prevent blank screen if a hook or child component throws
+class ErrorBoundary extends React.Component<
+  { children: React.ReactNode },
+  { error: Error | null }
+  constructor(props: { children: React.ReactNode }) {
+    super(props);
+    this.state = { error: null };
+  }
+
+  static getDerivedStateFromError(error: Error) {
+    return { error };
+  }
+
+  render() {
+    if (this.state.error) {
+      return (
+        <div style={{ padding: '2rem', background: '#111', color: '#f66', minHeight: '100vh', fontFamily: 'monospace' }}>
+          <h1>Render Error</h1>
+          <pre>{this.state.error.message}</pre>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
+
+function HookDebug({ label, state }: { label: string; state: AsyncState<unknown> }) {
+  return (
+    <div style={{ marginBottom: '1rem', fontFamily: 'monospace', fontSize: 12 }}>
+      <strong>{label}</strong>
+      {state.loading && <span> loading...</span>}
+      {state.error && (
+        <span style={{ color: '#f66' }}> error: {state.error.message}</span>
+      )}
+      {!state.loading && !state.error && state.data != null && (
+        <pre style={{ maxHeight: 150, overflow: 'auto', marginTop: 4 }}>
+          {JSON.stringify(state.data, null, 2).slice(0, 600)}
+        </pre>
+      )}
+    </div>
+  );
+}
+
+function Dashboard() {
+  const [detailId, setDetailId] = useState<string | null>('epic-001');
+
+  const summary = useProjectSummary();
+  const items = useProjectItems();
+  const sprint = useSprintMetrics();
+  const risks = useRisks();
+  const activity = useTeamActivity();
+  const roadmap = useRoadmap();
+  const detail = useReportDetail(detailId);
+
+  return (
+    <div style={{ padding: '2rem', background: '#111', color: '#eee', minHeight: '100vh' }}>
+      <h1 style={{ marginBottom: '1rem' }}>Hook Verification</h1>
+      <HookDebug label="useProjectSummary" state={summary} />
+      <HookDebug label="useProjectItems" state={items} />
+      <HookDebug label="useSprintMetrics" state={sprint} />
+      <HookDebug label="useRisks" state={risks} />
+      <HookDebug label="useTeamActivity" state={activity} />
+      <HookDebug label="useRoadmap" state={roadmap} />
+
+      <div style={{ marginBottom: '1rem', fontFamily: 'monospace', fontSize: 12 }}>
+        <strong>useReportDetail</strong> (id: {detailId ?? 'null'})
+        {detail.loading && <span> loading...</span>}
+        {detail.error && (
+          <span style={{ color: '#f66' }}> error: {detail.error.message}</span>
+        )}
+        {!detail.loading && !detail.error && detail.data != null && (
+          <pre style={{ maxHeight: 150, overflow: 'auto', marginTop: 4 }}>
+            {JSON.stringify(detail.data, null, 2).slice(0, 600)}
+          </pre>
+        )}
+        <div style={{ marginTop: 8 }}>
+          <label>Change ID:{' '}</label>
+          <input
+            value={detailId ?? ''}
+            onChange={(e) => setDetailId(e.target.value || null)}
+            placeholder="e.g. epic-001, risk-001"
+            style={{ background: '#222', color: '#eee', border: '1px solid #555', padding: '4px 8px' }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function App() {
+  return (
+    <ErrorBoundary>
+      <Dashboard />
+    </ErrorBoundary>
+  );
+}

--- a/client/src/api/client.ts
+++ b/client/src/api/client.ts
@@ -1,0 +1,78 @@
+import type {
+  ApiError,
+  ProjectSummary,
+  ProjectItem,
+  SprintMetrics,
+  Risk,
+  TeamActivity,
+  Roadmap,
+  ReportDetail,
+} from '../types';
+
+const BASE_URL = '/api';
+
+/** Custom error class carrying HTTP status and server error code */
+export class FetchError extends Error {
+  constructor(
+    public status: number,
+    public code: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'FetchError';
+  }
+}
+
+/**
+ * Generic JSON fetcher with AbortSignal support.
+ * Throws FetchError on non-2xx responses.
+ */
+async function fetchJson<T>(
+  endpoint: string,
+  options?: { signal?: AbortSignal },
+): Promise<T> {
+  const response = await fetch(`${BASE_URL}${endpoint}`, {
+    signal: options?.signal,
+  });
+
+  if (!response.ok) {
+    let code = 'UNKNOWN';
+    let message = `Request failed with status ${response.status}`;
+    try {
+      const body: ApiError = await response.json();
+      code = body.error.code;
+      message = body.error.message;
+    } catch {
+      // Server returned non-JSON error body; use default message
+    }
+    throw new FetchError(response.status, code, message);
+  }
+
+  return response.json() as Promise<T>;
+}
+
+// Typed API client - one method per endpoint, all accept an optional AbortSignal
+export const api = {
+  getProjectSummary: (signal?: AbortSignal) =>
+    fetchJson<ProjectSummary>('/project-summary', { signal }),
+
+  getProjectItems: (signal?: AbortSignal) =>
+    fetchJson<{ items: ProjectItem[] }>('/project-items', { signal }),
+
+  getSprintMetrics: (signal?: AbortSignal) =>
+    fetchJson<SprintMetrics>('/sprint-metrics', { signal }),
+
+  getRisks: (signal?: AbortSignal) =>
+    fetchJson<{ risks: Risk[] }>('/risks', { signal }),
+
+  getTeamActivity: (signal?: AbortSignal) =>
+    fetchJson<TeamActivity>('/team-activity', { signal }),
+
+  getRoadmap: (signal?: AbortSignal) =>
+    fetchJson<Roadmap>('/roadmap', { signal }),
+
+  getReportDetail: (id: string, signal?: AbortSignal) =>
+    fetchJson<ReportDetail>(`/report/${encodeURIComponent(id)}`, { signal }),
+};
+
+export default api;

--- a/client/src/hooks/useProjectData.ts
+++ b/client/src/hooks/useProjectData.ts
@@ -1,0 +1,157 @@
+// Data-fetching hooks for every dashboard endpoint.
+// Each hook returns { data, loading, error } (AsyncState<T>).
+// All hooks use AbortController to cancel in-flight requests on unmount.
+
+import { useState, useEffect, useCallback } from 'react';
+import { api } from '../api/client';
+import type {
+  AsyncState,
+  ProjectSummary,
+  ProjectItem,
+  SprintMetrics,
+  Risk,
+  TeamActivity,
+  Roadmap,
+  ReportDetail,
+} from '../types';
+
+/** Returns true if the error was caused by an aborted fetch */
+function isAbortError(err: unknown): boolean {
+  return err instanceof DOMException && err.name === 'AbortError';
+}
+
+/**
+ * Generic fetch hook. Accepts a stable fetcher that receives an AbortSignal.
+ * Creates a new AbortController per effect cycle and aborts on cleanup.
+ */
+function useFetch<T>(
+  fetcher: (signal: AbortSignal) => Promise<T>,
+): AsyncState<T> {
+  const [state, setState] = useState<AsyncState<T>>({
+    data: null,
+    loading: true,
+    error: null,
+  });
+
+  useEffect(() => {
+    const controller = new AbortController();
+    setState({ data: null, loading: true, error: null });
+
+    fetcher(controller.signal)
+      .then((data) => {
+        if (!controller.signal.aborted) {
+          setState({ data, loading: false, error: null });
+        }
+      })
+      .catch((err: unknown) => {
+        // Silently ignore abort errors - component is unmounting
+        if (isAbortError(err)) return;
+        if (!controller.signal.aborted) {
+          const error = err instanceof Error ? err : new Error(String(err));
+          setState({ data: null, loading: false, error });
+        }
+      });
+
+    return () => {
+      controller.abort();
+    };
+  }, [fetcher]);
+
+  return state;
+}
+
+// Individual hooks
+
+export function useProjectSummary(): AsyncState<ProjectSummary> {
+  const fetcher = useCallback(
+    (signal: AbortSignal) => api.getProjectSummary(signal),
+    [],
+  );
+  return useFetch(fetcher);
+}
+
+export function useProjectItems(): AsyncState<ProjectItem[]> {
+  const fetcher = useCallback(
+    (signal: AbortSignal) =>
+      api.getProjectItems(signal).then((res) => res.items),
+    [],
+  );
+  return useFetch(fetcher);
+}
+
+export function useSprintMetrics(): AsyncState<SprintMetrics> {
+  const fetcher = useCallback(
+    (signal: AbortSignal) => api.getSprintMetrics(signal),
+    [],
+  );
+  return useFetch(fetcher);
+}
+
+export function useRisks(): AsyncState<Risk[]> {
+  const fetcher = useCallback(
+    (signal: AbortSignal) =>
+      api.getRisks(signal).then((res) => res.risks),
+    [],
+  );
+  return useFetch(fetcher);
+}
+
+export function useTeamActivity(): AsyncState<TeamActivity> {
+  const fetcher = useCallback(
+    (signal: AbortSignal) => api.getTeamActivity(signal),
+    [],
+  );
+  return useFetch(fetcher);
+}
+
+export function useRoadmap(): AsyncState<Roadmap> {
+  const fetcher = useCallback(
+    (signal: AbortSignal) => api.getRoadmap(signal),
+    [],
+  );
+  return useFetch(fetcher);
+}
+
+/**
+ * Fetches report detail for a given id. Refetches whenever id changes.
+ * Pass null to skip fetching (returns idle state).
+ * Aborts in-flight request when id changes or component unmounts.
+ */
+export function useReportDetail(id: string | null): AsyncState<ReportDetail> {
+  const [state, setState] = useState<AsyncState<ReportDetail>>({
+    data: null,
+    loading: !!id,
+    error: null,
+  });
+
+  useEffect(() => {
+    if (!id) {
+      setState({ data: null, loading: false, error: null });
+      return;
+    }
+
+    const controller = new AbortController();
+    setState({ data: null, loading: true, error: null });
+
+    api
+      .getReportDetail(id, controller.signal)
+      .then((data) => {
+        if (!controller.signal.aborted) {
+          setState({ data, loading: false, error: null });
+        }
+      })
+      .catch((err: unknown) => {
+        if (isAbortError(err)) return;
+        if (!controller.signal.aborted) {
+          const error = err instanceof Error ? err : new Error(String(err));
+          setState({ data: null, loading: false, error });
+        }
+      });
+
+    return () => {
+      controller.abort();
+    };
+  }, [id]);
+
+  return state;
+}

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -1,0 +1,132 @@
+export type ItemStatus = 'done' | 'in-progress' | 'blocked' | 'not-started' | 'at-risk';
+export type ItemType = 'epic' | 'feature' | 'story' | 'task' | 'bug';
+export type RiskSeverity = 'critical' | 'high' | 'medium' | 'low';
+export type ActivityEventType = 'pr-completed' | 'task-completed' | 'comment' | 'deployment' | 'review';
+
+export interface ProjectSummary {
+  id: string;
+  name: string;
+  status: string;
+  currentSprint: string;
+  completionPercent: number;
+  deliveryConfidence: number;
+  daysRemaining: number;
+  healthScore: number;
+  healthColor: 'green' | 'yellow' | 'red';
+  totalEpics: number;
+  totalFeatures: number;
+  totalStories: number;
+}
+
+export interface ProjectItem {
+  id: string;
+  type: ItemType;
+  title: string;
+  description: string;
+  status: ItemStatus;
+  parentId: string | null;
+  owner: string;
+  priority: 'critical' | 'high' | 'medium' | 'low';
+  storyPoints: number;
+  remainingWork: number;
+  dependencies: string[];
+  recentActivity: ActivityEvent[];
+}
+
+export interface SprintMetrics {
+  sprintName: string;
+  sprintNumber: number;
+  startDate: string;
+  endDate: string;
+  velocity: {
+    sprints: string[];
+    planned: number[];
+    completed: number[];
+  };
+  burndown: {
+    days: string[];
+    ideal: number[];
+    actual: (number | null)[];
+  };
+  openBugs: number;
+  blockers: number;
+  carryoverItems: number;
+}
+
+export interface Risk {
+  id: string;
+  title: string;
+  description: string;
+  severity: RiskSeverity;
+  owner: string;
+  status: 'open' | 'mitigated' | 'closed';
+  category: string;
+  impactArea: string;
+  mitigationPlan: string;
+}
+
+export interface ActivityEvent {
+  id: string;
+  type: ActivityEventType;
+  actor: string;
+  actorAvatar: string;
+  description: string;
+  timestamp: string;
+  relatedItemId: string | null;
+}
+
+export interface TeamMember {
+  id: string;
+  name: string;
+  role: string;
+  avatar: string;
+}
+
+export interface TeamActivity {
+  events: ActivityEvent[];
+  teamMembers: TeamMember[];
+}
+
+export interface RoadmapMilestone {
+  id: string;
+  title: string;
+  date: string;
+  phase: 'completed' | 'active' | 'upcoming';
+  type: 'release' | 'milestone' | 'sprint-boundary';
+  description: string;
+}
+
+export interface Roadmap {
+  milestones: RoadmapMilestone[];
+  sprintBoundaries: { date: string; label: string }[];
+}
+
+export interface ReportDetail {
+  id: string;
+  type: ItemType | 'risk';
+  title: string;
+  description: string;
+  owner: string;
+  status: string;
+  priority: string;
+  estimate: number | null;
+  remainingWork: number | null;
+  dependencies: { id: string; title: string; status: string }[];
+  recentActivity: ActivityEvent[];
+  metadata: Record<string, string>;
+}
+
+// API error response shape (matches server error envelope)
+export interface ApiError {
+  error: {
+    code: string;
+    message: string;
+  };
+}
+
+// Generic async state returned by all data hooks
+export interface AsyncState<T> {
+  data: T | null;
+  loading: boolean;
+  error: Error | null;
+}

--- a/src/ReportingDashboard/ReportingDashboard.csproj
+++ b/src/ReportingDashboard/ReportingDashboard.csproj
@@ -1,1 +1,5 @@
-<Project Sdk="Microsoft.Build.NoTargets/3.7.56"><PropertyGroup><TargetFramework>net8.0</TargetFramework></PropertyGroup></Project>
+<Project Sdk="Microsoft.Build.NoTargets/3.7.56">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+</Project>

--- a/src/ReportingDashboard/ReportingDashboard.csproj
+++ b/src/ReportingDashboard/ReportingDashboard.csproj
@@ -1,0 +1,1 @@
+<Project Sdk="Microsoft.Build.NoTargets/3.7.56"><PropertyGroup><TargetFramework>net8.0</TargetFramework></PropertyGroup></Project>

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "reporting-dashboard-tests",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "devDependencies": {
+    "@testing-library/react": "^16.1.0",
+    "@testing-library/react-hooks": "^8.0.1",
+    "@types/react": "^19.0.0",
+    "jsdom": "^25.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "typescript": "^5.6.0",
+    "vitest": "^2.1.0"
+  }
+}

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["vitest/globals"]
+  },
+  "include": ["unit/**/*"],
+  "references": []
+}

--- a/tests/unit/apiClient.test.ts
+++ b/tests/unit/apiClient.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { FetchError, api } from '../../client/src/api/client';
+
+/**
+ * Unit tests for client/src/api/client.ts
+ * Tests the FetchError class and api object methods (fetchJson behavior).
+ */
+
+function mockFetchResponse(overrides: Partial<Response> & { json?: () => Promise<unknown> }) {
+  const headers = new Headers();
+  if (!overrides.headers) {
+    headers.set('content-type', 'application/json');
+  }
+  return {
+    ok: true,
+    status: 200,
+    headers: overrides.headers ?? headers,
+    json: overrides.json ?? (() => Promise.resolve({})),
+    ...overrides,
+  } as unknown as Response;
+}
+
+describe('FetchError', () => {
+  it('stores status, code, and message properties', () => {
+    const err = new FetchError(404, 'NOT_FOUND', 'Resource not found');
+
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe('FetchError');
+    expect(err.status).toBe(404);
+    expect(err.code).toBe('NOT_FOUND');
+    expect(err.message).toBe('Resource not found');
+  });
+});
+
+describe('api client (fetchJson)', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('[Trait("Category", "Unit")] fetches correct URL and returns parsed JSON', async () => {
+    const payload = { name: 'Project Phoenix', status: 'on-track' };
+    globalThis.fetch = vi.fn().mockResolvedValue(mockFetchResponse({
+      json: () => Promise.resolve(payload),
+    }));
+
+    const result = await api.getProjectSummary();
+
+    expect(globalThis.fetch).toHaveBeenCalledWith('/api/project-summary', { signal: undefined });
+    expect(result).toEqual(payload);
+  });
+
+  it('[Trait("Category", "Unit")] throws FetchError with server error body on non-2xx', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(mockFetchResponse({
+      ok: false,
+      status: 422,
+      json: () => Promise.resolve({ error: { code: 'VALIDATION', message: 'Invalid ID' } }),
+    }));
+
+    await expect(api.getReportDetail('bad-id')).rejects.toMatchObject({
+      status: 422,
+      code: 'VALIDATION',
+      message: 'Invalid ID',
+    });
+  });
+
+  it('[Trait("Category", "Unit")] throws FetchError with default message when error body is not JSON', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(mockFetchResponse({
+      ok: false,
+      status: 500,
+      json: () => Promise.reject(new SyntaxError('Unexpected token')),
+    }));
+
+    await expect(api.getSprintMetrics()).rejects.toMatchObject({
+      status: 500,
+      code: 'UNKNOWN',
+      message: 'Request failed with status 500',
+    });
+  });
+
+  it('[Trait("Category", "Unit")] encodes id in getReportDetail URL', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(mockFetchResponse({
+      json: () => Promise.resolve({ id: 'special/id' }),
+    }));
+
+    await api.getReportDetail('special/id');
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      '/api/report/special%2Fid',
+      expect.objectContaining({}),
+    );
+  });
+});

--- a/tests/unit/useProjectData.test.ts
+++ b/tests/unit/useProjectData.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import {
+  useProjectSummary,
+  useProjectItems,
+  useReportDetail,
+} from '../../client/src/hooks/useProjectData';
+
+/**
+ * Unit tests for client/src/hooks/useProjectData.ts
+ * Tests hook lifecycle: loading -> data, loading -> error, abort on unmount,
+ * and useReportDetail id-change / null-reset behavior.
+ */
+
+// Mock the api module so hooks don't make real fetch calls
+vi.mock('../../client/src/api/client', () => ({
+  api: {
+    getProjectSummary: vi.fn(),
+    getProjectItems: vi.fn(),
+    getSprintMetrics: vi.fn(),
+    getRisks: vi.fn(),
+    getTeamActivity: vi.fn(),
+    getRoadmap: vi.fn(),
+    getReportDetail: vi.fn(),
+  },
+}));
+
+import { api } from '../../client/src/api/client';
+
+const mockedApi = api as unknown as {
+  getProjectSummary: ReturnType<typeof vi.fn>;
+  getProjectItems: ReturnType<typeof vi.fn>;
+  getSprintMetrics: ReturnType<typeof vi.fn>;
+  getRisks: ReturnType<typeof vi.fn>;
+  getTeamActivity: ReturnType<typeof vi.fn>;
+  getRoadmap: ReturnType<typeof vi.fn>;
+  getReportDetail: ReturnType<typeof vi.fn>;
+};
+
+describe('useProjectSummary', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('[Trait("Category", "Unit")] starts in loading state then resolves data', async () => {
+    const mockData = { name: 'Phoenix', status: 'on-track', completionPercent: 68 };
+    mockedApi.getProjectSummary.mockResolvedValue(mockData);
+
+    const { result } = renderHook(() => useProjectSummary());
+
+    // Initial state is loading
+    expect(result.current.loading).toBe(true);
+    expect(result.current.data).toBeNull();
+    expect(result.current.error).toBeNull();
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.data).toEqual(mockData);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('[Trait("Category", "Unit")] sets error state on fetch failure', async () => {
+    mockedApi.getProjectSummary.mockRejectedValue(new Error('Network timeout'));
+
+    const { result } = renderHook(() => useProjectSummary());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.data).toBeNull();
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect(result.current.error!.message).toBe('Network timeout');
+  });
+});
+
+describe('useProjectItems', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('[Trait("Category", "Unit")] unwraps items array from response', async () => {
+    const items = [{ id: '1', title: 'Epic A', type: 'epic' }];
+    mockedApi.getProjectItems.mockResolvedValue({ items });
+
+    const { result } = renderHook(() => useProjectItems());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.data).toEqual(items);
+  });
+});
+
+describe('useReportDetail', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('[Trait("Category", "Unit")] returns idle state when id is null', () => {
+    const { result } = renderHook(() => useReportDetail(null));
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.data).toBeNull();
+    expect(result.current.error).toBeNull();
+    expect(mockedApi.getReportDetail).not.toHaveBeenCalled();
+  });
+
+  it('[Trait("Category", "Unit")] refetches when id changes and resets on null', async () => {
+    const detail1 = { id: 'r1', title: 'Report 1' };
+    const detail2 = { id: 'r2', title: 'Report 2' };
+    mockedApi.getReportDetail.mockImplementation((id: string) => {
+      if (id === 'r1') return Promise.resolve(detail1);
+      if (id === 'r2') return Promise.resolve(detail2);
+      return Promise.reject(new Error('unknown'));
+    });
+
+    const { result, rerender } = renderHook(
+      ({ id }: { id: string | null }) => useReportDetail(id),
+      { initialProps: { id: 'r1' } },
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.data).toEqual(detail1);
+
+    // Change id -> refetch
+    rerender({ id: 'r2' });
+    await waitFor(() => expect(result.current.data).toEqual(detail2));
+
+    // Set null -> reset
+    rerender({ id: null });
+    await waitFor(() => {
+      expect(result.current.data).toBeNull();
+      expect(result.current.loading).toBe(false);
+    });
+  });
+});

--- a/tests/vitest.config.ts
+++ b/tests/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    root: '.',
+    include: ['unit/**/*.test.ts', 'unit/**/*.test.tsx'],
+  },
+});


### PR DESCRIPTION
## Task Assignment
**Assigned To:** SoftwareEngineer 3
**Complexity:** Medium
**Branch:** `agent/dbc7f1e4/softwareengineer-3/t-3926-frontend-api-client-data-hooks`

## Requirements
Closes #3926

# Frontend API Client & Data Hooks

## Summary

Implements the typed frontend data layer for the ReportingDashboard application. This PR adds TypeScript type definitions mirroring the server's data model, a generic fetch wrapper with error handling, and seven React hooks (`useProjectSummary`, `useProjectItems`, `useSprintMetrics`, `useRisks`, `useTeamActivity`, `useRoadmap`, `useReportDetail`) that provide `{ data, loading, error }` tuples to all dashboard consumers. The `useReportDetail` hook accepts an `id` parameter and refetches when the ID changes. All hooks fetch from the Vite-proxied `/api/*` endpoints defined in the backend spec.

Depends on #3923 (project scaffold with Vite config, proxy setup, and server endpoints).

## Acceptance Criteria

- [ ] `client/src/types/index.ts` exports all shared interfaces: `ProjectSummary`, `ProjectItem`, `SprintMetrics`, `Risk`, `TeamActivity`, `ActivityEvent`, `TeamMember`, `RoadmapMilestone`, `Roadmap`, `ReportDetail`, and all union literal types (`ItemStatus`, `ItemType`, `RiskSeverity`, `ActivityEventType`)
- [ ] `client/src/api/client.ts` exports a generic `fetchApi<T>(endpoint: string): Promise<T>` function that prepends `/api/`, parses JSON, and throws a typed `ApiError` on non-2xx responses
- [ ] `ApiError` includes `code` and `message` fields matching the server error shape
- [ ] Each of the 7 hooks returns `{ data: T | null; loading: boolean; error: Error | null }`
- [ ] `useProjectSummary` fetches `GET /api/project-summary` on mount
- [ ] `useProjectItems` fetches `GET /api/project-items` on mount and returns the `items` array
- [ ] `useSprintMetrics` fetches `GET /api/sprint-metrics` on mount
- [ ] `useRisks` fetches `GET /api/risks` on mount and returns the `risks` array
- [ ] `useTeamActivity` fetches `GET /api/team-activity` on mount
- [ ] `useRoadmap` fetches `GET /api/roadmap` on mount
- [ ] `useReportDetail(id: string | null)` fetches `GET /api/report/:id` only when `id` is non-null, refetches when `id` changes, and resets state when `id` becomes null
- [ ] All hooks abort in-flight requests on unmount via `AbortController`
- [ ] TypeScript strict mode passes with no type errors in modified files
- [ ] Manual verification: temporarily rendering hook output in `App.tsx` shows loaded data from all endpoints in the browser console or DOM

## Implementation Steps

1. **Define frontend TypeScript types** — Create `client/src/types/index.ts` with all shared interfaces and union types mirroring `server/data/types.ts`. Export `ItemStatus`, `ItemType`, `RiskSeverity`, `ActivityEventType`, `ProjectSummary`, `ProjectItem`, `SprintMetrics`, `Risk`, `TeamActivity`, `ActivityEvent`, `TeamMember`, `RoadmapMilestone`, `Roadmap`, `ReportDetail`, and the API error shape `ApiErrorResponse`. This file has no runtime dependencies.

2. **Implement the typed fetch wrapper** — Create `client/src/api/client.ts` exporting `fetchApi<T>(endpoint: string, options?: { signal?: AbortSignal }): Promise<T>`. It should: construct the URL as `/api/${endpoint}`, call `fetch()` with the optional abort signal, check `response.ok`, parse the error body on failure and throw an `ApiError` class (extending `Error` with `code` and `message`), and return parsed JSON on success. Also export the `ApiError` class for consumers to use in `instanceof` checks.

3. **Implement data-fetching hooks** — Create `client/src/hooks/useProjectData.ts` exporting all 7 hooks. Extract a private `useApi<T>(endpoint: string)` base hook that manages `useState<T | null>`, `useState<boolean>(true)`, `useState<Error | null>`, and a `useEffect` that calls `fetchApi` with an `AbortController`, sets state on resolve/reject, and cleans up the controller on unmount. Build the 6 mount-once hooks (`useProjectSummary`, `useProjectItems`, `useSprintMetrics`, `useRisks`, `useTeamActivity`, `useRoadmap`) as thin wrappers over `useApi`. For `useProjectItems` and `useRisks`, unwrap the nested `items`/`risks` array from the response. Implement `useReportDetail(id: string | null)` separately with `id` in the `useEffect` dependency array and a guard that skips fetch + resets data when `id` is null.

4. **Verify integration** — Temporarily import hooks in `client/src/App.tsx`, call each hook, and render or `console.log` the results to confirm data loads from all 7 endpoints with the backend running. Confirm loading states transition to loaded, error states display when the server is stopped, and `useReportDetail` refetches on ID change. Remove temporary verification code before final commit (or leave behind a `// TODO: remove` comment for the next PR to clean up).

## Testing

Since the spec excludes formal test suites from MVP, verification is manual:

- **Happy path**: Start backend (`npm run dev`), open browser, confirm all 7 hooks resolve with correctly-typed data (check browser DevTools Network tab for 200 responses and console/DOM for rendered data)
- **Error handling**: Stop the backend, reload the page, confirm all hooks surface `error` state (not `loading` forever, no uncaught exceptions)
- **Abort on unmount**: Navigate away or conditionally unmount a component mid-fetch; confirm no React "state update on unmounted component" warnings in the console
- **useReportDetail reactivity**: Change the selected ID (e.g., click different nodes); confirm the hook refetches and displays the new detail data. Set ID to null; confirm data resets to null
- **Type safety**: Run `npx tsc --noEmit` from `client/` and confirm zero type errors in the three modified files

## References
- Architecture: Architecture.md
- PM Spec: 

## Status
- [ ] Implementation
- [ ] Tests Written
- [ ] Ready for Review